### PR TITLE
feat(portal): show clickable journalistic sources on incident detail

### DIFF
--- a/frontend/src/components/portal/RightPanel.tsx
+++ b/frontend/src/components/portal/RightPanel.tsx
@@ -1,6 +1,6 @@
 import { memo, useMemo, useState, useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { ChevronLeft, RotateCcw, SlidersHorizontal, MapPin, Clock, FileText, Download } from 'lucide-react';
+import { ChevronLeft, RotateCcw, SlidersHorizontal, MapPin, Clock, FileText, Download, ExternalLink } from 'lucide-react';
 import { useI18n } from '@/contexts/I18nContext';
 import { fetchPublicEventById, getExportUrl, type MapPoint } from '@/lib/api';
 import { cn } from '@/lib/utils';
@@ -719,6 +719,7 @@ function DetailView({ id, onClose }: { id: number; onClose: () => void }) {
   const cityLine = [event.city, ufName(event.state)].filter(Boolean).join(' · ');
   const srcCount = event.source_count ?? 0;
   const sourceWord = srcCount > 1 ? t.newsSources : t.newsSource;
+  const displayableSources = (event.sources ?? []).filter((source) => source.url);
 
   return (
     <div className="av-fade px-5 pb-7 pt-[18px]">
@@ -794,10 +795,51 @@ function DetailView({ id, onClose }: { id: number; onClose: () => void }) {
         </>
       )}
 
+      {displayableSources.length > 0 && (
+        <>
+          <div className="mb-[7px] font-mono text-[9.5px] uppercase tracking-[.1em]" style={{ color: 'var(--color-text-subtle)' }}>
+            {t.sourcesSection}
+          </div>
+          <ul className="mb-[18px] flex flex-col overflow-hidden rounded-[10px]" style={{ border: '1px solid var(--stone-200)' }}>
+            {displayableSources.map((source) => {
+              const title = source.headline || source.publisher_name || t.sourceFallback;
+              const showPublisher = Boolean(source.publisher_name && source.headline);
+              return (
+                <li key={source.id} style={{ borderBottom: '1px solid var(--stone-100)' }} className="last:border-b-0">
+                  <a
+                    href={source.url!}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="flex items-start gap-2.5 px-[13px] py-[11px] no-underline transition-colors hover:bg-[var(--stone-50)]"
+                  >
+                    <ExternalLink className="mt-0.5 h-4 w-4 flex-none" style={{ color: 'var(--blue-600)' }} />
+                    <div className="min-w-0 flex-1">
+                      <div style={{ fontSize: 13.5, fontWeight: 500, color: 'var(--blue-600)', lineHeight: 1.35 }}>
+                        {title}
+                      </div>
+                      {showPublisher && (
+                        <div style={{ fontSize: 12, color: 'var(--color-text-muted)' }}>{source.publisher_name}</div>
+                      )}
+                      {source.published_at && (
+                        <div style={{ fontSize: 11.5, color: 'var(--color-text-subtle)' }}>
+                          {fmtDateShort(source.published_at, lang)}
+                        </div>
+                      )}
+                    </div>
+                  </a>
+                </li>
+              );
+            })}
+          </ul>
+        </>
+      )}
+
+      {srcCount > 0 && (
       <div className="flex items-center gap-2 pt-3.5" style={{ borderTop: '1px solid var(--stone-100)', fontSize: 12, color: 'var(--color-text-muted)' }}>
         <FileText className="h-[15px] w-[15px]" />
         {`${t.reportedBy}${srcCount}${sourceWord} · #${event.id}`}
       </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/lib/i18n.ts
+++ b/frontend/src/lib/i18n.ts
@@ -68,6 +68,8 @@ export interface Strings {
   reportedBy: string;
   newsSource: string;
   newsSources: string;
+  sourcesSection: string;
+  sourceFallback: string;
   victim: string;
   victimsLower: string;
   loadingEvent: string;
@@ -140,6 +142,8 @@ const PT: Strings = {
   reportedBy: 'Reportado por ',
   newsSource: ' fonte jornalística',
   newsSources: ' fontes jornalísticas',
+  sourcesSection: 'Fontes jornalísticas',
+  sourceFallback: 'Matéria jornalística',
   victim: 'vítima',
   victimsLower: 'vítimas',
   loadingEvent: 'Carregando evento',
@@ -215,6 +219,8 @@ const EN: Strings = {
   reportedBy: 'Reported by ',
   newsSource: ' news source',
   newsSources: ' news sources',
+  sourcesSection: 'News sources',
+  sourceFallback: 'News article',
   victim: 'victim',
   victimsLower: 'victims',
   loadingEvent: 'Loading event',


### PR DESCRIPTION
## Descrição

Na página de detalhe do incidente, exibe a lista de fontes jornalísticas com links clicáveis para as matérias originais. A API de detalhe já retornava `sources[]`; a UI só mostrava a contagem.

Part of AQV-25

## Tipo de Mudança

- [x] Nova feature

## Como Foi Testado?

- [x] Testado em desenvolvimento local (`npm run build` passou)

**Plano vs implementação:** Segue o plano. Adicionada seção "Fontes jornalísticas" com links externos, título (headline → publisher → fallback), data de publicação quando disponível. Footer de contagem oculto quando `source_count` é 0.

## Checklist de aprovação

- [ ] Incidente com múltiplas fontes (ex. #7445) mostra lista clicável
- [ ] Cada fonte abre URL original em nova aba
- [ ] Fonte sem headline mostra publisher ou fallback
- [ ] Incidente sem fontes não exibe contagem enganosa
- [ ] Textos corretos em PT e EN
- [ ] `npm run build` passa