### PR TITLE
fix(pipeline): restore Gemini classification after model deprecation

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -38,7 +38,7 @@ class Settings(BaseSettings):
     # LLM (Gemini)
     gemini_api_key: str | None = None
     extraction_model: str = "gemini-2.5-flash"
-    selection_model: str = "gemini-2.0-flash-lite"  # Lightweight model for classification
+    selection_model: str = "gemini-2.5-flash-lite"  # Lightweight model for classification
     
     # Pipeline settings
     pipeline_max_workers: int = 10

--- a/backend/app/models/source_google_news.py
+++ b/backend/app/models/source_google_news.py
@@ -20,6 +20,7 @@ class SourceStatus(str, Enum):
     """
     
     ready_for_classification = "ready_for_classification"
+    classifying = "classifying"
     discarded = "discarded"
     ready_for_download = "ready_for_download"
     failed_in_download = "failed_in_download"

--- a/backend/app/services/classification.py
+++ b/backend/app/services/classification.py
@@ -203,7 +203,15 @@ async def classify_source(source_id: int) -> bool:
             
         except Exception as e:
             logger.error(f"Error classifying source {source_id}: {e}")
-            # Don't change status on error - leave as ready-for-classification for retry
+            await session.execute(
+                text("""
+                    UPDATE source_google_news
+                    SET status = 'ready_for_classification', updated_at = CURRENT_TIMESTAMP
+                    WHERE id = :id AND status = 'classifying'
+                """),
+                {"id": source_id},
+            )
+            await session.commit()
             return False
 
 

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -37,6 +37,8 @@ services:
       - REDIS_URL=redis://redis:6379
       - DATABASE_URL=sqlite+aiosqlite:///./instance/violence.db
       - GEMINI_API_KEY=${STAGING_GEMINI_API_KEY:-${GEMINI_API_KEY:-}}
+      - EXTRACTION_MODEL=${STAGING_EXTRACTION_MODEL:-${EXTRACTION_MODEL:-gemini-2.5-flash}}
+      - SELECTION_MODEL=${STAGING_SELECTION_MODEL:-${SELECTION_MODEL:-gemini-2.5-flash-lite}}
       - DEBUG=true
       - CORS_ORIGINS=["http://localhost:5173","http://localhost:8080","https://staging.arquivodaviolencia.com.br"]
       - JWT_SECRET_KEY=${STAGING_JWT_SECRET_KEY:-staging-secret-key}
@@ -57,6 +59,8 @@ services:
       - REDIS_URL=redis://redis:6379
       - DATABASE_URL=sqlite+aiosqlite:///./instance/violence.db
       - GEMINI_API_KEY=${STAGING_GEMINI_API_KEY:-${GEMINI_API_KEY:-}}
+      - EXTRACTION_MODEL=${STAGING_EXTRACTION_MODEL:-${EXTRACTION_MODEL:-gemini-2.5-flash}}
+      - SELECTION_MODEL=${STAGING_SELECTION_MODEL:-${SELECTION_MODEL:-gemini-2.5-flash-lite}}
       - ENABLE_CRON=${STAGING_ENABLE_CRON:-false}
       - JWT_SECRET_KEY=${STAGING_JWT_SECRET_KEY:-staging-secret-key}
       - ADMIN_USERNAME=${STAGING_ADMIN_USERNAME:-admin}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,6 +54,8 @@ services:
       - REDIS_URL=redis://redis:6379
       - DATABASE_URL=sqlite+aiosqlite:///./instance/violence.db
       - GEMINI_API_KEY=${GEMINI_API_KEY:-}
+      - EXTRACTION_MODEL=${EXTRACTION_MODEL:-gemini-2.5-flash}
+      - SELECTION_MODEL=${SELECTION_MODEL:-gemini-2.5-flash-lite}
       - DEBUG=${DEBUG:-false}
       - CORS_ORIGINS=["http://localhost:5173","http://localhost:3000","http://localhost:80","https://arquivodaviolencia.com.br","https://www.arquivodaviolencia.com.br"]
       - JWT_SECRET_KEY=${JWT_SECRET_KEY:-change-me-in-production}
@@ -86,6 +88,8 @@ services:
       - REDIS_URL=redis://redis:6379
       - DATABASE_URL=sqlite+aiosqlite:///./instance/violence.db
       - GEMINI_API_KEY=${GEMINI_API_KEY:-}
+      - EXTRACTION_MODEL=${EXTRACTION_MODEL:-gemini-2.5-flash}
+      - SELECTION_MODEL=${SELECTION_MODEL:-gemini-2.5-flash-lite}
       - ENABLE_CRON=${ENABLE_CRON:-false}
       - JWT_SECRET_KEY=${JWT_SECRET_KEY:-change-me-in-production}
       - ADMIN_USERNAME=${ADMIN_USERNAME:-admin}

--- a/env.example
+++ b/env.example
@@ -8,7 +8,7 @@ GEMINI_API_KEY=your-gemini-api-key-here
 # Model used for extracting structured event data from news articles
 EXTRACTION_MODEL=gemini-2.5-flash
 # Model used for selecting/filtering relevant sources (lightweight, fast)
-SELECTION_MODEL=gemini-2.0-flash-lite
+SELECTION_MODEL=gemini-2.5-flash-lite
 
 # Enable hourly cron job for city ingestion
 ENABLE_CRON=false


### PR DESCRIPTION
## Summary
- Pass `SELECTION_MODEL` and `EXTRACTION_MODEL` into production/staging Docker containers so Gemini uses current models instead of deprecated `gemini-2.0-flash-lite`
- Update default selection model to `gemini-2.5-flash-lite` in config and `env.example`
- Add `classifying` to `SourceStatus` enum and reset status on classification failure to prevent sources getting stuck

## Context
Production worker was healthy but pipeline stalled since June 4. Root causes on Hetzner:
1. Worker Redis deadlock (fixed by restart)
2. Model env vars not reaching containers (404 from Google API)
3. ~5k sources stuck in `classifying` after failed classification runs

## Test plan
- [ ] Merge and deploy backend to production via CI
- [ ] Verify `docker exec arquivo-worker printenv SELECTION_MODEL` → `gemini-2.5-flash-lite`
- [ ] Trigger `/api/pipeline/ingest-cities-pipeline?when=1h` and confirm classification logs show no 404 errors
- [ ] Confirm new sources move past `ready_for_classification` without enum errors


Made with [Cursor](https://cursor.com)