### PR TITLE
fix(pipeline): stop holding DB connections across LLM/network calls + recover stuck sources

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,39 @@
+# =============================================================================
+# Arquivo da Violência - Environment Configuration
+# =============================================================================
+# Copy this file to .env and fill in the values:
+#   cp .env.example .env
+# =============================================================================
+
+# --- Pipeline scheduling -----------------------------------------------------
+# MUST be "true" in production, otherwise the hourly ingestion cron never runs
+# and nothing gets downloaded or classified (the queue just stays empty).
+ENABLE_CRON=true
+
+# --- LLM (Gemini) ------------------------------------------------------------
+GEMINI_API_KEY=
+EXTRACTION_MODEL=gemini-2.5-flash
+SELECTION_MODEL=gemini-2.5-flash-lite
+
+# --- Infrastructure ----------------------------------------------------------
+# Inside docker compose these point at the service names; defaults shown.
+REDIS_URL=redis://redis:6379
+DATABASE_URL=sqlite+aiosqlite:///./instance/violence.db
+DEBUG=false
+
+# --- Auth --------------------------------------------------------------------
+# Generate a stable secret once with: openssl rand -hex 32
+# If this changes between restarts, all admin sessions are invalidated.
+JWT_SECRET_KEY=change-me-in-production
+ADMIN_USERNAME=admin
+ADMIN_PASSWORD=admin123
+
+# --- Telegram notifications (optional) ---------------------------------------
+# When set, the API sends pipeline + worker-health alerts to this chat,
+# including a "Worker Down" alert if the worker stops heartbeating.
+TELEGRAM_BOT_TOKEN=
+TELEGRAM_CHAT_ID=
+
+# --- GitHub issue creation on failures (optional) ----------------------------
+GITHUB_TOKEN=
+GITHUB_REPO=owner/repo

--- a/.gitignore
+++ b/.gitignore
@@ -105,6 +105,7 @@ celerybeat.pid
 # Environments
 .env
 .env.*
+!.env.example
 .venv/
 env/
 venv/

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -59,6 +59,15 @@ def get_engine() -> AsyncEngine:
             db_url,
             echo=settings.debug,
             future=True,
