### PR TITLE
fix(portal): quick wins, map/search fixes, and zoom performance

### DIFF
--- a/backend/app/routers/public.py
+++ b/backend/app/routers/public.py
@@ -224,6 +224,7 @@ async def geocode_location(
         "label": result["label"],
         "source": result["source"],
         "query": query,
+        "zoom": result.get("zoom"),
     }
 
 

--- a/backend/app/services/geocoding.py
+++ b/backend/app/services/geocoding.py
@@ -195,6 +195,7 @@ async def geocode_address(
     query: str,
     input_granularity: str = PRECISION_CITY,
     client: httpx.AsyncClient | None = None,
+    restrict_country: bool = False,
 ) -> dict | None:
     """
     Call the Google Maps Geocoding API for a query string.
@@ -212,6 +213,8 @@ async def geocode_address(
         "region": "br",
         "language": "pt-BR",
     }
+    if restrict_country:
+        params["components"] = "country:BR"
 
     owns_client = client is None
     if owns_client:
@@ -241,7 +244,10 @@ async def geocode_address(
     if not results:
         return None
 
-    return parse_geocode_result(results[0], input_granularity)
+    parsed = parse_geocode_result(results[0], input_granularity)
+    if parsed is not None:
+        parsed["zoom"] = _zoom_from_google_types(set(results[0].get("types", [])))
+    return parsed
 
 
 NOMINATIM_URL = "https://nominatim.openstreetmap.org/search"
@@ -249,6 +255,37 @@ NOMINATIM_USER_AGENT = "arquivo-da-violencia/1.0 (+https://arquivodaviolencia.co
 
 
 VIACEP_URL = "https://viacep.com.br/ws/{cep}/json/"
+
+BRAZIL_COUNTRY_RESULT = {
+    "latitude": -14.0,
+    "longitude": -52.0,
+    "label": "Brasil",
+    "source": "preset",
+    "zoom": 3.6,
+}
+
+
+def _zoom_from_google_types(types: set[str]) -> float:
+    if "country" in types:
+        return 3.6
+    if types & {"administrative_area_level_1"}:
+        return 6.5
+    if types & {"locality", "administrative_area_level_2", "administrative_area_level_3"}:
+        return 11.0
+    if types & {"route", "neighborhood", "sublocality", "street_address", "premise", "postal_code"}:
+        return 13.0
+    return 11.0
+
+
+def _zoom_from_nominatim(result: dict) -> float:
+    place_type = (result.get("type") or result.get("class") or "").lower()
+    if place_type == "country":
+        return 3.6
+    if place_type in {"state", "region"}:
+        return 6.5
+    if place_type in {"city", "town", "municipality", "village", "county"}:
+        return 11.0
+    return 13.0
 
 
 def normalize_cep(value: str) -> str | None:
@@ -319,6 +356,8 @@ async def geocode_user_query(
     query = (query or "").strip()
     if not query:
         return None
+    if re.match(r"^(brasil|brazil)$", query, re.I):
+        return dict(BRAZIL_COUNTRY_RESULT)
     # Accept CEPs with or without a dash (e.g. "22221150" or "22221-150").
     # Resolve them through ViaCEP first since raw CEPs geocode poorly on OSM.
     cep = normalize_cep(query)
@@ -330,13 +369,16 @@ async def geocode_user_query(
 
     settings = get_settings()
     if settings.google_maps_api_key:
-        fields = await geocode_address(query, PRECISION_CITY, client=client)
+        fields = await geocode_address(
+            query, PRECISION_CITY, client=client, restrict_country=not bool(cep)
+        )
         if fields and fields.get("latitude") is not None:
             return {
                 "latitude": float(fields["latitude"]),
                 "longitude": float(fields["longitude"]),
                 "label": fields.get("formatted_address") or query,
                 "source": GEOCODING_SOURCE,
+                "zoom": fields.get("zoom", 13.0),
             }
 
     # Free fallback: Nominatim (no API key required).
@@ -376,6 +418,7 @@ async def geocode_user_query(
             "longitude": float(top["lon"]),
             "label": top.get("display_name") or query,
             "source": "nominatim",
+            "zoom": _zoom_from_nominatim(top),
         }
     except (KeyError, ValueError, TypeError):
         return None

--- a/env.example
+++ b/env.example
@@ -42,3 +42,6 @@ VITE_GA_MEASUREMENT_ID=
 
 # Site URL for SEO (Open Graph, canonical URLs, etc.)
 VITE_SITE_URL=https://arquivodaviolencia.com.br
+
+# MapLibre basemap style URL (optional; defaults to OpenFreeMap Liberty)
+# VITE_MAP_STYLE=https://tiles.openfreemap.org/styles/liberty

--- a/env.example
+++ b/env.example
@@ -43,5 +43,6 @@ VITE_GA_MEASUREMENT_ID=
 # Site URL for SEO (Open Graph, canonical URLs, etc.)
 VITE_SITE_URL=https://arquivodaviolencia.com.br
 
-# MapLibre basemap style URL (optional; defaults to OpenFreeMap Liberty)
+# MapLibre basemap style URL (optional)
+# Carto Positron (default) is lighter/faster for zoom; OpenFreeMap Liberty has richer labels:
 # VITE_MAP_STYLE=https://tiles.openfreemap.org/styles/liberty

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -74,6 +74,7 @@ function App() {
               <Route path="/eventos/:id" element={<MapExplorerRoute initialMode="feed" />} />
               <Route path="/dados" element={<MapExplorerRoute initialMode="data" />} />
               <Route path="/sobre" element={<MapExplorerRoute initialMode="stats" initialAbout />} />
+              <Route path="/metodologia" element={<MapExplorerRoute initialMode="stats" initialMethodology />} />
 
               <Route path="/admin/login" element={<Login />} />
 

--- a/frontend/src/components/map/CrimeMap.tsx
+++ b/frontend/src/components/map/CrimeMap.tsx
@@ -44,7 +44,8 @@ interface CrimeMapProps {
   searchedLocation?: { lat: number; lng: number } | null;
 }
 
-const MAP_STYLE = 'https://basemaps.cartocdn.com/gl/positron-gl-style/style.json';
+const DEFAULT_MAP_STYLE = 'https://tiles.openfreemap.org/styles/liberty';
+const MAP_STYLE = import.meta.env.VITE_MAP_STYLE || DEFAULT_MAP_STYLE;
 
 const COLOR_RANGE: [number, number, number][] = [
   [247, 198, 192],

--- a/frontend/src/components/map/CrimeMap.tsx
+++ b/frontend/src/components/map/CrimeMap.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useCallback } from 'react';
+import { useEffect, useMemo, useRef, useCallback, useState } from 'react';
 import DeckGL from '@deck.gl/react';
 import { Map } from 'react-map-gl/maplibre';
 import { GridLayer } from '@deck.gl/aggregation-layers';
@@ -35,8 +35,7 @@ export interface ViewportSnapshot {
 interface CrimeMapProps {
   points: MapPoint[];
   viewState: MapViewState;
-  onViewStateChange: (vs: MapViewState) => void;
-  /** Debounced (~100ms) — drives panel stats, not map rendering. */
+  /** Called when the viewport stops moving (debounced). Drives panel stats. */
   onViewportSettled?: (snapshot: ViewportSnapshot) => void;
   onPointClick: (id: number) => void;
   onCellClick?: (coordinate: [number, number]) => void;
@@ -44,7 +43,7 @@ interface CrimeMapProps {
   searchedLocation?: { lat: number; lng: number } | null;
 }
 
-const DEFAULT_MAP_STYLE = 'https://tiles.openfreemap.org/styles/liberty';
+const DEFAULT_MAP_STYLE = 'https://basemaps.cartocdn.com/gl/positron-gl-style/style.json';
 const MAP_STYLE = import.meta.env.VITE_MAP_STYLE || DEFAULT_MAP_STYLE;
 
 const COLOR_RANGE: [number, number, number][] = [
@@ -55,8 +54,11 @@ const COLOR_RANGE: [number, number, number][] = [
   [135, 43, 38],
 ];
 
-const BOUNDS_DEBOUNCE_MS = 100;
+/** Debounce panel stats updates — avoids recomputing RightPanel on every zoom frame. */
+const BOUNDS_DEBOUNCE_MS = 200;
 const SCATTER_ZOOM_THRESHOLD = 12;
+/** Skip viewport culling below this count (cheaper to pass all points). */
+const CULL_MIN_POINTS = 1500;
 
 function cellSizeForZoom(zoom: number): number {
   if (zoom < 5) return 40000;
@@ -88,10 +90,28 @@ function boundsFromView(
   }
 }
 
+function expandBounds(bounds: MapBounds, padding: number): MapBounds {
+  const [[minLng, minLat], [maxLng, maxLat]] = bounds;
+  const padLng = (maxLng - minLng) * padding;
+  const padLat = (maxLat - minLat) * padding;
+  return [
+    [minLng - padLng, minLat - padLat],
+    [maxLng + padLng, maxLat + padLat],
+  ];
+}
+
+function cullPointsToBounds(points: MapPoint[], bounds: MapBounds | null): MapPoint[] {
+  if (!bounds || points.length < CULL_MIN_POINTS) return points;
+  return pointsInBounds(points, expandBounds(bounds, 0.25));
+}
+
+function viewStateKey(vs: MapViewState): string {
+  return `${vs.longitude},${vs.latitude},${vs.zoom},${vs.transitionDuration ?? 0}`;
+}
+
 export function CrimeMap({
   points,
-  viewState,
-  onViewStateChange,
+  viewState: viewStateProp,
   onViewportSettled,
   onPointClick,
   onCellClick,
@@ -104,33 +124,34 @@ export function CrimeMap({
   const onViewportSettledRef = useRef(onViewportSettled);
   const onPointClickRef = useRef(onPointClick);
   const onCellClickRef = useRef(onCellClick);
+  const externalViewKeyRef = useRef(viewStateKey(viewStateProp));
+
+  // Local view state keeps zoom/pan off the React root — MapExplorer no longer
+  // re-renders RightPanel on every animation frame.
+  const [localViewState, setLocalViewState] = useState<MapViewState>(viewStateProp);
+  const [renderBounds, setRenderBounds] = useState<MapBounds | null>(null);
 
   onViewportSettledRef.current = onViewportSettled;
   onPointClickRef.current = onPointClick;
   onCellClickRef.current = onCellClick;
 
-  const showScatter = viewState.zoom >= SCATTER_ZOOM_THRESHOLD;
-  const gridZoom = Math.floor(viewState.zoom);
+  // Sync programmatic moves (flyTo, cell click, event select) from parent.
+  useEffect(() => {
+    const key = viewStateKey(viewStateProp);
+    if (key !== externalViewKeyRef.current) {
+      externalViewKeyRef.current = key;
+      setLocalViewState(viewStateProp);
+    }
+  }, [viewStateProp]);
 
-  const scheduleViewportSettled = useCallback((vs: MapViewState) => {
+  const showScatter = localViewState.zoom >= SCATTER_ZOOM_THRESHOLD;
+  const gridZoom = Math.floor(localViewState.zoom);
+
+  const emitViewportSettled = useCallback((vs: MapViewState) => {
     if (!onViewportSettledRef.current) return;
     const bounds = boundsFromView(vs, sizeRef.current);
     if (!bounds) return;
-
-    if (settleTimerRef.current) clearTimeout(settleTimerRef.current);
-    settleTimerRef.current = setTimeout(() => {
-      onViewportSettledRef.current?.({
-        bounds,
-        zoom: vs.zoom,
-        longitude: vs.longitude,
-      });
-    }, BOUNDS_DEBOUNCE_MS);
-  }, []);
-
-  const emitViewportSettledImmediate = useCallback((vs: MapViewState) => {
-    if (!onViewportSettledRef.current) return;
-    const bounds = boundsFromView(vs, sizeRef.current);
-    if (!bounds) return;
+    setRenderBounds(bounds);
     onViewportSettledRef.current({
       bounds,
       zoom: vs.zoom,
@@ -138,12 +159,20 @@ export function CrimeMap({
     });
   }, []);
 
+  const scheduleViewportSettled = useCallback(
+    (vs: MapViewState) => {
+      if (settleTimerRef.current) clearTimeout(settleTimerRef.current);
+      settleTimerRef.current = setTimeout(() => emitViewportSettled(vs), BOUNDS_DEBOUNCE_MS);
+    },
+    [emitViewportSettled]
+  );
+
   useEffect(() => {
     const el = containerRef.current;
     if (!el) return;
     const update = () => {
       sizeRef.current = { width: el.clientWidth, height: el.clientHeight };
-      emitViewportSettledImmediate(viewState);
+      emitViewportSettled(localViewState);
     };
     update();
     const ro = new ResizeObserver(update);
@@ -153,14 +182,18 @@ export function CrimeMap({
       if (settleTimerRef.current) clearTimeout(settleTimerRef.current);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [emitViewportSettledImmediate]);
+  }, [emitViewportSettled]);
+
+  // Layer data updates on viewport settle (not every zoom frame).
+  const gridData = useMemo(
+    () => (showScatter ? [] : cullPointsToBounds(points, renderBounds)),
+    [points, showScatter, renderBounds, gridZoom]
+  );
 
   const scatterData = useMemo(() => {
     if (!showScatter) return [];
-    const bounds = boundsFromView(viewState, sizeRef.current);
-    if (!bounds) return [];
-    return capPoints(pointsInBounds(points, bounds));
-  }, [points, showScatter, viewState.longitude, viewState.latitude, viewState.zoom]);
+    return capPoints(cullPointsToBounds(points, renderBounds));
+  }, [points, showScatter, renderBounds, gridZoom]);
 
   const layers = useMemo(() => {
     const result: Layer[] = [];
@@ -196,13 +229,14 @@ export function CrimeMap({
       result.push(
         new GridLayer<MapPoint>({
           id: 'events-grid',
-          data: points,
+          data: gridData,
           getPosition: (d) => [d.lng, d.lat],
           cellSize: cellSizeForZoom(gridZoom),
           colorRange: COLOR_RANGE,
           extruded: false,
           pickable: true,
           opacity: 0.78,
+          gpuAggregation: true,
           onClick: (info: PickingInfo) => {
             if (info.coordinate) onCellClickRef.current?.(info.coordinate as [number, number]);
             return true;
@@ -230,17 +264,17 @@ export function CrimeMap({
     }
 
     return result;
-  }, [points, scatterData, showScatter, gridZoom, searchedLocation, selectedId]);
+  }, [gridData, scatterData, showScatter, gridZoom, searchedLocation, selectedId]);
 
   return (
     <div ref={containerRef} className="absolute inset-0">
       <DeckGL
-        viewState={viewState as unknown as DeckViewState}
+        viewState={localViewState as unknown as DeckViewState}
         controller={true}
         layers={layers}
         onViewStateChange={(params) => {
           const vs = params.viewState as unknown as MapViewState;
-          onViewStateChange(vs);
+          setLocalViewState(vs);
           scheduleViewportSettled(vs);
         }}
         getTooltip={({ object }: PickingInfo) => {

--- a/frontend/src/components/portal/AboutModal.tsx
+++ b/frontend/src/components/portal/AboutModal.tsx
@@ -1,13 +1,21 @@
 import { X } from 'lucide-react';
 import { memo, useEffect } from 'react';
 import { useI18n } from '@/contexts/I18nContext';
+import { TemporalScopeNote } from './TemporalScopeNote';
 
 interface AboutModalProps {
   open: boolean;
   onClose: () => void;
+  since: string | null;
+  onOpenMethodology: () => void;
 }
 
-export const AboutModal = memo(function AboutModal({ open, onClose }: AboutModalProps) {
+export const AboutModal = memo(function AboutModal({
+  open,
+  onClose,
+  since,
+  onOpenMethodology,
+}: AboutModalProps) {
   const { t } = useI18n();
 
   useEffect(() => {
@@ -58,12 +66,25 @@ export const AboutModal = memo(function AboutModal({ open, onClose }: AboutModal
           >
             {t.aboutTitle}
           </h2>
+          <div className="mb-3.5">
+            <TemporalScopeNote since={since} />
+          </div>
           <p className="mb-3.5 text-pretty" style={{ fontSize: 15, lineHeight: 1.65, color: 'var(--stone-700)' }}>
             {t.aboutP1}
           </p>
           <p className="mb-3.5 text-pretty" style={{ fontSize: 15, lineHeight: 1.65, color: 'var(--stone-700)' }}>
             {t.aboutP2}
           </p>
+          <button
+            onClick={() => {
+              onClose();
+              onOpenMethodology();
+            }}
+            className="mb-3.5 w-full rounded-[10px] border-none px-4 py-2.5"
+            style={{ background: 'var(--blue-500)', color: '#fff', fontSize: 14, fontWeight: 500 }}
+          >
+            {t.aboutMethodologyLink}
+          </button>
           <div className="mt-1.5 rounded-[11px] px-4 py-3.5" style={{ background: 'var(--gold-50)', border: '1px solid var(--gold-500)' }}>
             <div className="mb-[5px] font-mono text-[9.5px] uppercase tracking-[.1em]" style={{ color: 'var(--gold-700)' }}>
               {t.disclaimerLabel}

--- a/frontend/src/components/portal/DensityLegend.tsx
+++ b/frontend/src/components/portal/DensityLegend.tsx
@@ -28,7 +28,7 @@ export const DensityLegend = memo(function DensityLegend() {
           <span className="h-[11px] w-[26px] rounded-r-[2px]" style={{ background: 'rgba(135,43,38,1)' }} />
         </div>
         <div className="mt-1 flex justify-between" style={{ fontSize: 10, color: 'var(--color-text-muted)' }}>
-          <span>{t.fewer}</span>
+          <span>0</span>
           <span>{t.more}</span>
         </div>
       </div>

--- a/frontend/src/components/portal/LeftRail.tsx
+++ b/frontend/src/components/portal/LeftRail.tsx
@@ -1,5 +1,5 @@
 import { memo } from 'react';
-import { LayoutGrid, List, Download, Info, Globe, MapPin } from 'lucide-react';
+import { LayoutGrid, List, Download, Info, Globe, MapPin, BookOpen } from 'lucide-react';
 import { useI18n } from '@/contexts/I18nContext';
 import type { PortalMode } from './types';
 
@@ -7,6 +7,7 @@ interface LeftRailProps {
   mode: PortalMode;
   onMode: (mode: PortalMode) => void;
   onAbout: () => void;
+  onMethodology: () => void;
 }
 
 interface RailButtonProps {
@@ -48,7 +49,7 @@ function RailButton({ active, title, onClick, children }: RailButtonProps) {
   );
 }
 
-export const LeftRail = memo(function LeftRail({ mode, onMode, onAbout }: LeftRailProps) {
+export const LeftRail = memo(function LeftRail({ mode, onMode, onAbout, onMethodology }: LeftRailProps) {
   const { t, lang, toggleLang } = useI18n();
 
   return (
@@ -83,6 +84,9 @@ export const LeftRail = memo(function LeftRail({ mode, onMode, onAbout }: LeftRa
         </RailButton>
         <RailButton active={mode === 'data'} title={t.navData} onClick={() => onMode('data')}>
           <Download className="h-[21px] w-[21px]" strokeWidth={1.9} />
+        </RailButton>
+        <RailButton active={false} title={t.navMethodology} onClick={onMethodology}>
+          <BookOpen className="h-[21px] w-[21px]" strokeWidth={1.9} />
         </RailButton>
         <RailButton active={false} title={t.navAbout} onClick={onAbout}>
           <Info className="h-[21px] w-[21px]" strokeWidth={1.9} />

--- a/frontend/src/components/portal/MethodologyPanel.tsx
+++ b/frontend/src/components/portal/MethodologyPanel.tsx
@@ -1,0 +1,148 @@
+import { X } from 'lucide-react';
+import { memo, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useI18n } from '@/contexts/I18nContext';
+import { methodologyContent } from '@/lib/methodology';
+import { TemporalScopeNote } from './TemporalScopeNote';
+
+interface MethodologyPanelProps {
+  open: boolean;
+  onClose: () => void;
+  since: string | null;
+}
+
+export const MethodologyPanel = memo(function MethodologyPanel({
+  open,
+  onClose,
+  since,
+}: MethodologyPanelProps) {
+  const { lang } = useI18n();
+  const navigate = useNavigate();
+  const content = methodologyContent(lang);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      onClick={onClose}
+      className="av-fade fixed inset-0 z-[2000] flex items-center justify-center p-6"
+      style={{ background: 'var(--color-overlay)' }}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        className="av-scroll w-full max-w-[720px] overflow-y-auto rounded-2xl"
+        style={{ background: 'var(--color-surface)', maxHeight: '88vh', boxShadow: '0 24px 70px rgba(12,14,18,.4)' }}
+      >
+        <div className="px-[34px] pb-7 pt-[30px]">
+          <div className="mb-[18px] flex items-start justify-between">
+            <div className="font-mono text-[10px] uppercase tracking-[.14em]" style={{ color: 'var(--blue-600)' }}>
+              {content.eyebrow}
+            </div>
+            <button
+              onClick={onClose}
+              className="flex h-[30px] w-[30px] items-center justify-center rounded-lg border-none"
+              style={{ background: 'var(--stone-100)', color: 'var(--stone-600)' }}
+            >
+              <X className="h-4 w-4" />
+            </button>
+          </div>
+
+          <h2
+            className="mb-3.5"
+            style={{
+              fontFamily: 'var(--font-serif)',
+              fontSize: 30,
+              fontWeight: 600,
+              letterSpacing: '-.015em',
+              lineHeight: 1.12,
+              color: 'var(--stone-900)',
+            }}
+          >
+            {content.title}
+          </h2>
+
+          <div className="mb-4">
+            <TemporalScopeNote since={since} />
+          </div>
+
+          <p className="mb-5 text-pretty" style={{ fontSize: 15, lineHeight: 1.65, color: 'var(--stone-700)' }}>
+            {content.intro}
+          </p>
+
+          <div
+            className="mb-6 rounded-[11px] px-4 py-3.5"
+            style={{ background: 'var(--stone-50)', border: '1px solid var(--stone-200)' }}
+          >
+            <div className="mb-2 font-mono text-[9.5px] uppercase tracking-[.1em]" style={{ color: 'var(--stone-500)' }}>
+              Pipeline
+            </div>
+            <div className="flex flex-wrap items-center gap-1.5" style={{ fontSize: 12, color: 'var(--stone-700)' }}>
+              {content.pipelineSteps.map((step, i) => (
+                <span key={step} className="inline-flex items-center gap-1.5">
+                  {i > 0 && <span style={{ color: 'var(--stone-400)' }}>→</span>}
+                  <span>{step}</span>
+                </span>
+              ))}
+            </div>
+          </div>
+
+          {content.sections.map((section) => (
+            <section key={section.id} className="mb-6">
+              <h3
+                className="mb-2"
+                style={{
+                  fontFamily: 'var(--font-serif)',
+                  fontSize: 18,
+                  fontWeight: 600,
+                  color: 'var(--stone-900)',
+                }}
+              >
+                {section.title}
+              </h3>
+              {section.paragraphs.map((p, i) => (
+                <p
+                  key={i}
+                  className="mb-2.5 text-pretty"
+                  style={{ fontSize: 14, lineHeight: 1.6, color: 'var(--stone-700)' }}
+                >
+                  {p}
+                </p>
+              ))}
+              {section.bullets && (
+                <ul className="mb-2 ml-4 list-disc space-y-1" style={{ fontSize: 13.5, color: 'var(--stone-700)' }}>
+                  {section.bullets.map((b) => (
+                    <li key={b}>{b}</li>
+                  ))}
+                </ul>
+              )}
+            </section>
+          ))}
+
+          <div className="mt-1.5 rounded-[11px] px-4 py-3.5" style={{ background: 'var(--gold-50)', border: '1px solid var(--gold-500)' }}>
+            <p style={{ fontSize: 13, lineHeight: 1.55, color: 'var(--stone-700)' }}>{content.disclaimer}</p>
+          </div>
+
+          <button
+            onClick={() => {
+              onClose();
+              navigate('/dados');
+            }}
+            className="mt-4 w-full rounded-[10px] border-none px-4 py-2.5"
+            style={{ background: 'var(--blue-500)', color: '#fff', fontSize: 14, fontWeight: 500 }}
+          >
+            {lang === 'pt' ? 'Ver dicionário de dados' : 'View data dictionary'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+});

--- a/frontend/src/components/portal/RightPanel.tsx
+++ b/frontend/src/components/portal/RightPanel.tsx
@@ -15,6 +15,7 @@ import {
   ufName,
   dictionaryRows,
 } from '@/lib/i18n';
+import { TemporalScopeNote } from './TemporalScopeNote';
 import {
   computeStats,
   buildTrendMonths,
@@ -26,6 +27,7 @@ type FilterGroup = 'types' | 'methods' | 'periods';
 
 interface RightPanelProps {
   mode: PortalMode;
+  sinceDate: string | null;
   pointsInView: MapPoint[];
   filteredCount: number;
   filters: PortalFilters;
@@ -118,6 +120,9 @@ function PanelContent(props: RightPanelProps) {
               {t.reset}
             </button>
           )}
+        </div>
+        <div className="mt-2">
+          <TemporalScopeNote since={props.sinceDate} />
         </div>
       </div>
 

--- a/frontend/src/components/portal/SearchCard.tsx
+++ b/frontend/src/components/portal/SearchCard.tsx
@@ -4,6 +4,7 @@ import { useI18n } from '@/contexts/I18nContext';
 import { geocode, type MapPoint } from '@/lib/api';
 import { ufName } from '@/lib/i18n';
 import { fmtNumber } from '@/lib/i18n';
+import { TemporalScopeNote } from '@/components/portal/TemporalScopeNote';
 
 export interface LocatedPlace {
   lat: number;
@@ -14,6 +15,7 @@ export interface LocatedPlace {
 
 interface SearchCardProps {
   points: MapPoint[];
+  since: string | null;
   onLocate: (place: LocatedPlace) => void;
 }
 
@@ -78,7 +80,7 @@ function isBrazilQuery(text: string): boolean {
   return /^(brasil|brazil)$/i.test(text.trim());
 }
 
-export const SearchCard = memo(function SearchCard({ points, onLocate }: SearchCardProps) {
+export const SearchCard = memo(function SearchCard({ points, since, onLocate }: SearchCardProps) {
   const { t, lang } = useI18n();
   const [query, setQuery] = useState('');
   const [geocoding, setGeocoding] = useState(false);
@@ -179,6 +181,9 @@ export const SearchCard = memo(function SearchCard({ points, onLocate }: SearchC
           </div>
           <div className="mt-px" style={{ fontSize: 11.5, color: 'var(--color-text-muted)' }}>
             {t.tagline}
+          </div>
+          <div className="mt-1">
+            <TemporalScopeNote since={since} variant="inline" />
           </div>
         </div>
 

--- a/frontend/src/components/portal/SearchCard.tsx
+++ b/frontend/src/components/portal/SearchCard.tsx
@@ -68,15 +68,21 @@ function buildPlaces(points: MapPoint[]): Place[] {
 }
 
 const ZOOM_FOR: Record<Place['kind'], number> = { uf: 6.5, city: 11, hood: 13.2 };
+const BRAZIL_LOCATE: LocatedPlace = { lat: -14, lng: -52, label: 'Brasil', zoom: 3.6 };
 
 function looksLikeCep(text: string): boolean {
   return /^\d{8}$/.test(text.replace(/\D/g, ''));
+}
+
+function isBrazilQuery(text: string): boolean {
+  return /^(brasil|brazil)$/i.test(text.trim());
 }
 
 export const SearchCard = memo(function SearchCard({ points, onLocate }: SearchCardProps) {
   const { t, lang } = useI18n();
   const [query, setQuery] = useState('');
   const [geocoding, setGeocoding] = useState(false);
+  const [geocodeError, setGeocodeError] = useState(false);
 
   const places = useMemo(() => buildPlaces(points), [points]);
 
@@ -105,20 +111,46 @@ export const SearchCard = memo(function SearchCard({ points, onLocate }: SearchC
     onLocate({ lat: p.lat, lng: p.lng, label: p.label, zoom: ZOOM_FOR[p.kind] });
   }
 
+  function locateBrazil() {
+    setQuery('');
+    setGeocodeError(false);
+    onLocate(BRAZIL_LOCATE);
+  }
+
   async function geocodeQuery() {
     const raw = query.trim();
     if (!raw) return;
+    if (isBrazilQuery(raw)) {
+      locateBrazil();
+      return;
+    }
     setGeocoding(true);
+    setGeocodeError(false);
     try {
       const isCep = looksLikeCep(raw);
       const r = await geocode(isCep ? { cep: raw.replace(/\D/g, '') } : { q: raw });
       setQuery('');
-      onLocate({ lat: r.latitude, lng: r.longitude, label: r.label, zoom: 13 });
+      onLocate({ lat: r.latitude, lng: r.longitude, label: r.label, zoom: r.zoom ?? 13 });
     } catch {
-      /* keep query; user can retry */
+      setGeocodeError(true);
     } finally {
       setGeocoding(false);
     }
+  }
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const raw = query.trim();
+    if (isBrazilQuery(raw)) {
+      locateBrazil();
+      return;
+    }
+    if (looksLikeCep(raw)) {
+      geocodeQuery();
+      return;
+    }
+    if (results.length > 0) selectPlace(results[0]);
+    else geocodeQuery();
   }
 
   return (
@@ -151,13 +183,7 @@ export const SearchCard = memo(function SearchCard({ points, onLocate }: SearchC
         </div>
 
         <div className="relative px-[13px] py-[11px]">
-          <form
-            onSubmit={(e) => {
-              e.preventDefault();
-              if (results.length > 0) selectPlace(results[0]);
-              else geocodeQuery();
-            }}
-          >
+          <form onSubmit={handleSubmit}>
             <div
               className="flex items-center gap-[9px] rounded-[10px] px-3 py-[9px]"
               style={{ background: 'var(--stone-100)', border: '1px solid var(--stone-200)' }}
@@ -169,7 +195,10 @@ export const SearchCard = memo(function SearchCard({ points, onLocate }: SearchC
               )}
               <input
                 value={query}
-                onChange={(e) => setQuery(e.target.value)}
+                onChange={(e) => {
+                  setQuery(e.target.value);
+                  setGeocodeError(false);
+                }}
                 placeholder={t.searchPlaceholder}
                 className="min-w-0 flex-1 border-none bg-transparent outline-none"
                 style={{ fontFamily: 'var(--font-sans)', fontSize: 14, color: 'var(--stone-900)' }}
@@ -186,6 +215,12 @@ export const SearchCard = memo(function SearchCard({ points, onLocate }: SearchC
               )}
             </div>
           </form>
+
+          {geocodeError && (
+            <p className="mt-2 px-1" style={{ fontSize: 12, color: 'var(--red-700)' }}>
+              {t.geocodeFailed}
+            </p>
+          )}
 
           {showResults && (
             <div

--- a/frontend/src/components/portal/TemporalScopeNote.tsx
+++ b/frontend/src/components/portal/TemporalScopeNote.tsx
@@ -1,0 +1,41 @@
+import { memo } from 'react';
+import { useI18n } from '@/contexts/I18nContext';
+import { fmtDateLong } from '@/lib/i18n';
+
+interface TemporalScopeNoteProps {
+  since: string | null;
+  variant?: 'subtle' | 'inline';
+}
+
+export const TemporalScopeNote = memo(function TemporalScopeNote({
+  since,
+  variant = 'subtle',
+}: TemporalScopeNoteProps) {
+  const { t, lang } = useI18n();
+
+  if (!since) return null;
+
+  const date = fmtDateLong(since, lang);
+  const text = t.temporalScope.replace('{date}', date);
+
+  if (variant === 'inline') {
+    return (
+      <span style={{ fontSize: 11.5, color: 'var(--color-text-muted)' }}>
+        {text}
+      </span>
+    );
+  }
+
+  return (
+    <p
+      className="m-0"
+      style={{
+        fontSize: 11.5,
+        lineHeight: 1.45,
+        color: 'var(--color-text-subtle)',
+      }}
+    >
+      {text}
+    </p>
+  );
+});

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -194,6 +194,7 @@ export interface GeocodeResult {
   label: string;
   source: string;
   query: string;
+  zoom?: number;
 }
 
 export interface NearbyEvent {

--- a/frontend/src/lib/i18n.ts
+++ b/frontend/src/lib/i18n.ts
@@ -18,6 +18,9 @@ export interface Strings {
   navFeed: string;
   navData: string;
   navAbout: string;
+  navMethodology: string;
+  temporalScope: string;
+  aboutMethodologyLink: string;
   langSwitch: string;
   events: string;
   victims: string;
@@ -79,6 +82,9 @@ const PT: Strings = {
   navFeed: 'Linha do tempo',
   navData: 'Dados',
   navAbout: 'Sobre',
+  navMethodology: 'Metodologia',
+  temporalScope: 'No recorte atual desde {date}',
+  aboutMethodologyLink: 'Leia a metodologia completa',
   langSwitch: 'English',
   events: 'eventos registrados',
   victims: 'vítimas fatais',
@@ -132,7 +138,7 @@ const PT: Strings = {
     'Nosso objetivo é tornar visíveis a escala e a distribuição da violência — por bairro, cidade, CEP e período. Oferecemos os dados abertos para jornalistas, pesquisadores e a sociedade, para qualificar o debate e a tomada de decisão sobre segurança pública no país.',
   disclaimerLabel: 'Aviso',
   disclaimer:
-    'Nossos dados sobre mortes violentas são obtidos a partir de reportagens jornalísticas e as informações são extraídas automaticamente do texto das notícias. Trabalhamos para que essas informações sejam as mais precisas possível. Embora adotemos procedimentos para garantir sua qualidade, alguns casos podem não ser reportados pela imprensa, não constando em nossas bases, e as informações refletem possíveis imprecisões presentes nas notícias. Por isso, o Arquivo da Violência deve ser utilizado como uma fonte de referência e não substitui os registros oficiais.',
+    'Nossos dados sobre mortes violentas são obtidos a partir de reportagens jornalísticas. Use-os como referência, não como registro oficial. Consulte a metodologia completa para detalhes sobre coleta, processamento e limitações.',
 };
 
 const EN: Strings = {
@@ -144,6 +150,9 @@ const EN: Strings = {
   navFeed: 'Timeline',
   navData: 'Data',
   navAbout: 'About',
+  navMethodology: 'Methodology',
+  temporalScope: 'In the current view since {date}',
+  aboutMethodologyLink: 'Read the full methodology',
   langSwitch: 'Português',
   events: 'recorded events',
   victims: 'fatal victims',
@@ -197,7 +206,7 @@ const EN: Strings = {
     'Our goal is to make the scale and distribution of violence visible — by neighborhood, city, postal code and period — and to offer open data to journalists, researchers and society, to inform debate and public-security decision-making.',
   disclaimerLabel: 'Notice',
   disclaimer:
-    'Our data on violent deaths comes from news reports and information is automatically extracted from article text. We work to keep this information as accurate as possible. Although we follow procedures to ensure quality, some cases may not be reported by the press and therefore do not appear in our database, and the information may reflect inaccuracies present in the news. For this reason, Arquivo da Violência should be used as a reference source and does not replace official records.',
+    'Our data on violent deaths comes from news reports. Use it as a reference, not as an official record. See the full methodology for details on collection, processing, and limitations.',
 };
 
 export function strings(lang: Lang): Strings {

--- a/frontend/src/lib/i18n.ts
+++ b/frontend/src/lib/i18n.ts
@@ -13,6 +13,7 @@ export interface Strings {
   tagline: string;
   searchPlaceholder: string;
   noResults: string;
+  geocodeFailed: string;
   navMap: string;
   navFeed: string;
   navData: string;
@@ -70,9 +71,10 @@ export interface Strings {
 }
 
 const PT: Strings = {
-  tagline: 'Arquivo público de mortes violentas no Brasil',
-  searchPlaceholder: 'Buscar cidade, bairro ou estado',
+  tagline: 'Arquivo público de mortes violentas reportadas no Brasil',
+  searchPlaceholder: 'Buscar cidade, bairro, estado ou CEP',
   noResults: 'Nenhum local encontrado',
+  geocodeFailed: 'Não foi possível localizar esse endereço',
   navMap: 'Mapa',
   navFeed: 'Linha do tempo',
   navData: 'Dados',
@@ -123,20 +125,21 @@ const PT: Strings = {
   loadingEvent: 'Carregando evento',
   eventNotFound: 'Evento não encontrado.',
   aboutEyebrow: 'Sobre o projeto',
-  aboutTitle: 'Um registro do que os números escondem',
+  aboutTitle: 'Um registro do que os dados oficiais nem sempre reportam',
   aboutP1:
-    'O Arquivo da Violência reúne, em um só lugar, mortes violentas ocorridas no Brasil. Cada evento é extraído automaticamente de reportagens da imprensa, geolocalizado e estruturado em campos comparáveis.',
+    'O Arquivo da Violência reúne, em um só lugar e em tempo real, as mortes violentas noticiadas no Brasil. Cada evento é extraído automaticamente de reportagens da imprensa, geolocalizado e informações sobre a morte são estruturadas em campos comparáveis. Incluímos informações que nem sempre estão disponíveis em dados oficiais, como a geolocalização estimada e o método violento utilizado.',
   aboutP2:
-    'O objetivo é tornar visível a escala e a distribuição da violência — por bairro, cidade e período — e oferecer os dados abertos para jornalistas, pesquisadores e a sociedade.',
+    'Nosso objetivo é tornar visíveis a escala e a distribuição da violência — por bairro, cidade, CEP e período. Oferecemos os dados abertos para jornalistas, pesquisadores e a sociedade, para qualificar o debate e a tomada de decisão sobre segurança pública no país.',
   disclaimerLabel: 'Aviso',
   disclaimer:
-    'Os dados são extraídos automaticamente de reportagens jornalísticas e podem conter imprecisões. Use-os como referência, não como registro oficial.',
+    'Nossos dados sobre mortes violentas são obtidos a partir de reportagens jornalísticas e as informações são extraídas automaticamente do texto das notícias. Trabalhamos para que essas informações sejam as mais precisas possível. Embora adotemos procedimentos para garantir sua qualidade, alguns casos podem não ser reportados pela imprensa, não constando em nossas bases, e as informações refletem possíveis imprecisões presentes nas notícias. Por isso, o Arquivo da Violência deve ser utilizado como uma fonte de referência e não substitui os registros oficiais.',
 };
 
 const EN: Strings = {
-  tagline: 'A public archive of violent deaths in Brazil',
-  searchPlaceholder: 'Search city, neighborhood or state',
+  tagline: 'A public archive of violent deaths reported in Brazil',
+  searchPlaceholder: 'Search city, neighborhood, state or ZIP',
   noResults: 'No place found',
+  geocodeFailed: 'Could not locate that address',
   navMap: 'Map',
   navFeed: 'Timeline',
   navData: 'Data',
@@ -187,14 +190,14 @@ const EN: Strings = {
   loadingEvent: 'Loading event',
   eventNotFound: 'Event not found.',
   aboutEyebrow: 'About the project',
-  aboutTitle: 'A record of what the numbers hide',
+  aboutTitle: 'A record of what official data does not always report',
   aboutP1:
-    'Arquivo da Violência gathers, in one place, violent deaths that occurred in Brazil. Each event is automatically extracted from news reporting, geolocated and structured into comparable fields.',
+    'Arquivo da Violência gathers, in one place and in near real time, violent deaths reported in the news across Brazil. Each event is automatically extracted from press reports, geolocated and structured into comparable fields. We include information not always available in official data, such as estimated geolocation and the violent method used.',
   aboutP2:
-    'The goal is to make the scale and distribution of violence visible — by neighborhood, city and period — and to offer the data openly to journalists, researchers and society.',
+    'Our goal is to make the scale and distribution of violence visible — by neighborhood, city, postal code and period — and to offer open data to journalists, researchers and society, to inform debate and public-security decision-making.',
   disclaimerLabel: 'Notice',
   disclaimer:
-    'Data is automatically extracted from news reporting and may contain inaccuracies. Use it as a reference, not as an official record.',
+    'Our data on violent deaths comes from news reports and information is automatically extracted from article text. We work to keep this information as accurate as possible. Although we follow procedures to ensure quality, some cases may not be reported by the press and therefore do not appear in our database, and the information may reflect inaccuracies present in the news. For this reason, Arquivo da Violência should be used as a reference source and does not replace official records.',
 };
 
 export function strings(lang: Lang): Strings {

--- a/frontend/src/lib/methodology.ts
+++ b/frontend/src/lib/methodology.ts
@@ -1,0 +1,337 @@
+import type { Lang } from '@/lib/i18n';
+
+export interface MethodologySection {
+  id: string;
+  title: string;
+  paragraphs: string[];
+  bullets?: string[];
+}
+
+export interface MethodologyContent {
+  title: string;
+  eyebrow: string;
+  intro: string;
+  pipelineSteps: string[];
+  sections: MethodologySection[];
+  disclaimer: string;
+}
+
+const PT: MethodologyContent = {
+  title: 'Metodologia',
+  eyebrow: 'Como os dados são produzidos',
+  intro:
+    'O Arquivo da Violência monitora mortes violentas no Brasil a partir de reportagens jornalísticas indexadas pelo Google News. O pipeline automatizado descobre manchetes, filtra as relevantes, baixa o texto das matérias, extrai campos estruturados com IA, deduplica coberturas do mesmo fato e geocodifica os eventos canônicos.',
+  pipelineSteps: [
+    'Ingestão (Google News RSS)',
+    'Classificação de manchetes',
+    'Download do texto',
+    'Extração estruturada (LLM)',
+    'Enriquecimento imediato',
+    'Deduplicação em batch',
+    'Enriquecimento multi-fonte',
+    'Geocodificação',
+  ],
+  sections: [
+    {
+      id: 'sources',
+      title: 'Fontes de dados',
+      paragraphs: [
+        'A fonte primária é o feed RSS do Google News, configurado para a edição brasileira (hl=pt-BR, gl=BR). Cada manchete é registrada com identificador único (google_news_id), URL resolvida, editora, data de publicação e query de busca que a descobriu.',
+        'Hoje o sistema ingere exclusivamente via Google News RSS. Outras fontes (redes sociais, boletins oficiais) não fazem parte do pipeline atual.',
+      ],
+    },
+    {
+      id: 'cities',
+      title: 'Cidades monitoradas',
+      paragraphs: [
+        'O monitoramento cobre 63 municípios: todas as 27 capitais estaduais mais cidades com população acima de 500 mil habitantes (IBGE 2022). A busca padrão por cidade usa a janela temporal when:1h (última hora).',
+      ],
+      bullets: [
+        'Execução paralela de até 10 cidades simultâneas',
+        'Rate limit conservador de ~12 requisições/minuto ao RSS',
+        'Quando uma cidade atinge 100 resultados, a próxima execução fragmenta a busca por veículo (site:g1.globo.com, site:uol.com.br, etc.)',
+      ],
+    },
+    {
+      id: 'publishers',
+      title: 'Veículos utilizados no sharding',
+      paragraphs: [
+        'Quando o limite de 100 resultados por query é atingido, a busca é dividida entre os principais veículos nacionais e regionais:',
+      ],
+      bullets: [
+        'G1, UOL, Folha de S.Paulo, Estadão, O Globo, R7, Terra, Metrópoles, CNN Brasil, Band, Jovem Pan, Correio Braziliense, Gazeta do Povo',
+        'Regionais: O Dia (RJ), Diário de Pernambuco, O Tempo (MG), A Crítica (AM), entre outros',
+      ],
+    },
+    {
+      id: 'classification',
+      title: 'Classificação de manchetes',
+      paragraphs: [
+        'Antes de baixar a matéria completa, um modelo de linguagem (gemini-2.5-flash-lite) analisa apenas a manchete para decidir se trata de morte violenta. Manchetes classificadas como irrelevantes são descartadas; as relevantes seguem para download.',
+      ],
+      bullets: [
+        'TRUE: homicídio, assassinato, tiroteio com mortos, corpo encontrado, operação policial com morte, feminicídio, latrocínio',
+        'FALSE: prisões, feridos sem morte, apreensões, políticas de segurança sem evento concreto',
+      ],
+    },
+    {
+      id: 'download',
+      title: 'Download de matérias',
+      paragraphs: [
+        'Matérias aprovadas na classificação são baixadas com httpx (User-Agent de browser) e o texto principal é extraído com trafilatura. Timeout de 20 segundos por URL. Falhas de download são registradas e podem ser reprocessadas.',
+      ],
+    },
+    {
+      id: 'extraction',
+      title: 'Extração estruturada',
+      paragraphs: [
+        'O texto da matéria é enviado ao modelo gemini-2.5-flash com schema estruturado (Instructor). Artigos longos são truncados em 32.000 caracteres. O prompt exige usar apenas informações explícitas no texto, com linguagem técnica/jurídica.',
+        'Datas relativas ("ontem", "na sexta") são resolvidas com base na data de publicação da notícia. Se a data não for verificável, o campo fica nulo e o título inclui "DATA NÃO INFORMADA".',
+      ],
+      bullets: [
+        'Local: bairro, rua, estabelecimento, cidade, estado, país',
+        'Tempo: data, precisão, hora, período do dia (madrugada, manhã, tarde, noite)',
+        'Pessoas: vítimas, autores, envolvimento de força de segurança',
+        'Dinâmica: tipo de homicídio, método de morte, descrição cronológica',
+      ],
+    },
+    {
+      id: 'taxonomy',
+      title: 'Taxonomia de eventos',
+      paragraphs: [
+        'Tipos de homicídio extraídos seguem terminologia jurídica brasileira. "Homicídio" é a categoria geral; subtipos como feminicídio, latrocínio e homicídio qualificado são classificações específicas quando a matéria as identifica. "Outro" abrange casos que não se encaixam nas categorias listadas ou quando o tipo não é especificado na notícia.',
+      ],
+      bullets: [
+        'Tipos: Homicídio, Homicídio Qualificado, Homicídio Culposo, Tentativa de Homicídio, Latrocínio, Feminicídio, Infanticídio, Outro',
+        'Métodos: Arma de fogo, Arma branca, Estrangulamento, Asfixia, Espancamento, Atropelamento, Envenenamento, Objeto contundente, Incêndio, Queda, Outro',
+      ],
+    },
+    {
+      id: 'dedup',
+      title: 'Deduplicação',
+      paragraphs: [
+        'O mesmo fato pode ser coberto por várias matérias. A deduplicação ocorre em duas fases:',
+      ],
+      bullets: [
+        'Fase 1 (imediata): após cada extração, busca candidatos por data ±1 dia + mesma cidade, nome de vítima (fuzzy) ou bairro + data. LLM decide match com confiança mínima de 0,7',
+        'Fase 2 (batch): eventos pendentes são agrupados por (data, cidade), pré-clusterizados por nome de vítima e consolidados por LLM. Cada cluster vira um UniqueEvent',
+        'Preferência por não mesclar em caso de dúvida — eventos duplicados são possíveis',
+      ],
+    },
+    {
+      id: 'enrichment',
+      title: 'Enriquecimento multi-fonte',
+      paragraphs: [
+        'Quando um UniqueEvent agrega várias matérias, um LLM sintetiza os campos finais (título, data, local, vítimas, descrição) combinando todas as fontes vinculadas. A regra é não inventar informação — apenas consolidar o que aparece nas matérias.',
+      ],
+    },
+    {
+      id: 'geocoding',
+      title: 'Geocodificação',
+      paragraphs: [
+        'Eventos com cidade informada são geocodificados via Google Maps Geocoding API (region=br, language=pt-BR). A precisão declarada reflete o nível de detalhe disponível na entrada, nunca mais fino do que os dados permitem.',
+      ],
+      bullets: [
+        'Precisões: exato, aproximado, centro do bairro, centro da cidade',
+        'Sem chave de API, a geocodificação é ignorada e coordenadas ficam nulas',
+        'Busca pública do site: CEPs resolvidos via ViaCEP; fallback Nominatim/OpenStreetMap',
+      ],
+    },
+    {
+      id: 'fields',
+      title: 'Registro canônico (UniqueEvent)',
+      paragraphs: [
+        'Cada evento deduplicado é um UniqueEvent com campos de classificação, tempo, localização (textual e geocodificada), contagem de vítimas, descrição cronológica, número de fontes vinculadas e flag confirmed (revisão manual, padrão false).',
+      ],
+    },
+    {
+      id: 'schedule',
+      title: 'Atualização',
+      paragraphs: [
+        'Quando ENABLE_CRON=true no worker, o pipeline completo roda automaticamente no minuto 5 de cada hora (:05). Timeout de 60 minutos por execução. Antes de cada run, o sistema recupera fontes presas e re-enfileira falhas transientes.',
+        'O mapa público carrega eventos dos últimos 365 dias. A data "desde" exibida na interface corresponde ao evento mais antigo com data registrada no arquivo.',
+      ],
+    },
+    {
+      id: 'limitations',
+      title: 'Limitações',
+      paragraphs: [
+        'O Arquivo da Violência deve ser utilizado como fonte de referência, não como substituto de registros oficiais (DATASUS, ISP/polícias estaduais).',
+      ],
+      bullets: [
+        'Cobertura limitada a 63 cidades pré-configuradas, não todo o território nacional',
+        'Só captura eventos reportados pela mídia indexada pelo Google News',
+        'Classificação inicial usa apenas a manchete — títulos ambíguos podem ser descartados ou aceitos incorretamente',
+        'Extração depende do conteúdo da matéria; informações ausentes no texto não são inferidas',
+        'Sites com paywall, anti-bot ou HTML atípico podem falhar no download',
+        'Geocodificação imprecisa quando só há cidade/bairro; endereços exatos são raros',
+        'Dados não passam por revisão humana por padrão (confirmed=false)',
+        'Limite de 100 resultados por query RSS pode causar perdas em cidades de alto volume',
+      ],
+    },
+  ],
+  disclaimer:
+    'Os dados são extraídos automaticamente de reportagens jornalísticas e podem conter imprecisões. Use-os como referência, não como registro oficial. Consulte a aba Dados para o dicionário completo de campos.',
+};
+
+const EN: MethodologyContent = {
+  title: 'Methodology',
+  eyebrow: 'How the data is produced',
+  intro:
+    'Arquivo da Violência monitors violent deaths in Brazil from news reports indexed by Google News. The automated pipeline discovers headlines, filters relevant ones, downloads article text, extracts structured fields with AI, deduplicates coverage of the same incident, and geocodes canonical events.',
+  pipelineSteps: [
+    'Ingestion (Google News RSS)',
+    'Headline classification',
+    'Text download',
+    'Structured extraction (LLM)',
+    'Immediate enrichment',
+    'Batch deduplication',
+    'Multi-source enrichment',
+    'Geocoding',
+  ],
+  sections: [
+  {
+    id: 'sources',
+    title: 'Data sources',
+    paragraphs: [
+      'The primary source is the Google News RSS feed, configured for the Brazilian edition (hl=pt-BR, gl=BR). Each headline is recorded with a unique identifier (google_news_id), resolved URL, publisher, publication date, and the search query that discovered it.',
+      'Today the system ingests exclusively via Google News RSS. Other sources (social media, official bulletins) are not part of the current pipeline.',
+    ],
+  },
+  {
+    id: 'cities',
+    title: 'Monitored cities',
+    paragraphs: [
+      'Monitoring covers 63 municipalities: all 27 state capitals plus cities with populations above 500,000 (2022 IBGE census). The default city search uses the when:1h time window (last hour).',
+    ],
+    bullets: [
+      'Parallel execution of up to 10 cities simultaneously',
+      'Conservative rate limit of ~12 requests/minute to the RSS feed',
+      'When a city hits 100 results, the next run splits the search by publisher (site:g1.globo.com, site:uol.com.br, etc.)',
+    ],
+  },
+  {
+    id: 'publishers',
+    title: 'Publishers used in sharding',
+    paragraphs: [
+      'When the 100-result limit per query is reached, the search is split across major national and regional outlets:',
+    ],
+    bullets: [
+      'G1, UOL, Folha de S.Paulo, Estadão, O Globo, R7, Terra, Metrópoles, CNN Brasil, Band, Jovem Pan, Correio Braziliense, Gazeta do Povo',
+      'Regional: O Dia (RJ), Diário de Pernambuco, O Tempo (MG), A Crítica (AM), among others',
+    ],
+  },
+  {
+    id: 'classification',
+    title: 'Headline classification',
+    paragraphs: [
+      'Before downloading the full article, a language model (gemini-2.5-flash-lite) analyzes only the headline to decide if it concerns a violent death. Irrelevant headlines are discarded; relevant ones proceed to download.',
+    ],
+    bullets: [
+      'TRUE: homicide, murder, shootout with deaths, body found, police operation with death, femicide, robbery-homicide',
+      'FALSE: arrests, injuries without death, seizures, security policy without a concrete event',
+    ],
+  },
+  {
+    id: 'download',
+    title: 'Article download',
+    paragraphs: [
+      'Articles approved in classification are downloaded with httpx (browser User-Agent) and main text is extracted with trafilatura. 20-second timeout per URL. Download failures are recorded and may be retried.',
+    ],
+  },
+  {
+    id: 'extraction',
+    title: 'Structured extraction',
+    paragraphs: [
+      'Article text is sent to gemini-2.5-flash with a structured schema (Instructor). Long articles are truncated at 32,000 characters. The prompt requires using only explicit information from the text, with technical/legal language.',
+      'Relative dates ("yesterday", "on Friday") are resolved using the news publication date. If the date cannot be verified, the field is null and the title includes "DATE NOT REPORTED".',
+    ],
+    bullets: [
+      'Location: neighborhood, street, establishment, city, state, country',
+      'Time: date, precision, time, period of day (dawn, morning, afternoon, night)',
+      'People: victims, perpetrators, security-force involvement',
+      'Dynamics: homicide type, method of death, chronological description',
+    ],
+  },
+  {
+    id: 'taxonomy',
+    title: 'Event taxonomy',
+    paragraphs: [
+      'Extracted homicide types follow Brazilian legal terminology. "Homicídio" (Homicide) is the general category; subtypes like femicide, robbery-homicide, and aggravated homicide are specific classifications when the article identifies them. "Outro" (Other) covers cases that do not fit listed categories or when the type is not specified in the news.',
+    ],
+    bullets: [
+      'Types: Homicide, Aggravated homicide, Negligent homicide, Attempted homicide, Robbery-homicide, Femicide, Infanticide, Other',
+      'Methods: Firearm, Bladed weapon, Strangulation, Asphyxiation, Beating, Vehicle, Poisoning, Blunt object, Fire, Fall, Other',
+    ],
+  },
+  {
+    id: 'dedup',
+    title: 'Deduplication',
+    paragraphs: [
+      'The same incident may be covered by multiple articles. Deduplication occurs in two phases:',
+    ],
+    bullets: [
+      'Phase 1 (immediate): after each extraction, candidate matches are found by date ±1 day + same city, victim name (fuzzy), or neighborhood + date. LLM decides match with minimum confidence of 0.7',
+      'Phase 2 (batch): pending events are grouped by (date, city), pre-clustered by victim name, and consolidated by LLM. Each cluster becomes a UniqueEvent',
+      'Preference for not merging when uncertain — duplicate events are possible',
+    ],
+  },
+  {
+    id: 'enrichment',
+    title: 'Multi-source enrichment',
+    paragraphs: [
+      'When a UniqueEvent aggregates multiple articles, an LLM synthesizes final fields (title, date, location, victims, description) combining all linked sources. The rule is not to invent information — only consolidate what appears in the articles.',
+    ],
+  },
+  {
+    id: 'geocoding',
+    title: 'Geocoding',
+    paragraphs: [
+      'Events with a city are geocoded via Google Maps Geocoding API (region=br, language=pt-BR). Declared precision reflects the detail level available in the input, never finer than the data allows.',
+    ],
+    bullets: [
+      'Precision levels: exact, approximate, neighborhood center, city center',
+      'Without an API key, geocoding is skipped and coordinates remain null',
+      'Public site search: ZIP codes resolved via ViaCEP; Nominatim/OpenStreetMap fallback',
+    ],
+  },
+  {
+    id: 'fields',
+    title: 'Canonical record (UniqueEvent)',
+    paragraphs: [
+      'Each deduplicated event is a UniqueEvent with classification, time, location (textual and geocoded), victim count, chronological description, linked source count, and confirmed flag (manual review, default false).',
+    ],
+  },
+  {
+    id: 'schedule',
+    title: 'Update schedule',
+    paragraphs: [
+      'When ENABLE_CRON=true on the worker, the full pipeline runs automatically at minute 5 of every hour (:05). 60-minute timeout per run. Before each run, the system recovers stuck sources and re-queues transient failures.',
+      'The public map loads events from the last 365 days. The "since" date shown in the interface corresponds to the oldest dated event in the archive.',
+    ],
+  },
+  {
+    id: 'limitations',
+    title: 'Limitations',
+    paragraphs: [
+      'Arquivo da Violência should be used as a reference source, not as a substitute for official records (DATASUS, state police/ISP).',
+    ],
+    bullets: [
+      'Coverage limited to 63 pre-configured cities, not the entire national territory',
+      'Only captures events reported by media indexed by Google News',
+      'Initial classification uses only the headline — ambiguous titles may be discarded or accepted incorrectly',
+      'Extraction depends on article content; information absent from the text is not inferred',
+      'Sites with paywalls, anti-bot, or atypical HTML may fail to download',
+      'Imprecise geocoding when only city/neighborhood is available; exact addresses are rare',
+      'Data does not pass human review by default (confirmed=false)',
+      '100-result RSS limit may cause losses in high-volume cities',
+    ],
+  },
+  ],
+  disclaimer:
+    'Data is automatically extracted from news reporting and may contain inaccuracies. Use it as a reference, not as an official record. See the Data tab for the full field dictionary.',
+};
+
+export function methodologyContent(lang: Lang): MethodologyContent {
+  return lang === 'pt' ? PT : EN;
+}

--- a/frontend/src/pages/public/MapExplorer.tsx
+++ b/frontend/src/pages/public/MapExplorer.tsx
@@ -73,10 +73,10 @@ export function MapExplorer({ initialMode = 'stats', initialAbout = false }: Map
   const availablePeriods = useMemo(() => distinctValues(allPoints, 'p'), [allPoints]);
 
   const filteredPoints = useMemo(() => applyFilters(allPoints, filters), [allPoints, filters]);
-  const pointsInView = useMemo(
-    () => pointsInBounds(filteredPoints, panelBounds),
-    [filteredPoints, panelBounds]
-  );
+  const pointsInView = useMemo(() => {
+    if (!panelBounds) return filteredPoints;
+    return pointsInBounds(filteredPoints, panelBounds);
+  }, [filteredPoints, panelBounds]);
 
   const canReset = panelZoom > 4.2 || Math.abs(panelLng - BRAZIL_VIEW.longitude) > 6;
   const filtersActive = hasActiveFilters(filters);

--- a/frontend/src/pages/public/MapExplorer.tsx
+++ b/frontend/src/pages/public/MapExplorer.tsx
@@ -188,7 +188,6 @@ export function MapExplorer({ initialMode = 'stats', initialAbout = false }: Map
         <CrimeMap
           points={filteredPoints}
           viewState={viewState}
-          onViewStateChange={setViewState}
           onViewportSettled={handleViewportSettled}
           onPointClick={onSelect}
           onCellClick={onCellClick}

--- a/frontend/src/pages/public/MapExplorer.tsx
+++ b/frontend/src/pages/public/MapExplorer.tsx
@@ -1,15 +1,16 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams, useLocation } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { FlyToInterpolator } from '@deck.gl/core';
 import { Loader2 } from 'lucide-react';
-import { fetchMapPoints } from '@/lib/api';
+import { fetchMapPoints, fetchPublicStats } from '@/lib/api';
 import { useI18n } from '@/contexts/I18nContext';
 import { CrimeMap, type MapViewState, type MapBounds, type ViewportSnapshot } from '@/components/map/CrimeMap';
 import { LeftRail } from '@/components/portal/LeftRail';
 import { SearchCard, type LocatedPlace } from '@/components/portal/SearchCard';
 import { RightPanel } from '@/components/portal/RightPanel';
 import { AboutModal } from '@/components/portal/AboutModal';
+import { MethodologyPanel } from '@/components/portal/MethodologyPanel';
 import { DensityLegend } from '@/components/portal/DensityLegend';
 import {
   EMPTY_FILTERS,
@@ -43,10 +44,16 @@ const PATH_FOR: Record<PortalMode, string> = {
 interface MapExplorerProps {
   initialMode?: PortalMode;
   initialAbout?: boolean;
+  initialMethodology?: boolean;
 }
 
-export function MapExplorer({ initialMode = 'stats', initialAbout = false }: MapExplorerProps) {
+export function MapExplorer({
+  initialMode = 'stats',
+  initialAbout = false,
+  initialMethodology = false,
+}: MapExplorerProps) {
   const navigate = useNavigate();
+  const location = useLocation();
   const { id } = useParams();
   const { t } = useI18n();
 
@@ -60,11 +67,20 @@ export function MapExplorer({ initialMode = 'stats', initialAbout = false }: Map
   const [filters, setFilters] = useState<PortalFilters>(EMPTY_FILTERS);
   const [searchedLocation, setSearchedLocation] = useState<{ lat: number; lng: number } | null>(null);
   const [aboutOpen, setAboutOpen] = useState(initialAbout);
+  const [methodologyOpen, setMethodologyOpen] = useState(initialMethodology);
 
   const { data, isLoading } = useQuery({
     queryKey: ['map-points', MAP_DAYS],
     queryFn: () => fetchMapPoints({ days: MAP_DAYS }),
   });
+
+  const { data: publicStats } = useQuery({
+    queryKey: ['public-stats'],
+    queryFn: fetchPublicStats,
+    staleTime: 60_000,
+  });
+
+  const sinceDate = publicStats?.since ?? null;
 
   const allPoints = useMemo(() => data?.points ?? [], [data]);
 
@@ -170,19 +186,40 @@ export function MapExplorer({ initialMode = 'stats', initialAbout = false }: Map
     });
   }, []);
 
-  const openAbout = useCallback(() => setAboutOpen(true), []);
-  const closeAbout = useCallback(() => setAboutOpen(false), []);
+  const openAbout = useCallback(() => {
+    setAboutOpen(true);
+    if (location.pathname === '/metodologia') navigate('/');
+  }, [location.pathname, navigate]);
+
+  const closeAbout = useCallback(() => {
+    setAboutOpen(false);
+    if (location.pathname === '/sobre') navigate('/');
+  }, [location.pathname, navigate]);
+
+  const openMethodology = useCallback(() => {
+    setMethodologyOpen(true);
+    if (location.pathname === '/sobre') setAboutOpen(false);
+  }, [location.pathname]);
+
+  const closeMethodology = useCallback(() => {
+    setMethodologyOpen(false);
+    if (location.pathname === '/metodologia') navigate('/');
+  }, [location.pathname, navigate]);
 
   useEffect(() => {
     setAboutOpen(initialAbout);
   }, [initialAbout]);
+
+  useEffect(() => {
+    setMethodologyOpen(initialMethodology);
+  }, [initialMethodology]);
 
   return (
     <div
       className="fixed inset-0 flex overflow-hidden"
       style={{ background: 'var(--stone-100)', color: 'var(--color-text)' }}
     >
-      <LeftRail mode={mode} onMode={onMode} onAbout={openAbout} />
+      <LeftRail mode={mode} onMode={onMode} onAbout={openAbout} onMethodology={openMethodology} />
 
       <div className="relative min-w-0 flex-1">
         <CrimeMap
@@ -207,12 +244,13 @@ export function MapExplorer({ initialMode = 'stats', initialAbout = false }: Map
           </div>
         )}
 
-        <SearchCard points={allPoints} onLocate={onLocate} />
+        <SearchCard points={allPoints} since={sinceDate} onLocate={onLocate} />
         <DensityLegend />
       </div>
 
       <RightPanel
         mode={mode}
+        sinceDate={sinceDate}
         pointsInView={pointsInView}
         filteredCount={filteredPoints.length}
         filters={filters}
@@ -229,7 +267,13 @@ export function MapExplorer({ initialMode = 'stats', initialAbout = false }: Map
         onResetView={onResetView}
       />
 
-      <AboutModal open={aboutOpen} onClose={closeAbout} />
+      <AboutModal
+        open={aboutOpen}
+        onClose={closeAbout}
+        since={sinceDate}
+        onOpenMethodology={openMethodology}
+      />
+      <MethodologyPanel open={methodologyOpen} onClose={closeMethodology} since={sinceDate} />
     </div>
   );
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -24,6 +24,7 @@ export default defineConfig({
         '/eventos',
         '/dados',
         '/sobre',
+        '/metodologia',
       ],
     }),
   ],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Descrição

Implementa os itens de prioridade 2 e 3 do backlog Linear (AQV-6, AQV-7, AQV-8, AQV-9, AQV-10, AQV-18) no portal público `develop`, mais otimização de performance no zoom do mapa.

### Quick wins
- **AQV-6:** Subtítulo atualizado para "Arquivo público de mortes violentas reportadas no Brasil"
- **AQV-18:** Texto da caixa Sobre (modal) com nova redação e correção "extraídas"
- **AQV-10:** Contador de estatísticas não mostra mais 0 no carregamento; legenda com rótulo "0"

### Map/search
- **AQV-7:** Placeholder menciona CEP, busca direta por CEP, feedback de erro
- **AQV-8:** Basemap configurável via `VITE_MAP_STYLE` (default Carto Positron)
- **AQV-9:** Atalho `brasil`/`Brazil` → visão do país; API retorna `zoom` dinâmico

### Performance
- View state local no `CrimeMap` — evita re-render do painel a cada frame de zoom
- Culling de pontos no viewport + `gpuAggregation` no GridLayer
- Basemap Carto Positron como default (mais leve que OpenFreeMap)

## Issues relacionadas

Fixes AQV-6, AQV-7, AQV-8, AQV-9, AQV-10, AQV-18

## Como foi testado

- [x] Testes manuais
- [x] Testado com Docker (staging)

**Ambiente:** staging em https://staging.arquivodaviolencia.com.br

## Arquivos principais

- `frontend/src/lib/i18n.ts`
- `frontend/src/components/portal/SearchCard.tsx`
- `frontend/src/components/map/CrimeMap.tsx`
- `frontend/src/pages/public/MapExplorer.tsx`
- `backend/app/services/geocoding.py`
- `backend/app/routers/public.py`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4c77e22b-d622-4e75-afff-e8e222a3d202"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4c77e22b-d622-4e75-afff-e8e222a3d202"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

