### PR TITLE
fix(map): heatmap tooltip shows correct event count on GPU aggregation

### DIFF
--- a/frontend/src/components/map/CrimeMap.tsx
+++ b/frontend/src/components/map/CrimeMap.tsx
@@ -311,7 +311,8 @@ export function CrimeMap({
                 .join('\n'),
             };
           }
-          const count = (object as { points?: unknown[] }).points?.length ?? 0;
+          const cell = object as { count?: number; points?: unknown[] };
+          const count = cell.count ?? cell.points?.length ?? 0;
           return { text: `${count} ${count === 1 ? 'evento' : 'eventos'}` };
         }}
       >


### PR DESCRIPTION
## Descrição

Corrige o tooltip do heatmap no mapa que exibia "0 eventos" em células coloridas no desktop. O `GridLayer` do deck.gl com agregação GPU popula `object.count` mas não `object.points`; o tooltip lia apenas `points.length`.

Part of AQV-24

## Tipo de Mudança

- [x] Bug fix

## Como Foi Testado?

- [x] Testes manuais (análise de código + build)
- [x] Testado em desenvolvimento local (`npm run build` passou)

**Plano vs implementação:** Implementação segue o plano exatamente — uma linha em `CrimeMap.tsx` usando `object.count` com fallback para `points.length`.

## Checklist de aprovação

- [ ] Hover sobre células coloridas do heatmap (zoom < 12) no desktop mostra contagem > 0
- [ ] Contagem corresponde à intensidade visual da célula
- [ ] Tooltip de scatter (zoom ≥ 12) continua mostrando título/local do evento
- [ ] Mobile (agregação CPU) continua funcionando via fallback
- [ ] `npm run build` passa

## Notas

Sem desvios do plano. Lint tem erros pré-existentes não relacionados a esta mudança.