+            # The ARQ worker can run several batch jobs at once (max_jobs=10),
+            # each fanning out up to ~15 concurrent source-level coroutines. The
+            # default pool (5 + 10 overflow) is far too small for that and leads
+            # to "QueuePool limit ... connection timed out" errors. Size the pool
+            # generously; WAL mode + busy_timeout handle write serialization.
+            pool_size=30,
+            max_overflow=70,
+            pool_timeout=60,
+            pool_recycle=1800,
             connect_args={
                 "check_same_thread": False,
                 "timeout": 60,

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,5 +1,6 @@
 """FastAPI application factory and main entry point."""
 
+import asyncio
 from contextlib import asynccontextmanager
 from collections.abc import AsyncIterator
 
@@ -9,6 +10,7 @@ from loguru import logger
 
 from app.config import get_settings
 from app.database import init_db
+from app.services.worker_monitor import monitor_worker_health
 
 settings = get_settings()
 
@@ -25,11 +27,20 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     # Initialize database (creates tables if not using alembic)
     # await init_db()
     logger.info(f"Database ready: {settings.database_path}")
-    
+
+    # Background monitor that alerts (via Telegram) if the ARQ worker goes silent.
+    monitor_stop = asyncio.Event()
+    monitor_task = asyncio.create_task(monitor_worker_health(monitor_stop))
+
     yield
     
     # Shutdown
     logger.info("Shutting down application")
+    monitor_stop.set()
+    try:
+        await asyncio.wait_for(monitor_task, timeout=5)
+    except (asyncio.TimeoutError, asyncio.CancelledError):
+        monitor_task.cancel()
 
 
 def create_app() -> FastAPI:

--- a/backend/app/routers/pipeline.py
+++ b/backend/app/routers/pipeline.py
@@ -5,7 +5,14 @@ from arq import create_pool
 from arq.jobs import Job
 from loguru import logger
 
-from app.tasks.worker import get_redis_settings
+import json
+
+from app.tasks.worker import (
+    get_redis_settings,
+    HEALTH_CHECK_KEY,
+    WORKER_INFO_KEY,
+    is_cron_enabled,
+)
 from app.services.telegram import send_test_message, get_notifier
 
 router = APIRouter(prefix="/pipeline", tags=["pipeline"])
@@ -341,14 +348,51 @@ async def run_batch_enrichment(
 
 @router.get("/status")
 async def get_pipeline_status():
-    """Get queue status and worker health."""
+    """Get queue status and worker health.
+
+    Redis connectivity alone does NOT mean the pipeline is working: the worker
+    process (which also runs the cron that enqueues jobs) can be down while Redis
+    stays reachable. We additionally read the worker's heartbeat key and report
+    whether cron is enabled so the UI can distinguish "healthy" from "stalled".
+    """
     try:
         pool = await get_arq_pool()
         queued_jobs = await pool.queued_jobs()
+
+        # Worker heartbeat: arq refreshes this key on an interval; if it's
+        # missing the worker process is not running (or crashed).
+        raw_health = await pool.get(HEALTH_CHECK_KEY)
+        # Worker-published config (cron is scheduled by the worker, not the API).
+        raw_info = await pool.get(WORKER_INFO_KEY)
         await pool.close()
+
+        worker_alive = raw_health is not None
+        worker_health = None
+        if raw_health is not None:
+            worker_health = (
+                raw_health.decode() if isinstance(raw_health, bytes) else str(raw_health)
+            )
+
+        # Prefer the worker's self-reported cron status; fall back to this
+        # process's env only if the worker has not published yet.
+        cron_enabled = is_cron_enabled()
+        worker_started_at = None
+        if raw_info is not None:
+            try:
+                info = json.loads(
+                    raw_info.decode() if isinstance(raw_info, bytes) else raw_info
+                )
+                cron_enabled = bool(info.get("cron_enabled", cron_enabled))
+                worker_started_at = info.get("started_at")
+            except (ValueError, AttributeError):
+                pass
 
         return {
             "redis": "connected",
+            "worker_alive": worker_alive,
+            "worker_health": worker_health,
+            "worker_started_at": worker_started_at,
+            "cron_enabled": cron_enabled,
             "queued_jobs": len(queued_jobs),
             "jobs": [
                 {
@@ -364,6 +408,10 @@ async def get_pipeline_status():
     except Exception as e:
         return {
             "redis": "disconnected",
+            "worker_alive": False,
+            "worker_health": None,
+            "worker_started_at": None,
+            "cron_enabled": is_cron_enabled(),
             "error": str(e),
             "queued_jobs": 0,
         }

--- a/backend/app/services/classification.py
+++ b/backend/app/services/classification.py
@@ -135,24 +135,27 @@ async def classify_source(source_id: int) -> bool:
     Returns:
         True if classified as violent death, False otherwise
     """
+    import asyncio
+    from sqlalchemy import text
+
+    # Step 1: read the headline in a short-lived session, then release the
+    # connection. We must NOT hold a DB connection while the (slow, blocking)
+    # LLM call runs, otherwise concurrent workers exhaust the connection pool.
     async with async_session_maker() as session:
-        # Use raw SQL to get source (avoids enum conversion issues)
-        from sqlalchemy import text
         result = await session.execute(
             text("SELECT id, headline FROM source_google_news WHERE id = :id"),
             {"id": source_id}
         )
         row = result.fetchone()
-        
+
         if not row:
             logger.warning(f"Source {source_id} not found")
             return False
-        
+
         source_id, headline = row
-        
+
         if not headline:
             logger.warning(f"Source {source_id} has no headline")
-            # Update using raw SQL to avoid enum issues
             await session.execute(
                 text("""
                     UPDATE source_google_news 
@@ -166,43 +169,15 @@ async def classify_source(source_id: int) -> bool:
             )
             await session.commit()
             return False
-        
-        try:
-            logger.info(f"Classifying source {source_id}: {headline[:60]}...")
-            
-            classification = classify_headline(headline)
-            
-            # Update using raw SQL to avoid enum issues
-            new_status = "ready_for_download" if classification.is_violent_death else "discarded"
-            await session.execute(
-                text("""
-                    UPDATE source_google_news 
-                    SET status = :status,
-                        is_violent_death = :is_violent_death,
-                        classification_confidence = :confidence,
-                        classification_reasoning = :reasoning,
-                        updated_at = CURRENT_TIMESTAMP
-                    WHERE id = :id
-                """),
-                {
-                    "id": source_id,
-                    "status": new_status,
-                    "is_violent_death": 1 if classification.is_violent_death else 0,
-                    "confidence": classification.confidence,
-                    "reasoning": classification.reasoning,
-                }
-            )
-            await session.commit()
-            
-            if classification.is_violent_death:
-                logger.info(f"Source {source_id}: VIOLENT DEATH ({classification.confidence})")
-            else:
-                logger.info(f"Source {source_id}: DISCARDED ({classification.confidence})")
-            
-            return classification.is_violent_death
-            
-        except Exception as e:
-            logger.error(f"Error classifying source {source_id}: {e}")
+
+    # Step 2: run the blocking LLM classification off the event loop and
+    # WITHOUT holding a DB connection.
+    try:
+        logger.info(f"Classifying source {source_id}: {headline[:60]}...")
+        classification = await asyncio.to_thread(classify_headline, headline)
+    except Exception as e:
+        logger.error(f"Error classifying source {source_id}: {e}")
+        async with async_session_maker() as session:
             await session.execute(
                 text("""
                     UPDATE source_google_news
@@ -212,7 +187,37 @@ async def classify_source(source_id: int) -> bool:
                 {"id": source_id},
             )
             await session.commit()
-            return False
+        return False
+
+    # Step 3: persist the result in a fresh short-lived session.
+    new_status = "ready_for_download" if classification.is_violent_death else "discarded"
+    async with async_session_maker() as session:
+        await session.execute(
+            text("""
+                UPDATE source_google_news 
+                SET status = :status,
+                    is_violent_death = :is_violent_death,
+                    classification_confidence = :confidence,
+                    classification_reasoning = :reasoning,
+                    updated_at = CURRENT_TIMESTAMP
+                WHERE id = :id
+            """),
+            {
+                "id": source_id,
+                "status": new_status,
+                "is_violent_death": 1 if classification.is_violent_death else 0,
+                "confidence": classification.confidence,
+                "reasoning": classification.reasoning,
+            }
+        )
+        await session.commit()
+
+    if classification.is_violent_death:
+        logger.info(f"Source {source_id}: VIOLENT DEATH ({classification.confidence})")
+    else:
+        logger.info(f"Source {source_id}: DISCARDED ({classification.confidence})")
+
+    return classification.is_violent_death
 
 
 async def classify_pending_sources(limit: int = 50, concurrency: int = 10) -> dict:

--- a/backend/app/services/download.py
+++ b/backend/app/services/download.py
@@ -57,73 +57,27 @@ async def download_source_content(source_id: int) -> bool:
     Returns:
         True if successful, False otherwise
     """
+    import asyncio
     from sqlalchemy import text
-    
+
+    # Step 1: read the target URL in a short-lived session, then release the
+    # connection so we don't hold it during the (slow) network fetch.
     async with async_session_maker() as session:
-        # Get the source URL using raw SQL to avoid enum issues
         result = await session.execute(
             text("SELECT resolved_url, google_news_url FROM source_google_news WHERE id = :id"),
             {"id": source_id}
         )
         row = result.fetchone()
-        
+
         if not row:
             logger.warning(f"Source {source_id} not found")
             return False
-        
+
         # Use resolved URL if available, otherwise the Google News URL
         target_url = row[0] or row[1]
-        
-        logger.info(f"Downloading content from: {target_url[:80]}...")
-        
-        try:
-            # Download the page
-            downloaded = trafilatura.fetch_url(target_url)
-            
-            if not downloaded:
-                logger.warning(f"Failed to download: {target_url}")
-                await session.execute(
-                    text("""
-                        UPDATE source_google_news 
-                        SET status = 'failed_in_download', updated_at = CURRENT_TIMESTAMP
-                        WHERE id = :id
-                    """),
-                    {"id": source_id}
-                )
-                await session.commit()
-                return False
-            
-            # Extract content
-            content, metadata = extract_content_and_metadata(downloaded)
-            
-            if content:
-                await session.execute(
-                    text("""
-                        UPDATE source_google_news 
-                        SET content = :content, status = 'ready_for_extraction', updated_at = CURRENT_TIMESTAMP
-                        WHERE id = :id
-                    """),
-                    {"id": source_id, "content": content}
-                )
-                await session.commit()
-                
-                logger.info(f"Downloaded {len(content)} chars for source {source_id}")
-                return True
-            else:
-                logger.warning(f"No content extracted from: {target_url}")
-                await session.execute(
-                    text("""
-                        UPDATE source_google_news 
-                        SET status = 'failed_in_download', updated_at = CURRENT_TIMESTAMP
-                        WHERE id = :id
-                    """),
-                    {"id": source_id}
-                )
-                await session.commit()
-                return False
-                
-        except Exception as e:
-            logger.error(f"Error downloading source {source_id}: {e}")
+
+    async def _mark_failed():
+        async with async_session_maker() as session:
             await session.execute(
                 text("""
                     UPDATE source_google_news 
@@ -133,7 +87,43 @@ async def download_source_content(source_id: int) -> bool:
                 {"id": source_id}
             )
             await session.commit()
+
+    logger.info(f"Downloading content from: {target_url[:80]}...")
+
+    # Step 2: fetch + extract off the event loop, WITHOUT holding a DB connection.
+    try:
+        downloaded = await asyncio.to_thread(trafilatura.fetch_url, target_url)
+
+        if not downloaded:
+            logger.warning(f"Failed to download: {target_url}")
+            await _mark_failed()
             return False
+
+        content, metadata = await asyncio.to_thread(extract_content_and_metadata, downloaded)
+    except Exception as e:
+        logger.error(f"Error downloading source {source_id}: {e}")
+        await _mark_failed()
+        return False
+
+    if not content:
+        logger.warning(f"No content extracted from: {target_url}")
+        await _mark_failed()
+        return False
+
+    # Step 3: persist the content in a fresh short-lived session.
+    async with async_session_maker() as session:
+        await session.execute(
+            text("""
+                UPDATE source_google_news 
+                SET content = :content, status = 'ready_for_extraction', updated_at = CURRENT_TIMESTAMP
+                WHERE id = :id
+            """),
+            {"id": source_id, "content": content}
+        )
+        await session.commit()
+
+    logger.info(f"Downloaded {len(content)} chars for source {source_id}")
+    return True
 
 
 async def download_classified_sources(limit: int = 50, concurrency: int = 10) -> dict:

--- a/backend/app/services/extraction.py
+++ b/backend/app/services/extraction.py
@@ -171,10 +171,12 @@ async def extract_source(source_id: int) -> RawEvent | None:
     Returns:
         RawEvent if successful, None otherwise
     """
+    import asyncio
     from sqlalchemy import text
-    
+
+    # Step 1: read the source content/metadata in a short-lived session, then
+    # release the connection before the (slow, blocking) LLM extraction call.
     async with async_session_maker() as session:
-        # Get the source content and metadata using raw SQL
         result = await session.execute(
             text("""
                 SELECT id, headline, content, published_at, publisher_name, resolved_url 
@@ -184,97 +186,47 @@ async def extract_source(source_id: int) -> RawEvent | None:
             {"id": source_id}
         )
         row = result.fetchone()
-        
+
         if not row:
             logger.warning(f"Source {source_id} not found")
             return None
-        
+
         source_id_db, headline, content, published_at, publisher_name, resolved_url = row
-        
-        if not content:
-            logger.warning(f"Source {source_id} has no content")
-            return None
-        
-        headline_preview = (headline or "")[:50]
-        logger.info(f"Extracting event from source {source_id}: {headline_preview}...")
-        
-        # Build metadata context for the LLM
-        metadata = {
-            "headline": headline,
-            "publisher": publisher_name,
-            "url": resolved_url,
-        }
-        
-        # Format published_at for the LLM
-        if published_at:
-            try:
-                from datetime import datetime as dt
-                if isinstance(published_at, str):
-                    pub_date = dt.fromisoformat(published_at.replace('Z', '+00:00'))
-                else:
-                    pub_date = published_at
-                metadata["published_at"] = pub_date.strftime("%d/%m/%Y às %H:%M")
-            except Exception as e:
-                logger.debug(f"Could not format published_at: {e}")
-                metadata["published_at"] = str(published_at)
-        
+
+    if not content:
+        logger.warning(f"Source {source_id} has no content")
+        return None
+
+    headline_preview = (headline or "")[:50]
+    logger.info(f"Extracting event from source {source_id}: {headline_preview}...")
+
+    # Build metadata context for the LLM
+    metadata = {
+        "headline": headline,
+        "publisher": publisher_name,
+        "url": resolved_url,
+    }
+
+    # Format published_at for the LLM
+    if published_at:
         try:
-            # Extract structured event data with metadata context
-            event = extract_event_from_content(content, metadata=metadata)
-            event_data = event.model_dump()
-            
-            # Parse date string to datetime if present
-            event_date = None
-            if event.date_time.date:
-                try:
-                    from datetime import datetime as dt
-                    event_date = dt.strptime(event.date_time.date, "%Y-%m-%d")
-                except ValueError:
-                    logger.warning(f"Could not parse date: {event.date_time.date}")
-            
-            # Create RawEvent with denormalized fields
-            raw_event = RawEvent(
-                source_google_news_id=source_id,
-                # Denormalized queryable fields
-                event_date=event_date,
-                date_precision=event.date_time.date_precision,
-                time_of_day=event.date_time.time_of_day,
-                city=event.location_info.city,
-                state=event.location_info.state,
-                neighborhood=event.location_info.neighborhood,
-                victim_count=event.victims.number_of_victims,
-                identified_victim_count=event.victims.number_of_identifiable_victims,
-                perpetrator_count=event.perpetrators.number_of_perpetrators if event.perpetrators else None,
-                homicide_type=event.homicide_dynamic.homicide_type,
-                method_of_death=event.homicide_dynamic.method,
-                title=event.homicide_dynamic.title,
-                chronological_description=event.homicide_dynamic.chronological_description,
-                # Full structured data as JSON
-                extraction_data=event_data,
-                extraction_model=get_settings().extraction_model,
-                extraction_success=True,
-            )
-            
-            session.add(raw_event)
-            
-            # Update source status using raw SQL
-            await session.execute(
-                text("""
-                    UPDATE source_google_news 
-                    SET status = 'extracted', updated_at = CURRENT_TIMESTAMP
-                    WHERE id = :id
-                """),
-                {"id": source_id}
-            )
-            
-            await session.commit()
-            await session.refresh(raw_event)
-            
-            logger.info(f"Created RawEvent {raw_event.id} for source {source_id}")
-            return raw_event
-            
+            from datetime import datetime as dt
+            if isinstance(published_at, str):
+                pub_date = dt.fromisoformat(published_at.replace('Z', '+00:00'))
+            else:
+                pub_date = published_at
+            metadata["published_at"] = pub_date.strftime("%d/%m/%Y às %H:%M")
         except Exception as e:
-            logger.error(f"Extraction failed for source {source_id}: {e}")
+            logger.debug(f"Could not format published_at: {e}")
+            metadata["published_at"] = str(published_at)
+
+    # Step 2: run the blocking LLM extraction off the event loop and WITHOUT
+    # holding a DB connection.
+    try:
+        event = await asyncio.to_thread(extract_event_from_content, content, metadata)
+    except Exception as e:
+        logger.error(f"Extraction failed for source {source_id}: {e}")
+        async with async_session_maker() as session:
             await session.execute(
                 text("""
                     UPDATE source_google_news 
@@ -284,7 +236,59 @@ async def extract_source(source_id: int) -> RawEvent | None:
                 {"id": source_id}
             )
             await session.commit()
-            return None
+        return None
+
+    event_data = event.model_dump()
+
+    # Parse date string to datetime if present
+    event_date = None
+    if event.date_time.date:
+        try:
+            from datetime import datetime as dt
+            event_date = dt.strptime(event.date_time.date, "%Y-%m-%d")
+        except ValueError:
+            logger.warning(f"Could not parse date: {event.date_time.date}")
+
+    # Step 3: persist the RawEvent in a fresh short-lived session.
+    async with async_session_maker() as session:
+        raw_event = RawEvent(
+            source_google_news_id=source_id,
+            # Denormalized queryable fields
+            event_date=event_date,
+            date_precision=event.date_time.date_precision,
+            time_of_day=event.date_time.time_of_day,
+            city=event.location_info.city,
+            state=event.location_info.state,
+            neighborhood=event.location_info.neighborhood,
+            victim_count=event.victims.number_of_victims,
+            identified_victim_count=event.victims.number_of_identifiable_victims,
+            perpetrator_count=event.perpetrators.number_of_perpetrators if event.perpetrators else None,
+            homicide_type=event.homicide_dynamic.homicide_type,
+            method_of_death=event.homicide_dynamic.method,
+            title=event.homicide_dynamic.title,
+            chronological_description=event.homicide_dynamic.chronological_description,
+            # Full structured data as JSON
+            extraction_data=event_data,
+            extraction_model=get_settings().extraction_model,
+            extraction_success=True,
+        )
+
+        session.add(raw_event)
+
+        await session.execute(
+            text("""
+                UPDATE source_google_news 
+                SET status = 'extracted', updated_at = CURRENT_TIMESTAMP
+                WHERE id = :id
+            """),
+            {"id": source_id}
+        )
+
+        await session.commit()
+        await session.refresh(raw_event)
+
+    logger.info(f"Created RawEvent {raw_event.id} for source {source_id}")
+    return raw_event
 
 
 async def extract_ready_sources(limit: int = 10, concurrency: int = 15) -> dict:

--- a/backend/app/services/maintenance.py
+++ b/backend/app/services/maintenance.py
@@ -1,0 +1,59 @@
+"""Maintenance helpers for recovering the pipeline from stuck states."""
+
+from loguru import logger
+
+from app.database import async_session_maker
+
+
+# Map of transient "claimed" statuses back to the queue status they should
+# return to if a worker crashed / errored out mid-processing and left the row
+# stranded. These intermediate states are only valid while a task is actively
+# working a row; anything older than the threshold is safe to requeue.
+STUCK_STATUS_RESETS = {
+    "classifying": "ready_for_classification",
+    "downloading": "ready_for_download",
+    "extracting": "ready_for_extraction",
+}
+
+
+async def recover_stuck_sources(older_than_minutes: int = 15) -> dict:
+    """
+    Requeue sources stranded in transient processing states.
+
+    A row gets a transient status (e.g. 'classifying') when a batch task
+    atomically claims it. If the task then fails for an infrastructure reason
+    (pool exhaustion, lock timeout, worker restart) the row can be left stuck
+    in that status forever and never reprocessed. This resets any such row that
+    has not been touched within ``older_than_minutes`` back to its queue status.
+
+    Args:
+        older_than_minutes: Only reset rows whose ``updated_at`` is older than
+            this many minutes, to avoid disturbing in-flight work.
+
+    Returns:
+        Dict mapping each transient status to the number of rows requeued.
+    """
+    from sqlalchemy import text
+
+    recovered: dict[str, int] = {}
+    async with async_session_maker() as session:
+        for stuck_status, target_status in STUCK_STATUS_RESETS.items():
+            result = await session.execute(
+                text(f"""
+                    UPDATE source_google_news
+                    SET status = :target_status, updated_at = CURRENT_TIMESTAMP
+                    WHERE status = :stuck_status
+                    AND updated_at < datetime('now', '-{int(older_than_minutes)} minutes')
+                """),
+                {"target_status": target_status, "stuck_status": stuck_status},
+            )
+            recovered[stuck_status] = result.rowcount or 0
+        await session.commit()
+
+    total = sum(recovered.values())
+    if total:
+        logger.info(f"[RECOVERY] Requeued {total} stuck sources: {recovered}")
+    else:
+        logger.info("[RECOVERY] No stuck sources to requeue")
+
+    return recovered

--- a/backend/app/services/telegram.py
+++ b/backend/app/services/telegram.py
@@ -343,6 +343,61 @@ async def notify_pipeline_summary(
 
 
 # =============================================================================
+# WORKER HEALTH NOTIFICATIONS
+# =============================================================================
+
+
+async def notify_worker_down(seconds_silent: int | None = None) -> None:
+    """
+    Notify that the ARQ worker has stopped sending heartbeats.
+
+    While the worker is down nothing gets downloaded or classified, even though
+    Redis stays reachable, so this is sent loudly (not silenced).
+
+    Args:
+        seconds_silent: Approximate time since the last heartbeat was seen.
+    """
+    notifier = get_notifier()
+
+    timestamp = datetime.now().strftime("%H:%M:%S")
+
+    message = "🔴 <b>Worker Down</b>\n\n"
+    message += "The pipeline worker stopped sending heartbeats.\n"
+    message += "No jobs will be downloaded or classified until it recovers.\n"
+    if seconds_silent:
+        minutes = max(1, seconds_silent // 60)
+        message += f"\n⏱️ <b>Silent for:</b> ~{minutes} min\n"
+    message += f"🕐 <b>Time:</b> {timestamp}\n"
+    message += (
+        "\n<b>Check:</b> <code>docker compose -p prod ps</code> / "
+        "<code>docker compose -p prod logs --tail=200 worker</code>"
+    )
+
+    await notifier.send_message(message, disable_notification=False)
+
+
+async def notify_worker_recovered(seconds_down: int | None = None) -> None:
+    """
+    Notify that the ARQ worker is sending heartbeats again.
+
+    Args:
+        seconds_down: Approximate duration of the outage, if known.
+    """
+    notifier = get_notifier()
+
+    timestamp = datetime.now().strftime("%H:%M:%S")
+
+    message = "🟢 <b>Worker Recovered</b>\n\n"
+    message += "The pipeline worker is sending heartbeats again.\n"
+    if seconds_down:
+        minutes = max(1, seconds_down // 60)
+        message += f"\n⏱️ <b>Down for:</b> ~{minutes} min\n"
+    message += f"🕐 <b>Time:</b> {timestamp}"
+
+    await notifier.send_message(message, disable_notification=False)
+
+
+# =============================================================================
 # TEST / HEALTH CHECK
 # =============================================================================
 

--- a/backend/app/services/worker_monitor.py
+++ b/backend/app/services/worker_monitor.py
@@ -1,0 +1,89 @@
+"""
+Worker health monitor.
+
+Runs inside the API process (the always-on observer that is independent of the
+worker) and periodically reads the ARQ worker's heartbeat key from Redis. If the
+worker stops heartbeating it sends a Telegram alert once, and a recovery alert
+when it comes back.
+
+This exists because Redis connectivity says nothing about whether the worker
+process - which also schedules the ingestion cron - is actually alive. A dead
+worker silently stalls the whole pipeline.
+"""
+
+import asyncio
+
+from arq import create_pool
+from loguru import logger
+
+from app.tasks.worker import get_redis_settings, HEALTH_CHECK_KEY
+from app.services.telegram import notify_worker_down, notify_worker_recovered
+
+# How often to poll the heartbeat key.
+CHECK_INTERVAL_SECONDS = 60
+
+# Consecutive missed heartbeats before declaring the worker down. Kept high
+# enough to ride out a normal deploy (graceful worker shutdown can take ~120s)
+# without firing a false alarm.
+MISS_THRESHOLD = 5
+
+
+async def monitor_worker_health(stop_event: asyncio.Event) -> None:
+    """Poll the worker heartbeat until ``stop_event`` is set."""
+    consecutive_misses = 0
+    alerted_down = False
+    pool = None
+
+    logger.info(
+        f"[WorkerMonitor] Started (interval={CHECK_INTERVAL_SECONDS}s, "
+        f"threshold={MISS_THRESHOLD})"
+    )
+
+    while not stop_event.is_set():
+        try:
+            if pool is None:
+                pool = await create_pool(get_redis_settings())
+
+            alive = await pool.get(HEALTH_CHECK_KEY) is not None
+
+            if alive:
+                if alerted_down:
+                    seconds_down = consecutive_misses * CHECK_INTERVAL_SECONDS
+                    logger.info("[WorkerMonitor] Worker heartbeat recovered")
+                    await notify_worker_recovered(seconds_down)
+                consecutive_misses = 0
+                alerted_down = False
+            else:
+                consecutive_misses += 1
+                logger.warning(
+                    f"[WorkerMonitor] Missed heartbeat "
+                    f"({consecutive_misses}/{MISS_THRESHOLD})"
+                )
+                if consecutive_misses >= MISS_THRESHOLD and not alerted_down:
+                    seconds_silent = consecutive_misses * CHECK_INTERVAL_SECONDS
+                    logger.error("[WorkerMonitor] Worker appears down - alerting")
+                    await notify_worker_down(seconds_silent)
+                    alerted_down = True
+        except Exception as e:
+            # Redis errors etc. - don't treat as "worker down" (that's a
+            # different failure mode). Drop the pool so we reconnect cleanly.
+            logger.error(f"[WorkerMonitor] Health check error: {e}")
+            if pool is not None:
+                try:
+                    await pool.close()
+                except Exception:
+                    pass
+                pool = None
+
+        try:
+            await asyncio.wait_for(stop_event.wait(), timeout=CHECK_INTERVAL_SECONDS)
+        except asyncio.TimeoutError:
+            pass
+
+    if pool is not None:
+        try:
+            await pool.close()
+        except Exception:
+            pass
+
+    logger.info("[WorkerMonitor] Stopped")

--- a/backend/app/tasks/pipeline.py
+++ b/backend/app/tasks/pipeline.py
@@ -502,6 +502,11 @@ async def ingest_cities_full_pipeline(
     # Notify job started
     await notify_job_started("cities_full_pipeline", {"when": when})
     
+    # Step 0: Recover any sources stranded in a transient processing state by a
+    # previous run (e.g. due to a crash or DB contention), so they get reprocessed.
+    from app.services.maintenance import recover_stuck_sources
+    await recover_stuck_sources(older_than_minutes=15)
+    
     # Step 1: Ingest cities
     ingest_result = await ingest_cities_task(ctx, cities=cities, when=when)
     

--- a/backend/app/tasks/worker.py
+++ b/backend/app/tasks/worker.py
@@ -1,12 +1,32 @@
 """ARQ worker configuration."""
 
 import os
+import json
+from datetime import datetime, timezone
+
 from arq import cron
 from arq.connections import RedisSettings
+from arq.constants import default_queue_name, health_check_key_suffix
 
 from app.config import get_settings
 
 settings = get_settings()
+
+# Redis key under which the worker records its health heartbeat.
+# Must match arq's default (queue_name + suffix) since WorkerSettings does not
+# override queue_name / health_check_key. The API reads this key to tell whether
+# the worker process is actually alive (separate from Redis connectivity).
+HEALTH_CHECK_KEY = default_queue_name + health_check_key_suffix
+
+# Redis key the worker publishes its own config to on startup, so the API
+# (which runs in a different container and may not share ENABLE_CRON) can report
+# whether cron is actually enabled on the running worker.
+WORKER_INFO_KEY = "arquivo:worker:info"
+
+
+def is_cron_enabled() -> bool:
+    """Whether scheduled (cron) jobs are enabled for this worker."""
+    return os.environ.get("ENABLE_CRON", "false").lower() == "true"
 
 
 def get_redis_settings() -> RedisSettings:
@@ -23,8 +43,26 @@ def get_redis_settings() -> RedisSettings:
 async def startup(ctx: dict) -> None:
     """Worker startup handler."""
     from loguru import logger
+    cron_enabled = is_cron_enabled()
     logger.info("ARQ Worker starting up...")
-    logger.info(f"Cron enabled: {os.environ.get('ENABLE_CRON', 'false')}")
+    logger.info(f"Cron enabled: {cron_enabled}")
+
+    # Publish worker config to Redis so the API can report accurate status even
+    # though it runs in a separate container without ENABLE_CRON set.
+    redis = ctx.get("redis")
+    if redis is not None:
+        try:
+            await redis.set(
+                WORKER_INFO_KEY,
+                json.dumps(
+                    {
+                        "cron_enabled": cron_enabled,
+                        "started_at": datetime.now(timezone.utc).isoformat(),
+                    }
+                ),
+            )
+        except Exception as e:  # pragma: no cover - best effort, non-fatal
+            logger.warning(f"Failed to publish worker info to Redis: {e}")
 
 
 async def shutdown(ctx: dict) -> None:
@@ -42,7 +80,7 @@ def get_cron_jobs():
     from app.tasks.pipeline import ingest_cities_full_pipeline
     
     # Only enable cron if explicitly requested
-    if os.environ.get("ENABLE_CRON", "false").lower() != "true":
+    if not is_cron_enabled():
         return []
     
     return [
@@ -78,6 +116,9 @@ class WorkerSettings:
     max_jobs = 10
     job_timeout = 600  # 10 minutes default timeout (city ingestion can be slow)
     keep_result = 3600  # Keep results for 1 hour
+    # Refresh the health-check key every 30s (default is 3600s) so the API can
+    # detect a dead/crashed worker within ~30s instead of up to an hour.
+    health_check_interval = 30
     
     # Retry settings
     max_tries = 3

--- a/backend/app/tasks/worker.py
+++ b/backend/app/tasks/worker.py
@@ -64,6 +64,15 @@ async def startup(ctx: dict) -> None:
         except Exception as e:  # pragma: no cover - best effort, non-fatal
             logger.warning(f"Failed to publish worker info to Redis: {e}")
 
+    # Requeue any sources left stranded in a transient processing state by a
+    # previous worker that crashed or errored mid-batch.
+    try:
+        from app.services.maintenance import recover_stuck_sources
+
+        await recover_stuck_sources(older_than_minutes=5)
+    except Exception as e:  # pragma: no cover - best effort, non-fatal
+        logger.warning(f"Failed to recover stuck sources on startup: {e}")
+
 
 async def shutdown(ctx: dict) -> None:
     """Worker shutdown handler."""

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -17,6 +17,10 @@ export interface Job {
 
 export interface PipelineStatus {
   redis: string;
+  worker_alive?: boolean;
+  worker_health?: string | null;
+  worker_started_at?: string | null;
+  cron_enabled?: boolean;
   queued_jobs: number;
   jobs: Job[];
   error?: string;

--- a/frontend/src/pages/admin/Jobs.tsx
+++ b/frontend/src/pages/admin/Jobs.tsx
@@ -14,7 +14,7 @@ import {
   fetchPipelineStatus,
   type Job,
 } from '@/lib/api';
-import { Loader2, RefreshCw, CheckCircle, XCircle } from 'lucide-react';
+import { Loader2, RefreshCw, CheckCircle, XCircle, AlertTriangle } from 'lucide-react';
 
 function formatTime(isoString: string | null) {
   if (!isoString) return '—';
@@ -33,6 +33,13 @@ export function Jobs() {
   });
 
   const isRedisConnected = status?.redis === 'connected';
+  const isWorkerAlive = status?.worker_alive === true;
+  const isCronEnabled = status?.cron_enabled === true;
+
+  // Redis being up tells us nothing about whether the pipeline is actually
+  // running. The worker (which also schedules cron) can be dead or have cron
+  // disabled while Redis stays connected, which silently stalls everything.
+  const isStalled = isRedisConnected && (!isWorkerAlive || !isCronEnabled);
 
   return (
     <div className="space-y-6">
@@ -58,6 +65,61 @@ export function Jobs() {
           </>
         )}
       </div>
+
+      {/* Worker / Cron Status */}
+      {isRedisConnected && (
+        <div className="flex flex-wrap items-center gap-2 text-sm">
+          {isWorkerAlive ? (
+            <span className="inline-flex items-center gap-1.5 text-green-600">
+              <CheckCircle className="h-4 w-4 text-green-500" />
+              Worker running
+            </span>
+          ) : (
+            <span className="inline-flex items-center gap-1.5 text-red-600">
+              <XCircle className="h-4 w-4 text-red-500" />
+              Worker not responding
+            </span>
+          )}
+          <span className="text-muted-foreground">•</span>
+          {isCronEnabled ? (
+            <span className="inline-flex items-center gap-1.5 text-green-600">
+              <CheckCircle className="h-4 w-4 text-green-500" />
+              Hourly cron enabled
+            </span>
+          ) : (
+            <span className="inline-flex items-center gap-1.5 text-amber-600">
+              <AlertTriangle className="h-4 w-4 text-amber-500" />
+              Cron disabled
+            </span>
+          )}
+        </div>
+      )}
+
+      {/* Stalled pipeline warning - Redis up but nothing will run */}
+      {isStalled && (
+        <div className="flex items-start gap-3 rounded-md border border-amber-300 bg-amber-50 p-4 text-sm text-amber-800">
+          <AlertTriangle className="h-5 w-5 flex-shrink-0 text-amber-500" />
+          <div className="space-y-1">
+            <p className="font-medium">Pipeline is stalled — nothing will be downloaded or classified.</p>
+            {!isWorkerAlive && (
+              <p>
+                Redis is reachable but the <span className="font-mono">worker</span> process is not
+                sending heartbeats. Check it on the server:{' '}
+                <span className="font-mono">docker compose -p prod ps</span> and{' '}
+                <span className="font-mono">docker compose -p prod logs --tail=200 worker</span>.
+              </p>
+            )}
+            {isWorkerAlive && !isCronEnabled && (
+              <p>
+                The worker is running but scheduled ingestion is off. Set{' '}
+                <span className="font-mono">ENABLE_CRON=true</span> in the server{' '}
+                <span className="font-mono">.env</span> and restart the worker, or trigger a run
+                manually from the API.
+              </p>
+            )}
+          </div>
+        </div>
+      )}
 
       {/* Queued Jobs */}
       <Card>


### PR DESCRIPTION
## Summary

Classification (and download/extract) on prod were failing intermittently and stranding records. Worker logs showed `database is locked` and `QueuePool limit of size 5 overflow 10 reached, connection timed out`. At investigation time **1,226 sources were stuck in `classifying`**, 394 in `extracting`, and 6 in `downloading` — claimed by a batch job that then errored on a pool/lock timeout and were never reverted, so they never got reprocessed.

**Root cause:** `classify_source`, `download_source_content`, and `extract_source` each held a DB connection checked out for the entire duration of their slow, blocking LLM/network call. With the worker running up to 10 batch jobs at once (`max_jobs=10`), each fanning out ~10–15 concurrent source-level coroutines, this far exceeded the default 15-connection pool.

## Changes

- **`database.py`**: raise SQLite pool to `pool_size=30, max_overflow=70` (WAL + `busy_timeout` already handle write serialization).
- **`classification.py` / `download.py` / `extraction.py`**: read in a short-lived session → release the connection → run the LLM/network work via `asyncio.to_thread` (off the event loop, no connection held) → persist in a fresh short-lived session.
- **`maintenance.py`** (new): `recover_stuck_sources()` requeues rows stranded in transient states (`classifying`→`ready_for_classification`, etc.) older than a threshold. Wired into **worker startup** and the **start of the hourly pipeline**, so the currently-stuck rows auto-recover when the new worker boots.

Also includes the previously-committed worker/cron health surfacing change on this branch.

## Test plan

- [x] `python3 -m py_compile` on all changed modules passes.
- [ ] After deploy: confirm worker startup logs `[RECOVERY] Requeued N stuck sources`.
- [ ] Confirm `classifying`/`extracting`/`downloading` counts drop to ~0 and no longer accumulate.
- [ ] Confirm no `QueuePool limit` / `database is locked` errors in worker logs during a pipeline run.

## Out of scope (follow-up)

Enrichment is separately hitting Gemini safety blocks (`candidates=None ... prompt_feedback`); not addressed here.