### PR TITLE
Release: develop -> master

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -167,8 +167,15 @@ frontend/node_modules/*
 
 *.db
 *.cursor/*
+.venv-notebook/
 
 scripts/*
 
 # Generated failure test-set fixture (contains sampled prod article content)
 backend/tests/fixtures/failure_test_set.json
+
+# Classification eval fixture built from prod DB (pending manual labels)
+backend/tests/fixtures/eval/classification.json
+
+# Eval run outputs (may include LLM reasoning)
+backend/eval/results/

--- a/backend/app/routers/public.py
+++ b/backend/app/routers/public.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
 from fastapi.responses import StreamingResponse
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy import select, func, text
+from sqlalchemy import select, func
 import math
 import csv
 import json  # For serializing merged_data
@@ -14,6 +14,7 @@ from app.database import get_session
 from app.models.unique_event import UniqueEvent
 from app.models.raw_event import RawEvent
 from app.models.source_google_news import SourceGoogleNews
+from app.services.public_filters import apply_public_incident_filter
 
 router = APIRouter(prefix="/public", tags=["public"])
 
@@ -223,7 +224,9 @@ async def get_public_stats(session: AsyncSession = Depends(get_session)):
     """Get public overview stats."""
     
     # Total events
-    total = await session.scalar(select(func.count(UniqueEvent.id)))
+    total = await session.scalar(
+        apply_public_incident_filter(select(func.count(UniqueEvent.id)))
+    )
     
     # Current datetime for rolling window calculations
     now = datetime.utcnow()
@@ -231,36 +234,38 @@ async def get_public_stats(session: AsyncSession = Depends(get_session)):
     # Last 7 days - events from 7 days ago to now (exclude future events)
     last_7_days_start = now - timedelta(days=7)
     last_7_days = await session.scalar(
-        select(func.count(UniqueEvent.id)).where(
-            UniqueEvent.event_date >= last_7_days_start
-        ).where(
-            UniqueEvent.event_date <= now
-        ).where(
-            UniqueEvent.event_date.isnot(None)
+        apply_public_incident_filter(
+            select(func.count(UniqueEvent.id)).where(
+                UniqueEvent.event_date >= last_7_days_start,
+                UniqueEvent.event_date <= now,
+                UniqueEvent.event_date.isnot(None),
+            )
         )
     )
     
     # Last 30 days - events from 30 days ago to now (exclude future events)
     last_30_days_start = now - timedelta(days=30)
     last_30_days = await session.scalar(
-        select(func.count(UniqueEvent.id)).where(
-            UniqueEvent.event_date >= last_30_days_start
-        ).where(
-            UniqueEvent.event_date <= now
-        ).where(
-            UniqueEvent.event_date.isnot(None)
+        apply_public_incident_filter(
+            select(func.count(UniqueEvent.id)).where(
+                UniqueEvent.event_date >= last_30_days_start,
+                UniqueEvent.event_date <= now,
+                UniqueEvent.event_date.isnot(None),
+            )
         )
     )
     
     # Earliest event in the public map window (geocoded, last 365 days).
     cutoff, now = _map_window(PUBLIC_MAP_DAYS)
     earliest = await session.scalar(
-        select(func.min(UniqueEvent.event_date)).where(
-            UniqueEvent.event_date >= cutoff,
-            UniqueEvent.event_date <= now,
-            UniqueEvent.event_date.isnot(None),
-            UniqueEvent.latitude.isnot(None),
-            UniqueEvent.longitude.isnot(None),
+        apply_public_incident_filter(
+            select(func.min(UniqueEvent.event_date)).where(
+                UniqueEvent.event_date >= cutoff,
+                UniqueEvent.event_date <= now,
+                UniqueEvent.event_date.isnot(None),
+                UniqueEvent.latitude.isnot(None),
+                UniqueEvent.longitude.isnot(None),
+            )
         )
     )
     
@@ -346,20 +351,21 @@ async def get_stats_by_day(
     """Get daily event counts."""
     
     cutoff = datetime.utcnow() - timedelta(days=days)
-    
-    # Use SQLite date function with event_date instead of created_at
-    query = text("""
-        SELECT 
-            date(event_date) as date,
-            COUNT(*) as count
-        FROM unique_event
-        WHERE event_date >= :cutoff AND event_date IS NOT NULL
-        GROUP BY date
-        ORDER BY date ASC
-    """)
-    
-    result = await session.execute(query, {"cutoff": cutoff})
-    rows = result.fetchall()
+
+    query = apply_public_incident_filter(
+        select(
+            func.date(UniqueEvent.event_date).label("date"),
+            func.count(UniqueEvent.id).label("count"),
+        ).where(
+            UniqueEvent.event_date >= cutoff,
+            UniqueEvent.event_date.isnot(None),
+        )
+    ).group_by(func.date(UniqueEvent.event_date)).order_by(
+        func.date(UniqueEvent.event_date).asc()
+    )
+
+    result = await session.execute(query)
+    rows = result.all()
     
     data = []
     for row in rows:
@@ -495,13 +501,15 @@ async def get_nearby_events(
     min_lat, max_lat = lat - lat_delta, lat + lat_delta
     min_lng, max_lng = lng - lng_delta, lng + lng_delta
 
-    query = select(UniqueEvent).where(
-        UniqueEvent.latitude.isnot(None),
-        UniqueEvent.longitude.isnot(None),
-        UniqueEvent.latitude >= min_lat,
-        UniqueEvent.latitude <= max_lat,
-        UniqueEvent.longitude >= min_lng,
-        UniqueEvent.longitude <= max_lng,
+    query = apply_public_incident_filter(
+        select(UniqueEvent).where(
+            UniqueEvent.latitude.isnot(None),
+            UniqueEvent.longitude.isnot(None),
+            UniqueEvent.latitude >= min_lat,
+            UniqueEvent.latitude <= max_lat,
+            UniqueEvent.longitude >= min_lng,
+            UniqueEvent.longitude <= max_lng,
+        )
     )
 
     now = datetime.utcnow()
@@ -635,24 +643,26 @@ async def get_map_points(
     Defaults to the last 365 days. No sort — order is undefined (cheaper for map tiles).
     """
     cutoff, now = _map_window(days)
-    query = select(
-        UniqueEvent.id,
-        UniqueEvent.latitude,
-        UniqueEvent.longitude,
-        UniqueEvent.homicide_type,
-        UniqueEvent.method_of_death,
-        UniqueEvent.event_date,
-        UniqueEvent.victim_count,
-        UniqueEvent.security_force_involved,
-        UniqueEvent.city,
-        UniqueEvent.neighborhood,
-        UniqueEvent.state,
-        UniqueEvent.time_of_day,
-    ).where(
-        UniqueEvent.latitude.isnot(None),
-        UniqueEvent.longitude.isnot(None),
-        UniqueEvent.event_date >= cutoff,
-        UniqueEvent.event_date <= now,
+    query = apply_public_incident_filter(
+        select(
+            UniqueEvent.id,
+            UniqueEvent.latitude,
+            UniqueEvent.longitude,
+            UniqueEvent.homicide_type,
+            UniqueEvent.method_of_death,
+            UniqueEvent.event_date,
+            UniqueEvent.victim_count,
+            UniqueEvent.security_force_involved,
+            UniqueEvent.city,
+            UniqueEvent.neighborhood,
+            UniqueEvent.state,
+            UniqueEvent.time_of_day,
+        ).where(
+            UniqueEvent.latitude.isnot(None),
+            UniqueEvent.longitude.isnot(None),
+            UniqueEvent.event_date >= cutoff,
+            UniqueEvent.event_date <= now,
+        )
     )
 
     if type:

--- a/backend/app/routers/unique_events.py
+++ b/backend/app/routers/unique_events.py
@@ -9,6 +9,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.database import get_session
 from app.models import UniqueEvent, UniqueEventRead
+from app.services.public_filters import apply_public_incident_filter
 
 router = APIRouter(prefix="/unique-events", tags=["unique-events"])
 
@@ -196,41 +197,51 @@ async def get_unique_events_stats(
 ):
     """Get summary statistics for unique events."""
     # Total count
-    total_query = select(func.count(UniqueEvent.id))
+    total_query = apply_public_incident_filter(select(func.count(UniqueEvent.id)))
     total_result = await session.exec(total_query)
     total = total_result.one()
     
     # Count by homicide type
-    type_query = select(
-        UniqueEvent.homicide_type,
-        func.count(UniqueEvent.id)
-    ).where(UniqueEvent.homicide_type.isnot(None)).group_by(UniqueEvent.homicide_type)
+    type_query = apply_public_incident_filter(
+        select(
+            UniqueEvent.homicide_type,
+            func.count(UniqueEvent.id),
+        ).where(UniqueEvent.homicide_type.isnot(None))
+    ).group_by(UniqueEvent.homicide_type)
     
     type_result = await session.exec(type_query)
     by_type = {row[0]: row[1] for row in type_result.all()}
     
     # Total victims
-    victims_query = select(func.sum(UniqueEvent.victim_count))
+    victims_query = apply_public_incident_filter(
+        select(func.sum(UniqueEvent.victim_count))
+    )
     victims_result = await session.exec(victims_query)
     total_victims = victims_result.one() or 0
     
     # Geocoded count
-    geo_query = select(func.count(UniqueEvent.id)).where(
-        UniqueEvent.latitude.isnot(None)
+    geo_query = apply_public_incident_filter(
+        select(func.count(UniqueEvent.id)).where(
+            UniqueEvent.latitude.isnot(None)
+        )
     )
     geo_result = await session.exec(geo_query)
     geocoded = geo_result.one()
     
     # Confirmed count
-    confirmed_query = select(func.count(UniqueEvent.id)).where(
-        UniqueEvent.confirmed == True  # noqa: E712
+    confirmed_query = apply_public_incident_filter(
+        select(func.count(UniqueEvent.id)).where(
+            UniqueEvent.confirmed == True  # noqa: E712
+        )
     )
     confirmed_result = await session.exec(confirmed_query)
     confirmed = confirmed_result.one()
     
     # Security force involvement
-    sf_query = select(func.count(UniqueEvent.id)).where(
-        UniqueEvent.security_force_involved == True  # noqa: E712
+    sf_query = apply_public_incident_filter(
+        select(func.count(UniqueEvent.id)).where(
+            UniqueEvent.security_force_involved == True  # noqa: E712
+        )
     )
     sf_result = await session.exec(sf_query)
     security_force_count = sf_result.one()
@@ -256,13 +267,15 @@ async def get_events_by_date(
     end_date = datetime.utcnow()
     start_date = end_date - timedelta(days=days)
     
-    query = select(
-        func.date(UniqueEvent.event_date),
-        func.sum(UniqueEvent.victim_count)
-    ).where(
-        UniqueEvent.event_date >= start_date,
-        UniqueEvent.event_date <= end_date,
-        UniqueEvent.victim_count.isnot(None)
+    query = apply_public_incident_filter(
+        select(
+            func.date(UniqueEvent.event_date),
+            func.sum(UniqueEvent.victim_count),
+        ).where(
+            UniqueEvent.event_date >= start_date,
+            UniqueEvent.event_date <= end_date,
+            UniqueEvent.victim_count.isnot(None),
+        )
     ).group_by(
         func.date(UniqueEvent.event_date)
     ).order_by(

--- a/backend/app/services/classification.py
+++ b/backend/app/services/classification.py
@@ -1,7 +1,7 @@
 """Classification service - classifies headlines to filter violent death news."""
 
 from datetime import datetime
-from typing import Literal
+from typing import Literal, Optional
 
 import instructor
 from loguru import logger
@@ -52,11 +52,38 @@ class ViolentDeathClassification(BaseModel):
         description="Brief explanation (1-2 sentences) of why this classification was made."
     )
 
+    is_single_incident: bool = Field(
+        ...,
+        description="""
+        TRUE if the headline describes ONE specific violent-death incident (or a single
+        clearly bounded event such as one shootout with N victims).
+
+        FALSE for aggregate statistics, year-end crime reports, multi-city roundups,
+        foreign disasters, suicides, animal cruelty, policy/analysis pieces, or any
+        headline that is not about a discrete incident.
+        """
+    )
+
+    content_class_hint: Optional[
+        Literal[
+            "incident",
+            "aggregate_statistics",
+            "foreign",
+            "non_incident",
+            "suicide",
+            "accident_disaster",
+        ]
+    ] = Field(
+        None,
+        description="Optional hint about why the headline is or is not a single incident.",
+    )
+
 
 # System prompt for classification
 CLASSIFICATION_SYSTEM_PROMPT = """
-Você é um classificador de manchetes de notícias. Sua única tarefa é determinar se uma manchete 
-indica notícia sobre uma ou mais MORTES VIOLENTAS (homicídios, assassinatos, execuções).
+Você é um classificador de manchetes de notícias. Sua tarefa é determinar:
+1. Se a manchete indica MORTE(S) VIOLENTA(S) (homicídios, assassinatos, execuções).
+2. Se descreve UM ÚNICO INCIDENTE específico (is_single_incident), ou conteúdo agregado/fora de escopo.
 
 CLASSIFIQUE COMO MORTE VIOLENTA (is_violent_death = true):
 - Manchetes que mencionam morte por arma de fogo
@@ -72,6 +99,22 @@ NÃO CLASSIFIQUE COMO MORTE VIOLENTA (is_violent_death = false):
 - Manchetes sobre políticas de segurança
 - Manchetes sobre apreensões de drogas/armas
 - Manchetes que não mencionam morte explicitamente
+
+INCIDENTE ÚNICO (is_single_incident = true):
+- Um homicídio ou tiroteio específico em local e data identificáveis
+- "Tiroteio deixa dois mortos na Zona Norte" (um evento)
+- "Homem é morto a tiros em operação policial"
+
+NÃO É INCIDENTE ÚNICO (is_single_incident = false) — descarte mesmo se mencionar mortes:
+- Estatísticas agregadas: balanço anual, CVLI, "X mortes em 2025", "no estado", painéis estatísticos
+- Notícias estrangeiras: terremotos, guerras, desastres fora do Brasil
+- Suicídios (mesmo violentos)
+- Crueldade contra animais
+- Resumos com múltiplos incidentes não relacionados
+- Análises/políticas públicas sobre violência sem um caso específico
+
+Use content_class_hint quando aplicável: incident, aggregate_statistics, foreign,
+non_incident, suicide, accident_disaster.
 
 Baseie-se APENAS no texto da manchete fornecida.
 """
@@ -190,7 +233,14 @@ async def classify_source(source_id: int) -> bool:
         return False
 
     # Step 3: persist the result in a fresh short-lived session.
-    new_status = "ready_for_download" if classification.is_violent_death else "discarded"
+    passes_gate = classification.is_violent_death and classification.is_single_incident
+    new_status = "ready_for_download" if passes_gate else "discarded"
+
+    reasoning = classification.reasoning
+    if classification.is_violent_death and not classification.is_single_incident:
+        hint = classification.content_class_hint or "non-incident"
+        reasoning = f"{reasoning} [single_incident=false, hint={hint}]"
+
     async with async_session_maker() as session:
         await session.execute(
             text("""
@@ -207,17 +257,17 @@ async def classify_source(source_id: int) -> bool:
                 "status": new_status,
                 "is_violent_death": 1 if classification.is_violent_death else 0,
                 "confidence": classification.confidence,
-                "reasoning": classification.reasoning,
+                "reasoning": reasoning,
             }
         )
         await session.commit()
 
-    if classification.is_violent_death:
+    if passes_gate:
         logger.info(f"Source {source_id}: VIOLENT DEATH ({classification.confidence})")
     else:
         logger.info(f"Source {source_id}: DISCARDED ({classification.confidence})")
 
-    return classification.is_violent_death
+    return passes_gate
 
 
 async def classify_pending_sources(limit: int = 50, concurrency: int = 10) -> dict:

--- a/backend/app/services/classification.py
+++ b/backend/app/services/classification.py
@@ -20,23 +20,23 @@ class ViolentDeathClassification(BaseModel):
     is_violent_death: bool = Field(
         ...,
         description="""
-        TRUE if the headline indicates news about one or more violent deaths 
+        TRUE only if the headline is about one or more NEW violent deaths in Brazil
         (homicides, murders, killings, police operations with deaths).
-        
+
         Examples of TRUE:
         - "Homem é morto a tiros em operação policial"
         - "Corpo é encontrado com marcas de violência"
         - "Tiroteio deixa dois mortos na Zona Norte"
         - "Mulher é assassinada pelo ex-marido"
-        
+
         Examples of FALSE:
         - "Polícia prende suspeito de roubo"
-        - "Governo anuncia nova política de segurança"
         - "Homem sobrevive após ser baleado"
+        - "Vítima de facadas chora no julgamento do agressor" (victim alive)
+        - "Atirador em massa no Texas recebe pena de morte" (foreign event)
         - "Operação apreende drogas e armas"
         """
     )
-    
     confidence: Literal["alta", "média", "baixa"] = Field(
         ...,
         description="""
@@ -81,32 +81,39 @@ class ViolentDeathClassification(BaseModel):
 
 # System prompt for classification
 CLASSIFICATION_SYSTEM_PROMPT = """
-Você é um classificador de manchetes de notícias. Sua tarefa é determinar:
-1. Se a manchete indica MORTE(S) VIOLENTA(S) (homicídios, assassinatos, execuções).
-2. Se descreve UM ÚNICO INCIDENTE específico (is_single_incident), ou conteúdo agregado/fora de escopo.
+Você é um classificador de manchetes de notícias do GOOGLE NEWS BRASIL. Sua tarefa é:
+1. Determinar se a manchete indica NOTÍCIA sobre MORTE(S) VIOLENTA(S) no Brasil.
+2. Determinar se descreve UM ÚNICO INCIDENTE específico (is_single_incident).
+
+Este filtro alimenta um arquivo de violência no Rio de Janeiro. Manchetes sobre mortes
+violentas no exterior NÃO entram, mesmo que mencionem tiroteio, guerra ou assassinato.
 
 CLASSIFIQUE COMO MORTE VIOLENTA (is_violent_death = true):
-- Manchetes que mencionam morte por arma de fogo
-- Manchetes que mencionam morte por arma branca
-- Manchetes que mencionam corpo encontrado
-- Manchetes que mencionam morte em operação policial
-- Manchetes que mencionam morte em confronto
-- Manchetes que mencionam feminicídio, latrocínio, homicídio, assassinato
+- Morte violenta no Brasil: morto(s), assassinado(s), executado(s), baleado(s) MORTO
+- Corpo, restos mortais ou ossada encontrados com indícios de violência
+- Tiroteio/confronto/operação policial que deixa mortos (inclui jargão: "neutralizado",
+  "CPF cancelado" no sentido de pessoa morta)
+- Feminicídio, latrocínio, homicídio, chacina, execução
+- Vítima que MORRE: "não resistiu aos ferimentos", "morre após ser baleado"
 
 NÃO CLASSIFIQUE COMO MORTE VIOLENTA (is_violent_death = false):
-- Manchetes sobre prisões sem morte
-- Manchetes sobre violência sem morte (feridos, agressões)
-- Manchetes sobre políticas de segurança
-- Manchetes sobre apreensões de drogas/armas
-- Manchetes que não mencionam morte explicitamente
+- Eventos FORA DO BRASIL (EUA, Europa, Rússia, Ucrânia, México, etc.), mesmo com mortes
+- Vítima VIVA: sobrevive, ferido(s), hospitalizado, chora, presta depoimento, "vítima de
+  X facadas" no julgamento (sobrevivente), tentativa de homicídio sem morte
+- Tiroteio, operação ou confronto SEM menção a morte ou feridos mortos
+- Prisões, mandados, julgamentos, pena de morte como sentença judicial (notícia jurídica)
+- Apreensões de armas/drogas, políticas de segurança
+- Metáforas ("assassinato da língua", "executa o orçamento")
+- Acidentes (trânsito, queda) sem homicídio doloso
+- Arsenal apreendido para crimes futuros (crime frustrado, sem morte na notícia)
 
 INCIDENTE ÚNICO (is_single_incident = true):
-- Um homicídio ou tiroteio específico em local e data identificáveis
+- Um homicídio ou tiroteio específico no Brasil, em local identificável
 - "Tiroteio deixa dois mortos na Zona Norte" (um evento)
 - "Homem é morto a tiros em operação policial"
 
 NÃO É INCIDENTE ÚNICO (is_single_incident = false) — descarte mesmo se mencionar mortes:
-- Estatísticas agregadas: balanço anual, CVLI, "X mortes em 2025", "no estado", painéis estatísticos
+- Estatísticas agregadas: balanço anual, CVLI, "X mortes em 2025", "no estado", painéis
 - Notícias estrangeiras: terremotos, guerras, desastres fora do Brasil
 - Suicídios (mesmo violentos)
 - Crueldade contra animais
@@ -116,20 +123,22 @@ NÃO É INCIDENTE ÚNICO (is_single_incident = false) — descarte mesmo se menc
 Use content_class_hint quando aplicável: incident, aggregate_statistics, foreign,
 non_incident, suicide, accident_disaster.
 
-Baseie-se APENAS no texto da manchete fornecida.
+Baseie-se APENAS no texto da manchete. Em dúvida sobre local (Brasil vs exterior), procure
+topônimos estrangeiros (Texas, EUA, Rússia, Ucrânia) ou contexto claramente internacional.
 """
 
 
-def get_classification_client():
+def get_classification_client(*, model: str | None = None):
     """Get instructor client for classification using the selection model."""
     settings = get_settings()
-    
+
     if not settings.gemini_api_key:
         raise ValueError("GEMINI_API_KEY not configured")
-    
+
+    model_name = model or settings.selection_model
     return instructor.from_provider(
-        f"google/{settings.selection_model}",
-        api_key=settings.gemini_api_key
+        f"google/{model_name}",
+        api_key=settings.gemini_api_key,
     )
 
 
@@ -139,29 +148,37 @@ def get_classification_client():
     retry=retry_if_exception_type(Exception),
     reraise=True,
 )
-def classify_headline(headline: str) -> ViolentDeathClassification:
+def classify_headline(
+    headline: str,
+    *,
+    system_prompt: str | None = None,
+    model: str | None = None,
+) -> ViolentDeathClassification:
     """
     Classify a headline to determine if it's about violent death.
-    
+
     Uses tenacity for retries with exponential backoff.
-    
+
     Args:
         headline: News headline text
-    
+        system_prompt: Optional override for the classification system prompt
+        model: Optional override for the Gemini model name
+
     Returns:
         ViolentDeathClassification with is_violent_death, confidence, and reasoning
     """
-    client = get_classification_client()
-    
+    client = get_classification_client(model=model)
+    prompt = system_prompt or CLASSIFICATION_SYSTEM_PROMPT
+
     result = client.create(
         response_model=ViolentDeathClassification,
         messages=[
-            {"role": "system", "content": CLASSIFICATION_SYSTEM_PROMPT},
-            {"role": "user", "content": f"Classifique esta manchete:\n\n{headline}"}
+            {"role": "system", "content": prompt},
+            {"role": "user", "content": f"Classifique esta manchete:\n\n{headline}"},
         ],
-        max_retries=2  # Instructor's internal retry
+        max_retries=2,  # Instructor's internal retry
     )
-    
+
     return result
 
 

--- a/backend/app/services/enrichment.py
+++ b/backend/app/services/enrichment.py
@@ -50,8 +50,10 @@ def parse_datetime(value) -> datetime | None:
 # === Configuration ===
 DATE_TOLERANCE_DAYS = 1  # For date+city blocking
 VICTIM_NAME_DATE_TOLERANCE_DAYS = 10  # Wider window when victim name matches
+TITLE_DATE_TOLERANCE_DAYS = 3  # Wider window when title similarity is high
 FUZZY_NAME_THRESHOLD = 0.85  # Threshold for fuzzy name matching
-LLM_MATCH_CONFIDENCE_THRESHOLD = 0.7  # Minimum confidence to accept LLM match
+FUZZY_TITLE_THRESHOLD = 0.85  # Threshold for fuzzy title matching
+LLM_MATCH_CONFIDENCE_THRESHOLD = 0.6  # Minimum confidence to accept LLM match
 
 
 # =============================================================================
@@ -99,6 +101,31 @@ def fuzzy_name_match(name1: str, name2: str, threshold: float = FUZZY_NAME_THRES
         return True
     
     return False
+
+
+def normalize_title(title: str) -> str:
+    """Normalize event title for fuzzy matching."""
+    if not title:
+        return ""
+    normalized = unidecode(title.lower().strip())
+    normalized = " ".join(normalized.split())
+    return normalized
+
+
+def fuzzy_title_match(
+    title1: str,
+    title2: str,
+    threshold: float = FUZZY_TITLE_THRESHOLD,
+) -> bool:
+    """Check if two event titles refer to the same incident."""
+    t1, t2 = normalize_title(title1), normalize_title(title2)
+    if not t1 or not t2:
+        return False
+    if t1 == t2:
+        return True
+    if t1 in t2 or t2 in t1:
+        return True
+    return SequenceMatcher(None, t1, t2).ratio() >= threshold
 
 
 def extract_victim_names(raw_event: RawEvent) -> list[str]:
@@ -335,36 +362,97 @@ async def block_by_neighborhood(raw_event: RawEvent) -> list[UniqueEvent]:
         return candidates
 
 
+def _unique_event_from_row(row) -> UniqueEvent:
+    """Build a UniqueEvent from a SQL row."""
+    return UniqueEvent(
+        id=row.id,
+        event_date=parse_datetime(row.event_date),
+        city=row.city,
+        state=row.state,
+        neighborhood=row.neighborhood,
+        street=row.street,
+        victims_summary=row.victims_summary,
+        victim_count=row.victim_count,
+        homicide_type=row.homicide_type,
+        title=row.title,
+        chronological_description=row.chronological_description,
+        source_count=row.source_count,
+        merged_data=row.merged_data,
+    )
+
+
+async def block_by_title_fuzzy(
+    raw_event: RawEvent,
+    days: int = TITLE_DATE_TOLERANCE_DAYS,
+    threshold: float = FUZZY_TITLE_THRESHOLD,
+) -> list[UniqueEvent]:
+    """
+    Find UniqueEvents with similar titles in the same city within a wider date window.
+    """
+    if not raw_event.event_date or not raw_event.city or not raw_event.title:
+        return []
+
+    min_date = raw_event.event_date - timedelta(days=days)
+    max_date = raw_event.event_date + timedelta(days=days)
+    city_lower = raw_event.city.lower()
+
+    async with async_session_maker() as session:
+        result = await session.execute(
+            text("""
+                SELECT * FROM unique_event
+                WHERE event_date BETWEEN :min_date AND :max_date
+                AND LOWER(city) = :city
+                AND title IS NOT NULL
+            """),
+            {"min_date": min_date, "max_date": max_date, "city": city_lower},
+        )
+        rows = result.fetchall()
+
+    candidates = []
+    for row in rows:
+        if fuzzy_title_match(raw_event.title, row.title, threshold=threshold):
+            candidates.append(_unique_event_from_row(row))
+
+    return candidates
+
+
 async def find_candidate_unique_events(raw_event: RawEvent) -> list[UniqueEvent]:
     """
     Combine all blocking strategies and return unique candidates.
     
     Priority:
     1. Victim name match (highest priority, widest date window)
-    2. Date + City (baseline)
-    3. Neighborhood + Date (for events without victim names)
+    2. Title fuzzy match (±3 days, same city)
+    3. Date + City (baseline)
+    4. Neighborhood + Date (for events without victim names)
     """
     candidates_dict = {}  # id -> UniqueEvent to deduplicate
-    
-    # Strategy 1: Date + City (always run if we have date and city)
-    if raw_event.event_date and raw_event.city:
-        date_city_candidates = await block_by_date_city(raw_event)
-        for c in date_city_candidates:
-            candidates_dict[c.id] = c
-    
-    # Strategy 2: Victim Name + City (if victim identified - highest priority)
+
+    # Strategy 1: Victim Name + City (if victim identified - highest priority)
     victim_names = extract_victim_names(raw_event)
     if victim_names:
         victim_candidates = await block_by_victim_name(raw_event, victim_names)
         for c in victim_candidates:
             candidates_dict[c.id] = c
-    
-    # Strategy 3: Neighborhood + Date (if no victim but has neighborhood)
+
+    # Strategy 2: Title fuzzy match (same city, ±3 days)
+    if raw_event.title and raw_event.event_date and raw_event.city:
+        title_candidates = await block_by_title_fuzzy(raw_event)
+        for c in title_candidates:
+            candidates_dict[c.id] = c
+
+    # Strategy 3: Date + City (always run if we have date and city)
+    if raw_event.event_date and raw_event.city:
+        date_city_candidates = await block_by_date_city(raw_event)
+        for c in date_city_candidates:
+            candidates_dict[c.id] = c
+
+    # Strategy 4: Neighborhood + Date (if no victim but has neighborhood)
     if not victim_names and raw_event.neighborhood:
         neighborhood_candidates = await block_by_neighborhood(raw_event)
         for c in neighborhood_candidates:
             candidates_dict[c.id] = c
-    
+
     return list(candidates_dict.values())
 
 
@@ -468,12 +556,16 @@ REGRAS DE MATCHING (em ordem de importância):
    - Exemplo: "João Silva" e "Joao da Silva" = MESMA pessoa
    - Exemplo: fontes diferentes podem focar em aspectos diferentes do mesmo crime
 
-2. **DATA + LOCAL** (peso alto): Mesmo dia + mesmo bairro/local sugere mesmo evento, especialmente se não há vítimas identificadas.
+2. **TÍTULO** (peso alto): Manchetes/títulos muito similares sobre o mesmo crime indicam o MESMO evento,
+   mesmo com pequenas diferenças de data (±3 dias) ou redação entre fontes.
 
-3. **DESCRIÇÃO** (peso médio): Descrições similares do crime ajudam a confirmar, mas fontes diferentes podem descrever o mesmo evento de formas diferentes.
+3. **DATA + LOCAL** (peso alto): Mesmo dia + mesmo bairro/local sugere mesmo evento, especialmente se não há vítimas identificadas.
+
+4. **DESCRIÇÃO** (peso médio): Descrições similares do crime ajudam a confirmar, mas fontes diferentes podem descrever o mesmo evento de formas diferentes.
    - "Homem baleado no Complexo da Maré" e "Tiroteio deixa um morto na Maré" podem ser o MESMO evento
 
-IMPORTANTE: Se há dúvida significativa, responda que NÃO há match. É melhor criar eventos separados que podem ser mesclados depois.
+IMPORTANTE: Prefira match quando há evidência convergente (vítima, título ou local+data).
+Se a evidência for fraca ou ambígua, responda que NÃO há match.
 
 Responda APENAS com JSON válido:
 {{
@@ -1055,7 +1147,7 @@ async def process_single_raw_event(raw_event_id: int) -> dict:
         }
 
 
-async def process_pending_deduplication(limit: int = 100) -> dict:
+async def process_pending_deduplication(limit: int = 200) -> dict:
     """
     Phase 2: Batch clustering (called periodically).
     

--- a/backend/app/services/extraction.py
+++ b/backend/app/services/extraction.py
@@ -16,6 +16,30 @@ from app.services import diagnostics
 from app.services.extraction_schemas import ViolentDeathEvent
 
 
+def derive_security_force_involved(event: ViolentDeathEvent) -> bool | None:
+    """Return True if any party is flagged as security force, False if explicitly not, else None."""
+    flags: list[bool | None] = []
+
+    for victim in event.victims.identifiable_victims:
+        flags.append(victim.is_security_force)
+    if event.victims.unidentified_groups:
+        for group in event.victims.unidentified_groups:
+            flags.append(group.is_security_force)
+
+    if event.perpetrators:
+        for perpetrator in event.perpetrators.identifiable_perpetrators:
+            flags.append(perpetrator.is_security_force)
+        if event.perpetrators.unidentified_groups:
+            for group in event.perpetrators.unidentified_groups:
+                flags.append(group.is_security_force)
+
+    if any(flag is True for flag in flags):
+        return True
+    if flags and all(flag is False for flag in flags):
+        return False
+    return None
+
+
 # System prompt for extraction
 EXTRACTION_SYSTEM_PROMPT = """
 Você é um assistente especializado em extrair informações de notícias sobre mortes violentas 
@@ -271,8 +295,40 @@ async def extract_source(source_id: int) -> RawEvent | None:
         duration_ms = int((time.monotonic() - started) * 1000)
         reason = diagnostics.classify_extraction_exception(e)
         logger.error(f"Extraction failed for source {source_id} ({reason}): {e}")
+
+        if reason == diagnostics.VALIDATION_ERROR:
+            async with async_session_maker() as session:
+                await session.execute(
+                    text("""
+                        UPDATE source_google_news
+                        SET status = 'discarded',
+                            classification_reasoning = :reasoning,
+                            updated_at = CURRENT_TIMESTAMP
+                        WHERE id = :id
+                    """),
+                    {
+                        "id": source_id,
+                        "reasoning": f"Extraction validation failed: {str(e)[:500]}",
+                    },
+                )
+                await session.commit()
+            await diagnostics.record_attempt(
+                stage=diagnostics.STAGE_EXTRACTION,
+                outcome=diagnostics.OUTCOME_FAILURE,
+                source_google_news_id=source_id,
+                failure_reason=reason,
+                failure_detail=str(e),
+                model=model_name,
+                content_length=original_length,
+                duration_ms=duration_ms,
+                attempt_number=attempt_number,
+            )
+            return None
+
         await _mark_failed(reason, str(e), duration_ms)
         return None
+
+    security_force_involved = derive_security_force_involved(event)
 
     event_data = event.model_dump()
 
@@ -299,6 +355,7 @@ async def extract_source(source_id: int) -> RawEvent | None:
             victim_count=event.victims.number_of_victims,
             identified_victim_count=event.victims.number_of_identifiable_victims,
             perpetrator_count=event.perpetrators.number_of_perpetrators if event.perpetrators else None,
+            security_force_involved=security_force_involved,
             homicide_type=event.homicide_dynamic.homicide_type,
             method_of_death=event.homicide_dynamic.method,
             title=event.homicide_dynamic.title,

--- a/backend/app/services/extraction_schemas.py
+++ b/backend/app/services/extraction_schemas.py
@@ -192,8 +192,40 @@ class Victims(BaseModel):
         None, description="Número de vítimas não identificadas"
     )
     number_of_victims: int = Field(
-        ..., description="Número total de vítimas de morte violenta mencionadas na notícia"
+        ...,
+        ge=1,
+        le=20,
+        description="Número total de vítimas de morte violenta mencionadas na notícia",
     )
+
+    @model_validator(mode="after")
+    def validate_victim_counts(self):
+        """Ensure victim totals are internally consistent."""
+        identifiable = self.number_of_identifiable_victims
+        if identifiable != len(self.identifiable_victims):
+            raise ValueError(
+                f"number_of_identifiable_victims ({identifiable}) must match "
+                f"identifiable_victims list length ({len(self.identifiable_victims)})"
+            )
+
+        group_total = 0
+        if self.unidentified_groups:
+            group_total = sum(group.count for group in self.unidentified_groups)
+            if self.number_of_unidentified_victims is not None:
+                if self.number_of_unidentified_victims != group_total:
+                    raise ValueError(
+                        f"number_of_unidentified_victims ({self.number_of_unidentified_victims}) "
+                        f"must match sum of unidentified group counts ({group_total})"
+                    )
+
+        expected_total = identifiable + group_total
+        if abs(self.number_of_victims - expected_total) > 1:
+            raise ValueError(
+                f"number_of_victims ({self.number_of_victims}) inconsistent with "
+                f"identifiable ({identifiable}) + unidentified ({group_total})"
+            )
+
+        return self
 
 
 class DateVerification(BaseModel):

--- a/backend/app/services/ingestion.py
+++ b/backend/app/services/ingestion.py
@@ -30,6 +30,16 @@ DEFAULT_PARAMS = {
     "ceid": "BR:pt-419",
 }
 
+
+async def _resolved_url_exists(session: AsyncSession, resolved_url: str | None) -> bool:
+    """Return True if another source already has this resolved article URL."""
+    if not resolved_url:
+        return False
+    existing = await session.exec(
+        select(SourceGoogleNews).where(SourceGoogleNews.resolved_url == resolved_url)
+    )
+    return existing.first() is not None
+
 # Default search queries for violence-related news in Rio de Janeiro
 DEFAULT_QUERIES = [
     "homicídio Rio de Janeiro",
@@ -171,6 +181,10 @@ async def ingest_feeds(
                 resolved_url = resolve_google_news_url(google_news_url)
                 if resolved_url:
                     logger.debug(f"Resolved: {resolved_url[:60]}...")
+
+            if await _resolved_url_exists(session, resolved_url):
+                logger.debug(f"Skipping duplicate resolved URL: {resolved_url[:60]}...")
+                continue
             
             # Create new source record
             source = SourceGoogleNews(
@@ -394,6 +408,9 @@ async def ingest_city(
             resolved_url = None
             if resolve_urls:
                 resolved_url = resolve_google_news_url(google_news_url)
+
+            if await _resolved_url_exists(session, resolved_url):
+                continue
             
             # Create source record
             source = SourceGoogleNews(

--- a/backend/app/services/public_filters.py
+++ b/backend/app/services/public_filters.py
@@ -1,0 +1,56 @@
+"""Reusable filters for public-facing aggregation endpoints."""
+
+from sqlalchemy import ColumnElement, or_
+
+from app.models.unique_event import UniqueEvent
+
+# Brazilian federative units (27 states + DF).
+BR_UFS = frozenset(
+    {
+        "AC",
+        "AL",
+        "AP",
+        "AM",
+        "BA",
+        "CE",
+        "DF",
+        "ES",
+        "GO",
+        "MA",
+        "MT",
+        "MS",
+        "MG",
+        "PA",
+        "PB",
+        "PR",
+        "PE",
+        "PI",
+        "RJ",
+        "RN",
+        "RS",
+        "RO",
+        "RR",
+        "SC",
+        "SP",
+        "SE",
+        "TO",
+    }
+)
+
+# Phase A (interim, no migration): cap victim_count and exclude non-BR states by UF.
+# Phase B (after AQV-28): switch to UniqueEvent.content_class == "incident".
+
+
+def public_incident_criteria() -> tuple[ColumnElement, ...]:
+    """SQLAlchemy criteria for plausible single-incident rows (Phase A)."""
+    return (
+        UniqueEvent.victim_count <= 10,
+        or_(UniqueEvent.state.in_(BR_UFS), UniqueEvent.state.is_(None)),
+    )
+
+
+def apply_public_incident_filter(statement):
+    """Apply Phase A public guardrail filters to a Select statement."""
+    for criterion in public_incident_criteria():
+        statement = statement.where(criterion)
+    return statement

--- a/backend/app/tasks/pipeline.py
+++ b/backend/app/tasks/pipeline.py
@@ -348,7 +348,7 @@ async def extract_ready_task(ctx: dict, limit: int = 10) -> dict:
 
 
 @notify_on_failure("batch_dedup")
-async def batch_dedup_task(ctx: dict, limit: int = 100) -> dict:
+async def batch_dedup_task(ctx: dict, limit: int = 200) -> dict:
     """
     Periodic: Process pending RawEvents through batch clustering.
     

--- a/backend/eval/__init__.py
+++ b/backend/eval/__init__.py
@@ -1,0 +1,1 @@
+"""Pipeline evaluation harness for AI stages."""

--- a/backend/eval/__main__.py
+++ b/backend/eval/__main__.py
@@ -1,0 +1,6 @@
+"""CLI entry point: python -m eval classification <command> ..."""
+
+from eval.cli import main
+
+if __name__ == "__main__":
+    main()

--- a/backend/eval/cli.py
+++ b/backend/eval/cli.py
@@ -1,0 +1,177 @@
+"""Eval CLI dispatcher."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from eval.compare import compare_reports, load_report, print_compare
+from eval.schemas import load_fixture
+from eval.stages.classification.build import DEFAULT_OUT, build_fixture, write_fixture
+from eval.stages.classification.validate import print_validation, validate_fixture
+
+DEFAULT_SEED_FIXTURE = (
+    BACKEND_ROOT / "tests" / "fixtures" / "eval" / "classification_seed.json"
+)
+DEFAULT_HARD_FIXTURE = (
+    BACKEND_ROOT / "tests" / "fixtures" / "eval" / "classification_hard.json"
+)
+
+
+def _load_fixture_path(path: str):
+    fixture_path = Path(path)
+    if not fixture_path.exists():
+        raise SystemExit(f"Fixture not found: {fixture_path}")
+    return load_fixture(json.loads(fixture_path.read_text())), str(fixture_path)
+
+
+def cmd_validate(args: argparse.Namespace) -> None:
+    fixture, fixture_path = _load_fixture_path(args.fixture)
+    result = validate_fixture(fixture)
+    print_validation(result, fixture_path)
+    if not result.valid:
+        raise SystemExit(1)
+
+
+def cmd_build(args: argparse.Namespace) -> None:
+    db_path = Path(args.db)
+    if not db_path.exists():
+        raise SystemExit(f"DB not found: {db_path}")
+
+    merge_into = Path(args.merge_into) if args.merge_into else None
+    fixture, added = build_fixture(db_path, args.n, args.seed, merge_into)
+    out_path = Path(args.out)
+    write_fixture(fixture, out_path)
+    print(
+        f"Wrote {out_path}: {added} new cases, "
+        f"{fixture.meta.labeled_count} labeled, {fixture.meta.pending_count} pending"
+    )
+
+
+def cmd_generate_hard(args: argparse.Namespace) -> None:
+    from eval.stages.classification.generate_hard import (
+        GENERATOR_MODEL,
+        write_hard_fixture,
+    )
+
+    out_path = Path(args.out)
+    model = args.model or GENERATOR_MODEL
+    path, true_count, false_count = write_hard_fixture(out_path, model=model)
+    print(f"Wrote {path} (30 cases: {true_count} true, {false_count} false)")
+    print(f"  generator: {model}")
+
+
+async def cmd_run_async(args: argparse.Namespace) -> None:
+    from eval.stages.classification.run import (
+        default_output_path,
+        print_report,
+        run_classification_eval,
+        write_report,
+    )
+
+    fixture, fixture_path = _load_fixture_path(args.fixture)
+    case_ids = {s.strip() for s in args.ids.split(",") if s.strip()} if args.ids else None
+    report = await run_classification_eval(
+        fixture,
+        variant_name=args.variant,
+        concurrency=args.concurrency,
+        limit=args.limit,
+        case_ids=case_ids,
+        fail_fast=args.fail_fast,
+        dry_run=args.no_llm,
+        fixture_path=fixture_path,
+    )
+    print_report(report)
+    if args.output:
+        output_path = Path(args.output)
+    elif args.no_llm:
+        output_path = None
+    else:
+        output_path = default_output_path(args.variant)
+    if output_path:
+        write_report(report, output_path)
+        print(f"\nWrote {output_path}")
+
+
+def cmd_run(args: argparse.Namespace) -> None:
+    asyncio.run(cmd_run_async(args))
+
+
+def cmd_compare(args: argparse.Namespace) -> None:
+    baseline = load_report(Path(args.baseline))
+    candidate = load_report(Path(args.candidate))
+    result = compare_reports(baseline, candidate)
+    print_compare(result)
+
+
+def cmd_report(args: argparse.Namespace) -> None:
+    from eval.stages.classification.run import print_report
+
+    report = load_report(Path(args.run))
+    print_report(report)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Pipeline eval harness")
+    sub = parser.add_subparsers(dest="stage", required=True)
+
+    cls = sub.add_parser("classification", help="Classification eval")
+    cls_sub = cls.add_subparsers(dest="command", required=True)
+
+    p_validate = cls_sub.add_parser("validate", help="Validate fixture schema")
+    p_validate.add_argument("--fixture", default=str(DEFAULT_SEED_FIXTURE))
+    p_validate.set_defaults(func=cmd_validate)
+
+    p_build = cls_sub.add_parser("build", help="Sample pending cases from DB copy")
+    p_build.add_argument("--db", required=True)
+    p_build.add_argument("--n", type=int, default=50)
+    p_build.add_argument("--seed", type=int, default=42)
+    p_build.add_argument("--out", default=str(DEFAULT_OUT))
+    p_build.add_argument("--merge-into", default=None, help="Append into existing fixture")
+    p_build.set_defaults(func=cmd_build)
+
+    p_generate = cls_sub.add_parser(
+        "generate-hard",
+        help="Generate adversarial cases with Gemini Pro (costs tokens)",
+    )
+    p_generate.add_argument("--out", default=str(DEFAULT_HARD_FIXTURE))
+    p_generate.add_argument(
+        "--model",
+        default=None,
+        help="Generator model (default: gemini-3.1-pro-preview)",
+    )
+    p_generate.set_defaults(func=cmd_generate_hard)
+
+    p_run = cls_sub.add_parser("run", help="Run eval against labeled cases")
+    p_run.add_argument("--fixture", default=str(DEFAULT_SEED_FIXTURE))
+    p_run.add_argument("--variant", default="baseline")
+    p_run.add_argument("--concurrency", type=int, default=5)
+    p_run.add_argument("--limit", type=int, default=None)
+    p_run.add_argument("--ids", default=None, help="Comma-separated case ids")
+    p_run.add_argument("--output", default=None)
+    p_run.add_argument("--fail-fast", action="store_true")
+    p_run.add_argument("--no-llm", action="store_true", help="Validate only, no LLM calls")
+    p_run.set_defaults(func=cmd_run)
+
+    p_compare = cls_sub.add_parser("compare", help="Compare two run reports")
+    p_compare.add_argument("--baseline", required=True)
+    p_compare.add_argument("--candidate", required=True)
+    p_compare.set_defaults(func=cmd_compare)
+
+    p_report = cls_sub.add_parser("report", help="Print a run report summary")
+    p_report.add_argument("--run", required=True)
+    p_report.set_defaults(func=cmd_report)
+
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/eval/compare.py
+++ b/backend/eval/compare.py
@@ -1,0 +1,102 @@
+"""Compare two classification eval run reports."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from eval.schemas import RunReport
+
+
+def load_report(path: Path) -> RunReport:
+    data = json.loads(path.read_text())
+    return RunReport.model_validate(data)
+
+
+def compare_reports(baseline: RunReport, candidate: RunReport) -> dict:
+    baseline_by_id = {c.id: c for c in baseline.cases}
+    candidate_by_id = {c.id: c for c in candidate.cases}
+
+    common_ids = sorted(set(baseline_by_id) & set(candidate_by_id))
+    regressions: list[dict] = []
+    improvements: list[dict] = []
+    unchanged_pass = 0
+    unchanged_fail = 0
+
+    for case_id in common_ids:
+        b = baseline_by_id[case_id]
+        c = candidate_by_id[case_id]
+        if b.passed and not c.passed:
+            regressions.append(
+                {
+                    "id": case_id,
+                    "headline": c.headline or b.headline,
+                    "expected": c.expected,
+                    "baseline_actual": b.actual,
+                    "candidate_actual": c.actual,
+                }
+            )
+        elif not b.passed and c.passed:
+            improvements.append(
+                {
+                    "id": case_id,
+                    "headline": c.headline or b.headline,
+                    "expected": c.expected,
+                    "baseline_actual": b.actual,
+                    "candidate_actual": c.actual,
+                }
+            )
+        elif b.passed and c.passed:
+            unchanged_pass += 1
+        else:
+            unchanged_fail += 1
+
+    return {
+        "baseline": {
+            "variant": baseline.meta.variant,
+            "accuracy": baseline.summary.accuracy,
+            "passed": baseline.summary.passed,
+            "total": baseline.summary.total,
+        },
+        "candidate": {
+            "variant": candidate.meta.variant,
+            "accuracy": candidate.summary.accuracy,
+            "passed": candidate.summary.passed,
+            "total": candidate.summary.total,
+        },
+        "common_cases": len(common_ids),
+        "regressions": regressions,
+        "improvements": improvements,
+        "unchanged_pass": unchanged_pass,
+        "unchanged_fail": unchanged_fail,
+    }
+
+
+def print_compare(result: dict) -> None:
+    b = result["baseline"]
+    c = result["candidate"]
+    print(f"\n=== COMPARE: {b['variant']} vs {c['variant']} ===")
+    print(f"  baseline:  {b['passed']}/{b['total']} ({_pct(b['accuracy'])})")
+    print(f"  candidate: {c['passed']}/{c['total']} ({_pct(c['accuracy'])})")
+    print(f"  common cases: {result['common_cases']}")
+    print(f"  unchanged pass: {result['unchanged_pass']}, unchanged fail: {result['unchanged_fail']}")
+
+    if result["regressions"]:
+        print(f"\n  REGRESSIONS ({len(result['regressions'])}):")
+        for item in result["regressions"]:
+            print(f"    - {item['id']}: expected={item['expected']}, was {item['baseline_actual']}, now {item['candidate_actual']}")
+            if item.get("headline"):
+                print(f"      \"{item['headline'][:80]}\"")
+
+    if result["improvements"]:
+        print(f"\n  IMPROVEMENTS ({len(result['improvements'])}):")
+        for item in result["improvements"]:
+            print(f"    + {item['id']}: expected={item['expected']}, was {item['baseline_actual']}, now {item['candidate_actual']}")
+            if item.get("headline"):
+                print(f"      \"{item['headline'][:80]}\"")
+
+
+def _pct(value: float | None) -> str:
+    if value is None:
+        return "n/a"
+    return f"{value * 100:.1f}%"

--- a/backend/eval/schemas.py
+++ b/backend/eval/schemas.py
@@ -1,0 +1,120 @@
+"""Pydantic schemas for eval fixtures and run reports."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+
+LabelStatus = Literal["labeled", "pending"]
+
+
+class ClassificationInput(BaseModel):
+    headline: str
+
+
+class ClassificationExpected(BaseModel):
+    is_violent_death: bool
+
+
+class CaseMetadata(BaseModel):
+    source_id: int | None = None
+    notes: str = ""
+
+
+class ClassificationCase(BaseModel):
+    id: str
+    tags: list[str] = Field(default_factory=list)
+    label_status: LabelStatus
+    input: ClassificationInput
+    expected: ClassificationExpected | None = None
+    metadata: CaseMetadata = Field(default_factory=CaseMetadata)
+
+
+class FixtureMeta(BaseModel):
+    stage: Literal["classification"] = "classification"
+    version: int = 1
+    source_db: str | None = None
+    seed: int | None = None
+    labeled_count: int = 0
+    pending_count: int = 0
+    generator_model: str | None = None
+
+
+class ClassificationFixture(BaseModel):
+    meta: FixtureMeta
+    cases: list[ClassificationCase]
+
+
+class ValidationIssue(BaseModel):
+    case_id: str | None
+    message: str
+
+
+class ValidationResult(BaseModel):
+    valid: bool
+    labeled_count: int
+    pending_count: int
+    issues: list[ValidationIssue] = Field(default_factory=list)
+
+
+class CaseResult(BaseModel):
+    id: str
+    passed: bool
+    expected: bool | None = None
+    actual: bool | None = None
+    confidence: str | None = None
+    reasoning: str | None = None
+    headline: str | None = None
+    tags: list[str] = Field(default_factory=list)
+    latency_ms: int | None = None
+    error: str | None = None
+
+
+class RunSummary(BaseModel):
+    total: int
+    passed: int
+    failed: int
+    errors: int
+    accuracy: float | None = None
+    precision: float | None = None
+    recall: float | None = None
+    f1: float | None = None
+    by_tag: dict[str, dict[str, Any]] = Field(default_factory=dict)
+
+
+class RunMeta(BaseModel):
+    stage: Literal["classification"] = "classification"
+    variant: str
+    model: str
+    fixture: str
+    run_at: str
+    dry_run: bool = False
+
+
+class RunReport(BaseModel):
+    meta: RunMeta
+    summary: RunSummary
+    cases: list[CaseResult]
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def load_fixture(data: dict[str, Any]) -> ClassificationFixture:
+    return ClassificationFixture.model_validate(data)
+
+
+def dump_fixture(fixture: ClassificationFixture) -> dict[str, Any]:
+    return fixture.model_dump(mode="json", exclude_none=False)
+
+
+def update_fixture_counts(fixture: ClassificationFixture) -> ClassificationFixture:
+    labeled = sum(1 for c in fixture.cases if c.label_status == "labeled")
+    pending = sum(1 for c in fixture.cases if c.label_status == "pending")
+    fixture.meta.labeled_count = labeled
+    fixture.meta.pending_count = pending
+    return fixture

--- a/backend/eval/stages/classification/build.py
+++ b/backend/eval/stages/classification/build.py
@@ -1,0 +1,191 @@
+"""Build classification eval fixtures from a prod DB copy."""
+
+from __future__ import annotations
+
+import json
+import random
+import re
+import sqlite3
+from collections import defaultdict
+from pathlib import Path
+
+from eval.schemas import (
+    CaseMetadata,
+    ClassificationCase,
+    ClassificationFixture,
+    ClassificationInput,
+    FixtureMeta,
+    dump_fixture,
+    load_fixture,
+    update_fixture_counts,
+)
+
+DEFAULT_OUT = (
+    Path(__file__).resolve().parents[3] / "tests" / "fixtures" / "eval" / "classification.json"
+)
+
+DEATH_KEYWORDS = re.compile(
+    r"\b(morto|morta|mortos|mortas|assassin|homicíd|homicid|executad|"
+    r"corpo|feminicíd|feminicid|latrocín|latrocin|assassinat)\b",
+    re.IGNORECASE,
+)
+
+POSITIVE_STATUSES = (
+    "ready_for_download",
+    "downloading",
+    "ready_for_extraction",
+    "extracting",
+    "extracted",
+)
+
+
+def _round_robin(groups: dict[str, list], total: int) -> list:
+    selected: list = []
+    pools = {k: list(v) for k, v in groups.items()}
+    for pool in pools.values():
+        random.shuffle(pool)
+    keys = list(pools.keys())
+    random.shuffle(keys)
+    while len(selected) < total and any(pools.values()):
+        for key in keys:
+            if not pools[key]:
+                continue
+            selected.append(pools[key].pop())
+            if len(selected) >= total:
+                break
+    return selected
+
+
+def _heuristic_tags(headline: str, pool: str) -> list[str]:
+    tags = [pool]
+    lower = headline.lower()
+    if any(w in lower for w in ("ferid", "balead", "sobreviv")):
+        tags.append("injured_not_dead")
+    if DEATH_KEYWORDS.search(headline):
+        tags.append("death_keyword")
+    if any(w in lower for w in ("operação", "operacao", "confronto", "tiroteio")):
+        tags.append("ambiguous")
+    if any(w in lower for w in ("prende", "apreend", "política", "politica")):
+        tags.append("clear_false")
+    if any(w in lower for w in ("morto", "morta", "assassin", "corpo")):
+        tags.append("clear_true")
+    return tags
+
+
+def _fetch_rows(conn: sqlite3.Connection, query: str) -> list[sqlite3.Row]:
+    return conn.execute(query).fetchall()
+
+
+def sample_classification_cases(conn: sqlite3.Connection, n: int) -> list[ClassificationCase]:
+    negatives = _fetch_rows(
+        conn,
+        """
+        SELECT id, headline
+        FROM source_google_news
+        WHERE status = 'discarded' AND is_violent_death = 0 AND headline IS NOT NULL
+        """,
+    )
+    positives = _fetch_rows(
+        conn,
+        """
+        SELECT id, headline
+        FROM source_google_news
+        WHERE status IN ({}) AND is_violent_death = 1 AND headline IS NOT NULL
+        """.format(",".join(f"'{s}'" for s in POSITIVE_STATUSES)),
+    )
+    disagreements = _fetch_rows(
+        conn,
+        """
+        SELECT id, headline
+        FROM source_google_news
+        WHERE status = 'discarded' AND headline IS NOT NULL
+        """,
+    )
+    disagreement_rows = [r for r in disagreements if DEATH_KEYWORDS.search(r["headline"] or "")]
+
+    per_pool = max(1, n // 3)
+    pools = {
+        "negative": [dict(r) for r in negatives],
+        "positive": [dict(r) for r in positives],
+        "disagreement": [dict(r) for r in disagreement_rows],
+    }
+
+    negative_groups: dict[str, list] = defaultdict(list)
+    for row in pools["negative"]:
+        negative_groups["negative"].append(row)
+
+    positive_groups: dict[str, list] = defaultdict(list)
+    for row in pools["positive"]:
+        positive_groups["positive"].append(row)
+
+    disagreement_groups: dict[str, list] = defaultdict(list)
+    for row in pools["disagreement"]:
+        disagreement_groups["disagreement"].append(row)
+
+    selected: list[tuple[str, dict]] = (
+        [("negative", row) for row in _round_robin(negative_groups, per_pool)]
+        + [("positive", row) for row in _round_robin(positive_groups, per_pool)]
+        + [("disagreement", row) for row in _round_robin(disagreement_groups, per_pool)]
+    )
+    random.shuffle(selected)
+    selected = selected[:n]
+
+    cases: list[ClassificationCase] = []
+    for pool, row in selected:
+        headline = row["headline"]
+        source_id = row["id"]
+        cases.append(
+            ClassificationCase(
+                id=f"cls-{source_id}",
+                tags=_heuristic_tags(headline, pool),
+                label_status="pending",
+                input=ClassificationInput(headline=headline),
+                expected=None,
+                metadata=CaseMetadata(source_id=source_id, notes=""),
+            )
+        )
+    return cases
+
+
+def build_fixture(
+    db_path: Path,
+    n: int,
+    seed: int,
+    merge_into: Path | None = None,
+) -> tuple[ClassificationFixture, int]:
+    random.seed(seed)
+    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    conn.row_factory = sqlite3.Row
+    try:
+        new_cases = sample_classification_cases(conn, n)
+    finally:
+        conn.close()
+
+    existing_ids: set[str] = set()
+    cases: list[ClassificationCase] = []
+    meta = FixtureMeta(source_db=str(db_path), seed=seed)
+
+    if merge_into and merge_into.exists():
+        existing = load_fixture(json.loads(merge_into.read_text()))
+        cases.extend(existing.cases)
+        existing_ids = {c.id for c in existing.cases}
+        meta = existing.meta
+        meta.source_db = str(db_path)
+        meta.seed = seed
+
+    added = 0
+    for case in new_cases:
+        if case.id in existing_ids:
+            continue
+        cases.append(case)
+        existing_ids.add(case.id)
+        added += 1
+
+    fixture = ClassificationFixture(meta=meta, cases=cases)
+    update_fixture_counts(fixture)
+    return fixture, added
+
+
+def write_fixture(fixture: ClassificationFixture, out_path: Path) -> None:
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(dump_fixture(fixture), ensure_ascii=False, indent=2))

--- a/backend/eval/stages/classification/generate_hard.py
+++ b/backend/eval/stages/classification/generate_hard.py
@@ -1,0 +1,146 @@
+"""Generate challenging classification benchmark cases with a strong Gemini model."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import instructor
+from pydantic import BaseModel, Field
+
+from app.config import get_settings
+from app.services.classification import CLASSIFICATION_SYSTEM_PROMPT
+
+DEFAULT_OUT = (
+    Path(__file__).resolve().parents[3]
+    / "tests"
+    / "fixtures"
+    / "eval"
+    / "classification_hard.json"
+)
+
+GENERATOR_MODEL = "gemini-3.1-pro-preview"
+
+GENERATOR_SYSTEM_PROMPT = """
+Você cria casos de teste adversariais para um classificador de manchetes de notícias
+sobre mortes violentas no Brasil (homicídios, assassinatos, execuções).
+
+Use EXATAMENTE os mesmos critérios de classificação abaixo para rotular cada manchete.
+O objetivo é produzir manchetes DIFÍCEIS que confundiriam modelos leves, mas com rótulo
+correto inequívoco para um humano que conhece as regras.
+
+CRITÉRIOS (is_violent_death):
+TRUE: manchete sobre morte violenta no Brasil (homicídio, assassinato, execução,
+corpo/restos mortais com violência, tiroteio COM morte, feminicídio, latrocínio,
+morte em operação/confronto, jargão policial como "neutralizado" ou "CPF cancelado").
+FALSE: feridos ou vítimas que sobreviveram, tentativa sem morte, prisões, apreensões,
+políticas de segurança, metáforas, morte culposa/acidente, morte natural, entretenimento,
+notícias de morte violenta NO EXTERIOR (EUA, Europa, guerras fora do BR), tiroteio/operação
+SEM menção a morte, processo judicial sobre crime passado sem notícia de nova morte.
+
+Produza manchetes realistas em português brasileiro, estilo Google News, curtas.
+Evite repetir estruturas. Cada manchete deve ser desafiadora por um motivo diferente.
+Balanceie ~15 TRUE e ~15 FALSE.
+"""
+
+GENERATOR_USER_PROMPT = """
+Gere exatamente 30 casos adversariais para benchmark de classificação.
+
+Inclua variedade entre estas categorias (tags):
+- implied_death: morte implícita mas corretamente rotulável
+- explicit_non_death: violência clara sem morte
+- accident_vs_violent: acidente/culposo vs homicídio
+- metaphor_or_fiction: linguagem figurada ou entretenimento
+- police_op_ambiguous: operação/confronto/tiroteio sem ou com morte explícita
+- victim_status_unclear: vítima em estado incerto na manchete
+- legal_process: investigação/julgamento/prisão relacionada a homicídio
+- foreign_or_offtopic: falso positivo geográfico ou tema tangencial
+- subtle_true: TRUE difícil (morte violenta fácil de perder)
+- subtle_false: FALSE difícil (parece morte violenta mas não é)
+
+Para cada caso forneça:
+- headline: manchete
+- is_violent_death: rótulo correto segundo as regras
+- tags: 1-3 tags da lista acima
+- notes: 1 frase explicando por que é difícil
+
+Não copie manchetes do seed existente. Seja criativo e adversarial.
+"""
+
+
+class GeneratedCase(BaseModel):
+    headline: str = Field(..., min_length=10, max_length=200)
+    is_violent_death: bool
+    tags: list[str] = Field(..., min_length=1, max_length=3)
+    notes: str = Field(..., min_length=5, max_length=300)
+
+
+class GeneratedHardSet(BaseModel):
+    cases: list[GeneratedCase] = Field(..., min_length=30, max_length=30)
+
+
+def generate_hard_cases(model: str = GENERATOR_MODEL) -> GeneratedHardSet:
+    settings = get_settings()
+    if not settings.gemini_api_key:
+        raise ValueError("GEMINI_API_KEY not configured")
+
+    client = instructor.from_provider(
+        f"google/{model}",
+        api_key=settings.gemini_api_key,
+    )
+
+    return client.create(
+        response_model=GeneratedHardSet,
+        messages=[
+            {
+                "role": "system",
+                "content": GENERATOR_SYSTEM_PROMPT + "\n\n" + CLASSIFICATION_SYSTEM_PROMPT,
+            },
+            {"role": "user", "content": GENERATOR_USER_PROMPT},
+        ],
+        max_retries=2,
+    )
+
+
+def to_fixture(generated: GeneratedHardSet, *, model: str) -> dict:
+    from eval.schemas import (
+        CaseMetadata,
+        ClassificationCase,
+        ClassificationExpected,
+        ClassificationFixture,
+        ClassificationInput,
+        FixtureMeta,
+        dump_fixture,
+        update_fixture_counts,
+    )
+
+    cases: list[ClassificationCase] = []
+    for i, item in enumerate(generated.cases, start=1):
+        cases.append(
+            ClassificationCase(
+                id=f"cls-hard-{i:03d}",
+                tags=item.tags,
+                label_status="labeled",
+                input=ClassificationInput(headline=item.headline),
+                expected=ClassificationExpected(is_violent_death=item.is_violent_death),
+                metadata=CaseMetadata(notes=item.notes),
+            )
+        )
+
+    fixture = ClassificationFixture(
+        meta=FixtureMeta(generator_model=model),
+        cases=cases,
+    )
+
+    update_fixture_counts(fixture)
+    return dump_fixture(fixture)
+
+
+def write_hard_fixture(out_path: Path, model: str = GENERATOR_MODEL) -> tuple[Path, int, int]:
+    generated = generate_hard_cases(model=model)
+    fixture_dict = to_fixture(generated, model=model)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(fixture_dict, ensure_ascii=False, indent=2))
+    true_count = sum(1 for c in generated.cases if c.is_violent_death)
+    false_count = len(generated.cases) - true_count
+    return out_path, true_count, false_count

--- a/backend/eval/stages/classification/run.py
+++ b/backend/eval/stages/classification/run.py
@@ -1,0 +1,202 @@
+"""Run classification eval against a labeled fixture."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+from eval.schemas import CaseResult, RunMeta, RunReport, utc_now_iso
+from eval.stages.classification.score import score_case_results
+from eval.stages.classification.validate import labeled_cases, validate_fixture
+from eval.variants import ClassificationVariant, load_classification_variant
+
+
+def _resolve_model(variant: ClassificationVariant) -> str:
+    from app.config import get_settings
+
+    if variant.selection_model:
+        return variant.selection_model
+    return get_settings().selection_model
+
+
+def _run_one_case(
+    case,
+    variant: ClassificationVariant,
+) -> CaseResult:
+    from app.config import get_settings
+    from app.services.classification import classify_headline
+
+    start = time.perf_counter()
+    try:
+        result = classify_headline(
+            case.input.headline,
+            system_prompt=variant.system_prompt,
+            model=variant.selection_model,
+        )
+        latency_ms = int((time.perf_counter() - start) * 1000)
+        expected = case.expected.is_violent_death
+        actual = result.is_violent_death
+        return CaseResult(
+            id=case.id,
+            passed=expected == actual,
+            expected=expected,
+            actual=actual,
+            confidence=result.confidence,
+            reasoning=result.reasoning,
+            headline=case.input.headline,
+            tags=case.tags,
+            latency_ms=latency_ms,
+        )
+    except Exception as e:
+        latency_ms = int((time.perf_counter() - start) * 1000)
+        expected = case.expected.is_violent_death if case.expected else None
+        return CaseResult(
+            id=case.id,
+            passed=False,
+            expected=expected,
+            actual=None,
+            headline=case.input.headline,
+            tags=case.tags,
+            latency_ms=latency_ms,
+            error=str(e),
+        )
+
+
+async def run_classification_eval(
+    fixture,
+    *,
+    variant_name: str = "baseline",
+    concurrency: int = 5,
+    limit: int | None = None,
+    case_ids: set[str] | None = None,
+    fail_fast: bool = False,
+    dry_run: bool = False,
+    fixture_path: str = "",
+) -> RunReport:
+    validation = validate_fixture(fixture)
+    if not validation.valid:
+        raise ValueError("Fixture validation failed; fix issues before running eval")
+
+    cases = labeled_cases(fixture)
+    if case_ids:
+        cases = [c for c in cases if c.id in case_ids]
+    if limit is not None:
+        cases = cases[:limit]
+
+    variant = load_classification_variant(variant_name)
+    model = _resolve_model(variant)
+
+    if dry_run:
+        summary = score_case_results([])
+        summary.total = len(cases)
+        return RunReport(
+            meta=RunMeta(
+                variant=variant_name,
+                model=model,
+                fixture=fixture_path,
+                run_at=utc_now_iso(),
+                dry_run=True,
+            ),
+            summary=summary,
+            cases=[],
+        )
+
+    from app.config import get_settings
+
+    if not get_settings().gemini_api_key:
+        raise ValueError("GEMINI_API_KEY not configured")
+
+    sem = asyncio.Semaphore(concurrency)
+
+    async def worker(case):
+        async with sem:
+            return await asyncio.to_thread(_run_one_case, case, variant)
+
+    tasks = [worker(case) for case in cases]
+    if fail_fast:
+        results = []
+        for task in tasks:
+            result = await task
+            results.append(result)
+            if not result.passed:
+                break
+    else:
+        results = list(await asyncio.gather(*tasks))
+
+    summary = score_case_results(results)
+    return RunReport(
+        meta=RunMeta(
+            variant=variant_name,
+            model=model,
+            fixture=fixture_path,
+            run_at=utc_now_iso(),
+        ),
+        summary=summary,
+        cases=results,
+    )
+
+
+def write_report(report: RunReport, output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(report.model_dump(mode="json"), ensure_ascii=False, indent=2))
+
+
+def default_output_path(variant: str) -> Path:
+    ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    return Path(__file__).resolve().parents[2] / "results" / f"classification-{variant}-{ts}.json"
+
+
+def print_report(report: RunReport) -> None:
+    s = report.summary
+    print(f"\n=== RUN: classification ({report.meta.variant}) ===")
+    print(f"  model: {report.meta.model}")
+    print(f"  fixture: {report.meta.fixture}")
+    if report.meta.dry_run:
+        print(f"  dry-run: {s.total} labeled cases would run")
+        return
+
+    print(f"  passed: {s.passed}/{s.total} ({_pct(s.accuracy)})")
+    print(f"  precision: {_pct(s.precision)}, recall: {_pct(s.recall)}, f1: {_pct(s.f1)}")
+    if s.errors:
+        print(f"  errors: {s.errors}")
+
+    if s.by_tag:
+        print("  by tag:")
+        for tag, stats in s.by_tag.items():
+            print(f"    {tag}: {stats['passed']}/{stats['total']} ({_pct(stats['accuracy'])})")
+
+    false_positives = [
+        r for r in report.cases if r.error is None and r.expected is False and r.actual is True
+    ]
+    false_negatives = [
+        r for r in report.cases if r.error is None and r.expected is True and r.actual is False
+    ]
+
+    if false_positives:
+        print(f"\n  false positives ({len(false_positives)}):")
+        for r in false_positives[:10]:
+            print(f"    - {r.id}: \"{r.headline[:70] if r.headline else ''}\"")
+            if r.reasoning:
+                print(f"      {r.reasoning[:120]}")
+
+    if false_negatives:
+        print(f"\n  false negatives ({len(false_negatives)}):")
+        for r in false_negatives[:10]:
+            print(f"    - {r.id}: \"{r.headline[:70] if r.headline else ''}\"")
+            if r.reasoning:
+                print(f"      {r.reasoning[:120]}")
+
+    if s.errors:
+        print(f"\n  case errors ({s.errors}):")
+        for r in report.cases:
+            if r.error:
+                print(f"    - {r.id}: {r.error}")
+
+
+def _pct(value: float | None) -> str:
+    if value is None:
+        return "n/a"
+    return f"{value * 100:.1f}%"

--- a/backend/eval/stages/classification/score.py
+++ b/backend/eval/stages/classification/score.py
@@ -1,0 +1,69 @@
+"""Score classification eval results."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Iterable
+
+from eval.schemas import CaseResult, RunSummary
+
+
+def score_case_results(results: Iterable[CaseResult]) -> RunSummary:
+    results_list = list(results)
+    total = len(results_list)
+    passed = sum(1 for r in results_list if r.passed)
+    failed = sum(1 for r in results_list if not r.passed and r.error is None)
+    errors = sum(1 for r in results_list if r.error is not None)
+
+    tp = fp = fn = 0
+    for r in results_list:
+        if r.error is not None or r.expected is None or r.actual is None:
+            continue
+        if r.expected and r.actual:
+            tp += 1
+        elif not r.expected and r.actual:
+            fp += 1
+        elif r.expected and not r.actual:
+            fn += 1
+
+    precision = tp / (tp + fp) if (tp + fp) else None
+    recall = tp / (tp + fn) if (tp + fn) else None
+    if precision is not None and recall is not None and (precision + recall):
+        f1 = 2 * precision * recall / (precision + recall)
+    else:
+        f1 = None
+
+    accuracy = passed / total if total else None
+    by_tag = _by_tag_accuracy(results_list)
+
+    return RunSummary(
+        total=total,
+        passed=passed,
+        failed=failed,
+        errors=errors,
+        accuracy=accuracy,
+        precision=precision,
+        recall=recall,
+        f1=f1,
+        by_tag=by_tag,
+    )
+
+
+def _by_tag_accuracy(results: list[CaseResult]) -> dict[str, dict]:
+    tag_stats: dict[str, dict[str, int]] = defaultdict(lambda: {"total": 0, "passed": 0})
+    for r in results:
+        for tag in r.tags:
+            tag_stats[tag]["total"] += 1
+            if r.passed:
+                tag_stats[tag]["passed"] += 1
+
+    by_tag: dict[str, dict] = {}
+    for tag, stats in sorted(tag_stats.items()):
+        total = stats["total"]
+        passed = stats["passed"]
+        by_tag[tag] = {
+            "total": total,
+            "passed": passed,
+            "accuracy": passed / total if total else None,
+        }
+    return by_tag

--- a/backend/eval/stages/classification/validate.py
+++ b/backend/eval/stages/classification/validate.py
@@ -1,0 +1,69 @@
+"""Validate classification fixture files."""
+
+from __future__ import annotations
+
+from eval.schemas import ClassificationCase, ClassificationFixture, ValidationIssue, ValidationResult
+
+
+def validate_fixture(fixture: ClassificationFixture) -> ValidationResult:
+    issues: list[ValidationIssue] = []
+    seen_ids: set[str] = set()
+
+    for case in fixture.cases:
+        if case.id in seen_ids:
+            issues.append(ValidationIssue(case_id=case.id, message="duplicate case id"))
+        seen_ids.add(case.id)
+
+        if not case.input.headline.strip():
+            issues.append(ValidationIssue(case_id=case.id, message="empty headline"))
+
+        if case.label_status == "labeled":
+            if case.expected is None:
+                issues.append(
+                    ValidationIssue(
+                        case_id=case.id,
+                        message="labeled case missing expected.is_violent_death",
+                    )
+                )
+        elif case.label_status == "pending":
+            if case.expected is not None:
+                issues.append(
+                    ValidationIssue(
+                        case_id=case.id,
+                        message="pending case should have expected=null",
+                    )
+                )
+
+    labeled = sum(1 for c in fixture.cases if c.label_status == "labeled")
+    pending = sum(1 for c in fixture.cases if c.label_status == "pending")
+
+    blocking = [i for i in issues if "duplicate" in i.message or "empty headline" in i.message]
+    return ValidationResult(
+        valid=len(blocking) == 0,
+        labeled_count=labeled,
+        pending_count=pending,
+        issues=issues,
+    )
+
+
+def labeled_cases(fixture: ClassificationFixture) -> list[ClassificationCase]:
+    return [
+        c
+        for c in fixture.cases
+        if c.label_status == "labeled" and c.expected is not None
+    ]
+
+
+def print_validation(result: ValidationResult, fixture_path: str) -> None:
+    print(f"\n=== VALIDATE: {fixture_path} ===")
+    print(f"  labeled: {result.labeled_count}, pending: {result.pending_count}")
+    if result.valid:
+        print("  schema: OK")
+    else:
+        print("  schema: INVALID")
+
+    if result.issues:
+        print(f"  issues ({len(result.issues)}):")
+        for issue in result.issues:
+            prefix = issue.case_id or "fixture"
+            print(f"    - [{prefix}] {issue.message}")

--- a/backend/eval/variants.py
+++ b/backend/eval/variants.py
@@ -1,0 +1,49 @@
+"""Load variant YAML configs for eval runs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+
+VARIANTS_DIR = Path(__file__).resolve().parent / "variants"
+
+
+@dataclass
+class ClassificationVariant:
+    name: str
+    selection_model: str | None = None
+    system_prompt: str | None = None
+
+
+def _variants_dir() -> Path:
+    return VARIANTS_DIR
+
+
+def load_classification_variant(name: str) -> ClassificationVariant:
+    """Load variant config from eval/variants/{name}.yaml."""
+    if name == "baseline":
+        return ClassificationVariant(name="baseline")
+
+    path = _variants_dir() / f"{name}.yaml"
+    if not path.exists():
+        raise FileNotFoundError(
+            f"Variant config not found: {path}. "
+            f"Copy proposed.example.yaml to {name}.yaml and edit."
+        )
+
+    raw = yaml.safe_load(path.read_text()) or {}
+    system_prompt: str | None = None
+    prompt_file = raw.get("system_prompt_file")
+    if prompt_file:
+        prompt_path = path.parent / prompt_file
+        if not prompt_path.exists():
+            raise FileNotFoundError(f"system_prompt_file not found: {prompt_path}")
+        system_prompt = prompt_path.read_text()
+
+    return ClassificationVariant(
+        name=name,
+        selection_model=raw.get("selection_model"),
+        system_prompt=system_prompt,
+    )

--- a/backend/eval/variants/baseline.yaml
+++ b/backend/eval/variants/baseline.yaml
@@ -1,0 +1,2 @@
+# Baseline uses production classification prompt and selection_model.
+stage: classification

--- a/backend/eval/variants/proposed.example.yaml
+++ b/backend/eval/variants/proposed.example.yaml
@@ -1,0 +1,4 @@
+# Copy to proposed.yaml and edit for prompt/model experiments.
+stage: classification
+selection_model: gemini-2.5-flash-lite
+# system_prompt_file: proposed_prompt.txt

--- a/backend/tests/fixtures/eval/classification_hard.json
+++ b/backend/tests/fixtures/eval/classification_hard.json
@@ -1,0 +1,558 @@
+{
+  "meta": {
+    "stage": "classification",
+    "version": 1,
+    "source_db": null,
+    "seed": null,
+    "labeled_count": 30,
+    "pending_count": 0,
+    "generator_model": "gemini-3.1-pro-preview"
+  },
+  "cases": [
+    {
+      "id": "cls-hard-001",
+      "tags": [
+        "metaphor_or_fiction",
+        "subtle_false"
+      ],
+      "label_status": "labeled",
+      "input": {
+        "headline": "O assassinato da língua portuguesa pelo Enem virou piada nas redes."
+      },
+      "expected": {
+        "is_violent_death": false
+      },
+      "metadata": {
+        "source_id": null,
+        "notes": "Usa a palavra 'assassinato' explicitamente, mas em um contexto puramente figurativo."
+      }
+    },
+    {
+      "id": "cls-hard-002",
+      "tags": [
+        "implied_death",
+        "subtle_true"
+      ],
+      "label_status": "labeled",
+      "input": {
+        "headline": "Saco com restos mortais é deixado em porta de delegacia na Baixada."
+      },
+      "expected": {
+        "is_violent_death": true
+      },
+      "metadata": {
+        "source_id": null,
+        "notes": "A expressão 'restos mortais deixado' indica desova de corpo, uma clara morte violenta implícita."
+      }
+    },
+    {
+      "id": "cls-hard-003",
+      "tags": [
+        "police_op_ambiguous",
+        "explicit_non_death"
+      ],
+      "label_status": "labeled",
+      "input": {
+        "headline": "Bope troca tiros com traficantes no Jacarezinho; caveirão é acionado."
+      },
+      "expected": {
+        "is_violent_death": false
+      },
+      "metadata": {
+        "source_id": null,
+        "notes": "Houve intenso tiroteio (violência armada), mas sem nenhuma menção a mortos ou feridos."
+      }
+    },
+    {
+      "id": "cls-hard-004",
+      "tags": [
+        "police_op_ambiguous",
+        "implied_death",
+        "subtle_true"
+      ],
+      "label_status": "labeled",
+      "input": {
+        "headline": "Confronto em comunidade termina com um neutralizado e três fuzis apreendidos."
+      },
+      "expected": {
+        "is_violent_death": true
+      },
+      "metadata": {
+        "source_id": null,
+        "notes": "Usa o jargão policial 'neutralizado' para indicar que um suspeito foi morto no confronto."
+      }
+    },
+    {
+      "id": "cls-hard-005",
+      "tags": [
+        "legal_process",
+        "victim_status_unclear",
+        "subtle_false"
+      ],
+      "label_status": "labeled",
+      "input": {
+        "headline": "Vítima de 15 facadas chora ao ver ex-marido sentar no banco dos réus."
+      },
+      "expected": {
+        "is_violent_death": false
+      },
+      "metadata": {
+        "source_id": null,
+        "notes": "A manchete relata extrema violência ('15 facadas') e um processo legal, mas a vítima sobreviveu."
+      }
+    },
+    {
+      "id": "cls-hard-006",
+      "tags": [
+        "implied_death",
+        "subtle_true"
+      ],
+      "label_status": "labeled",
+      "input": {
+        "headline": "Após sequestro, empresário é achado carbonizado no porta-malas de seu veículo."
+      },
+      "expected": {
+        "is_violent_death": true
+      },
+      "metadata": {
+        "source_id": null,
+        "notes": "Não usa as palavras 'morte' ou 'assassinato', mas 'carbonizado no porta-malas' é prova incontestável de morte violenta."
+      }
+    },
+    {
+      "id": "cls-hard-007",
+      "tags": [
+        "accident_vs_violent",
+        "subtle_false"
+      ],
+      "label_status": "labeled",
+      "input": {
+        "headline": "Caminhão perde freio na Dutra e motorista perde a vida preso às ferragens."
+      },
+      "expected": {
+        "is_violent_death": false
+      },
+      "metadata": {
+        "source_id": null,
+        "notes": "Menciona morte de forma explícita ('perde a vida'), porém trata-se de acidente de trânsito culposo, não homicídio."
+      }
+    },
+    {
+      "id": "cls-hard-008",
+      "tags": [
+        "legal_process",
+        "subtle_true"
+      ],
+      "label_status": "labeled",
+      "input": {
+        "headline": "Após confessar duplo homicídio, criminoso leva polícia ao local onde ocultou os corpos."
+      },
+      "expected": {
+        "is_violent_death": true
+      },
+      "metadata": {
+        "source_id": null,
+        "notes": "Foca no processo legal (confissão), mas confirma a ocorrência de um assassinato múltiplo."
+      }
+    },
+    {
+      "id": "cls-hard-009",
+      "tags": [
+        "explicit_non_death",
+        "victim_status_unclear",
+        "subtle_false"
+      ],
+      "label_status": "labeled",
+      "input": {
+        "headline": "Jovem baleado na cabeça durante assalto a padaria tem quadro estável no hospital."
+      },
+      "expected": {
+        "is_violent_death": false
+      },
+      "metadata": {
+        "source_id": null,
+        "notes": "Ação incrivelmente violenta ('baleado na cabeça' num assalto), mas não houve óbito."
+      }
+    },
+    {
+      "id": "cls-hard-010",
+      "tags": [
+        "subtle_true"
+      ],
+      "label_status": "labeled",
+      "input": {
+        "headline": "Feminicídio: ex-companheiro não aceita término e dispara contra professora."
+      },
+      "expected": {
+        "is_violent_death": true
+      },
+      "metadata": {
+        "source_id": null,
+        "notes": "A palavra 'dispara' sozinha poderia ser tentativa, mas a tag 'Feminicídio' no início garante que houve morte."
+      }
+    },
+    {
+      "id": "cls-hard-011",
+      "tags": [
+        "foreign_or_offtopic",
+        "legal_process"
+      ],
+      "label_status": "labeled",
+      "input": {
+        "headline": "Atirador em massa de escola no Texas recebe pena de morte nos EUA."
+      },
+      "expected": {
+        "is_violent_death": false
+      },
+      "metadata": {
+        "source_id": null,
+        "notes": "Menciona tiroteio em massa e pena de morte, mas o evento ocorreu fora do Brasil."
+      }
+    },
+    {
+      "id": "cls-hard-012",
+      "tags": [
+        "accident_vs_violent",
+        "subtle_true"
+      ],
+      "label_status": "labeled",
+      "input": {
+        "headline": "Laudo aponta que suposto atropelamento acidental foi, na verdade, homicídio doloso."
+      },
+      "expected": {
+        "is_violent_death": true
+      },
+      "metadata": {
+        "source_id": null,
+        "notes": "Reverte a premissa de um acidente, revelando tratar-se de um assassinato intencional."
+      }
+    },
+    {
+      "id": "cls-hard-013",
+      "tags": [
+        "metaphor_or_fiction",
+        "subtle_false"
+      ],
+      "label_status": "labeled",
+      "input": {
+        "headline": "Inflação e juros altos executam o orçamento das famílias de baixa renda."
+      },
+      "expected": {
+        "is_violent_death": false
+      },
+      "metadata": {
+        "source_id": null,
+        "notes": "O termo 'executam' simula um assassinato, mas refere-se metaforicamente à economia."
+      }
+    },
+    {
+      "id": "cls-hard-014",
+      "tags": [
+        "implied_death",
+        "subtle_true"
+      ],
+      "label_status": "labeled",
+      "input": {
+        "headline": "Ataque a tiros em bar deixa dois CPFs cancelados na zona sul."
+      },
+      "expected": {
+        "is_violent_death": true
+      },
+      "metadata": {
+        "source_id": null,
+        "notes": "Usa a gíria 'CPFs cancelados' para noticiar uma execução a tiros, comum na linguagem popular e policial."
+      }
+    },
+    {
+      "id": "cls-hard-015",
+      "tags": [
+        "legal_process",
+        "explicit_non_death",
+        "subtle_false"
+      ],
+      "label_status": "labeled",
+      "input": {
+        "headline": "Polícia Federal cumpre mandados contra grupo de extermínio no nordeste."
+      },
+      "expected": {
+        "is_violent_death": false
+      },
+      "metadata": {
+        "source_id": null,
+        "notes": "Menciona um 'grupo de extermínio' (que mata pessoas), mas a notícia é estritamente sobre a operação de busca/prisão."
+      }
+    },
+    {
+      "id": "cls-hard-016",
+      "tags": [
+        "implied_death",
+        "subtle_true"
+      ],
+      "label_status": "labeled",
+      "input": {
+        "headline": "Reagiu ao assalto: universitário não entrega o celular e é crivado de balas."
+      },
+      "expected": {
+        "is_violent_death": true
+      },
+      "metadata": {
+        "source_id": null,
+        "notes": "Descreve um óbvio latrocínio. 'Crivado de balas' aponta para letalidade extrema da violência armada."
+      }
+    },
+    {
+      "id": "cls-hard-017",
+      "tags": [
+        "accident_vs_violent",
+        "subtle_false"
+      ],
+      "label_status": "labeled",
+      "input": {
+        "headline": "Pedreiro tem morte instantânea após cair do 5º andar de obra por falta de EPI."
+      },
+      "expected": {
+        "is_violent_death": false
+      },
+      "metadata": {
+        "source_id": null,
+        "notes": "Uma morte brutal e explícita, porém classifica-se como acidente de trabalho, não morte violenta intencional/homicídio."
+      }
+    },
+    {
+      "id": "cls-hard-018",
+      "tags": [
+        "police_op_ambiguous",
+        "implied_death",
+        "subtle_true"
+      ],
+      "label_status": "labeled",
+      "input": {
+        "headline": "Operação Escudo: sobe para 14 o número de suspeitos que tombaram na Baixada."
+      },
+      "expected": {
+        "is_violent_death": true
+      },
+      "metadata": {
+        "source_id": null,
+        "notes": "Usa o eufemismo 'tombaram' no contexto de operação policial, indicando mortes em confronto."
+      }
+    },
+    {
+      "id": "cls-hard-019",
+      "tags": [
+        "metaphor_or_fiction",
+        "subtle_false"
+      ],
+      "label_status": "labeled",
+      "input": {
+        "headline": "No último capítulo da novela, vilã planeja o assassinato do rival com veneno."
+      },
+      "expected": {
+        "is_violent_death": false
+      },
+      "metadata": {
+        "source_id": null,
+        "notes": "Contém a palavra 'assassinato', mas descreve explicitamente uma obra de ficção/entretenimento."
+      }
+    },
+    {
+      "id": "cls-hard-020",
+      "tags": [
+        "implied_death",
+        "subtle_true"
+      ],
+      "label_status": "labeled",
+      "input": {
+        "headline": "Desova: pescadores relatam ter visto lancha jogando corpo amarrado no mar."
+      },
+      "expected": {
+        "is_violent_death": true
+      },
+      "metadata": {
+        "source_id": null,
+        "notes": "Palavras como 'desova' e 'corpo amarrado' são fortíssimos indicadores de ocultação de cadáver por homicídio."
+      }
+    },
+    {
+      "id": "cls-hard-021",
+      "tags": [
+        "police_op_ambiguous",
+        "explicit_non_death"
+      ],
+      "label_status": "labeled",
+      "input": {
+        "headline": "Rocam persegue dupla em moto roubada; suspeitos perdem o controle e são presos."
+      },
+      "expected": {
+        "is_violent_death": false
+      },
+      "metadata": {
+        "source_id": null,
+        "notes": "Trata de perseguição e crime, mas não houve morte, apenas acidente leve seguido de prisão."
+      }
+    },
+    {
+      "id": "cls-hard-022",
+      "tags": [
+        "implied_death",
+        "subtle_true"
+      ],
+      "label_status": "labeled",
+      "input": {
+        "headline": "Vingança do tráfico: facção divulga vídeo de execução brutal de informante."
+      },
+      "expected": {
+        "is_violent_death": true
+      },
+      "metadata": {
+        "source_id": null,
+        "notes": "A notícia cobre a divulgação de um vídeo, mas confirma indiretamente que ocorreu um homicídio brutal."
+      }
+    },
+    {
+      "id": "cls-hard-023",
+      "tags": [
+        "explicit_non_death",
+        "victim_status_unclear",
+        "subtle_false"
+      ],
+      "label_status": "labeled",
+      "input": {
+        "headline": "Atentado a faca em praça pública termina com três pessoas no centro cirúrgico."
+      },
+      "expected": {
+        "is_violent_death": false
+      },
+      "metadata": {
+        "source_id": null,
+        "notes": "Citação de um ataque violento ('atentado a faca'), porém os feridos estão em cirurgia (não relata morte)."
+      }
+    },
+    {
+      "id": "cls-hard-024",
+      "tags": [
+        "implied_death",
+        "subtle_true"
+      ],
+      "label_status": "labeled",
+      "input": {
+        "headline": "Chacina na madrugada: bando encapuzado invade residência e não deixa sobreviventes."
+      },
+      "expected": {
+        "is_violent_death": true
+      },
+      "metadata": {
+        "source_id": null,
+        "notes": "O termo 'chacina' e a frase 'não deixa sobreviventes' apontam para múltiplas vítimas de execução letal."
+      }
+    },
+    {
+      "id": "cls-hard-025",
+      "tags": [
+        "accident_vs_violent",
+        "subtle_false"
+      ],
+      "label_status": "labeled",
+      "input": {
+        "headline": "Idoso morre após sofrer infarto fulminante ao presenciar assalto em sua loja."
+      },
+      "expected": {
+        "is_violent_death": false
+      },
+      "metadata": {
+        "source_id": null,
+        "notes": "Houve um crime e uma morte, mas a causa mortis foi médica (infarto), não a violência direta dos criminosos."
+      }
+    },
+    {
+      "id": "cls-hard-026",
+      "tags": [
+        "implied_death",
+        "subtle_true"
+      ],
+      "label_status": "labeled",
+      "input": {
+        "headline": "Amarrado a um poste, suspeito de estupro é linchado até parar de respirar."
+      },
+      "expected": {
+        "is_violent_death": true
+      },
+      "metadata": {
+        "source_id": null,
+        "notes": "Descreve um justiçamento popular fatal, usando 'até parar de respirar' para implicar a morte por espancamento."
+      }
+    },
+    {
+      "id": "cls-hard-027",
+      "tags": [
+        "foreign_or_offtopic",
+        "explicit_non_death"
+      ],
+      "label_status": "labeled",
+      "input": {
+        "headline": "Ataque com drones em base militar russa deixa dezenas de soldados mortos."
+      },
+      "expected": {
+        "is_violent_death": false
+      },
+      "metadata": {
+        "source_id": null,
+        "notes": "Trata-se de mortes violentas por conflito armado, mas ocorre na Rússia (guerra no exterior), irrelevante para o filtro BR."
+      }
+    },
+    {
+      "id": "cls-hard-028",
+      "tags": [
+        "victim_status_unclear",
+        "subtle_true"
+      ],
+      "label_status": "labeled",
+      "input": {
+        "headline": "Baleado no peito em emboscada, sargento não resiste aos ferimentos no bloco cirúrgico."
+      },
+      "expected": {
+        "is_violent_death": true
+      },
+      "metadata": {
+        "source_id": null,
+        "notes": "O início da manchete foca no ferimento, mas o fim usa a expressão 'não resiste' para confirmar a morte da vítima."
+      }
+    },
+    {
+      "id": "cls-hard-029",
+      "tags": [
+        "subtle_false",
+        "explicit_non_death"
+      ],
+      "label_status": "labeled",
+      "input": {
+        "headline": "Polícia Civil apreende arsenal que seria usado para cometer série de assassinatos."
+      },
+      "expected": {
+        "is_violent_death": false
+      },
+      "metadata": {
+        "source_id": null,
+        "notes": "Possui a palavra forte 'assassinatos', mas o crime foi frustrado; trata-se de apreensão de armas."
+      }
+    },
+    {
+      "id": "cls-hard-030",
+      "tags": [
+        "implied_death",
+        "subtle_true"
+      ],
+      "label_status": "labeled",
+      "input": {
+        "headline": "Ossada humana com marca de tiro no crânio é descoberta em área de mata."
+      },
+      "expected": {
+        "is_violent_death": true
+      },
+      "metadata": {
+        "source_id": null,
+        "notes": "Não diz 'assassinato' nem 'morte', mas o achado de ossada e uma 'marca de tiro' evidenciam execução passada."
+      }
+    }
+  ]
+}

--- a/backend/tests/fixtures/eval/classification_seed.json
+++ b/backend/tests/fixtures/eval/classification_seed.json
@@ -1,0 +1,252 @@
+{
+  "meta": {
+    "stage": "classification",
+    "version": 1,
+    "source_db": null,
+    "seed": null,
+    "labeled_count": 30,
+    "pending_count": 0
+  },
+  "cases": [
+    {
+      "id": "cls-seed-001",
+      "tags": ["clear_true", "explicit_death"],
+      "label_status": "labeled",
+      "input": { "headline": "Tiroteio deixa dois mortos na Zona Norte do Rio" },
+      "expected": { "is_violent_death": true },
+      "metadata": { "source_id": null, "notes": "" }
+    },
+    {
+      "id": "cls-seed-002",
+      "tags": ["clear_true", "explicit_death"],
+      "label_status": "labeled",
+      "input": { "headline": "Homem é morto a tiros em operação policial no Complexo da Maré" },
+      "expected": { "is_violent_death": true },
+      "metadata": { "source_id": null, "notes": "" }
+    },
+    {
+      "id": "cls-seed-003",
+      "tags": ["clear_true", "explicit_death"],
+      "label_status": "labeled",
+      "input": { "headline": "Mulher é assassinada pelo ex-marido em Niterói" },
+      "expected": { "is_violent_death": true },
+      "metadata": { "source_id": null, "notes": "" }
+    },
+    {
+      "id": "cls-seed-004",
+      "tags": ["clear_true", "explicit_death"],
+      "label_status": "labeled",
+      "input": { "headline": "Corpo é encontrado com marcas de violência em terreno baldio na Baixada" },
+      "expected": { "is_violent_death": true },
+      "metadata": { "source_id": null, "notes": "" }
+    },
+    {
+      "id": "cls-seed-005",
+      "tags": ["clear_true", "explicit_death"],
+      "label_status": "labeled",
+      "input": { "headline": "Jovem é executado a tiros na porta de casa em São Gonçalo" },
+      "expected": { "is_violent_death": true },
+      "metadata": { "source_id": null, "notes": "" }
+    },
+    {
+      "id": "cls-seed-006",
+      "tags": ["clear_true", "explicit_death"],
+      "label_status": "labeled",
+      "input": { "headline": "Feminicídio: mulher é morta a facadas pelo companheiro em Duque de Caxias" },
+      "expected": { "is_violent_death": true },
+      "metadata": { "source_id": null, "notes": "" }
+    },
+    {
+      "id": "cls-seed-007",
+      "tags": ["clear_true", "explicit_death"],
+      "label_status": "labeled",
+      "input": { "headline": "Latrocínio termina com morte de comerciante na Zona Oeste" },
+      "expected": { "is_violent_death": true },
+      "metadata": { "source_id": null, "notes": "" }
+    },
+    {
+      "id": "cls-seed-008",
+      "tags": ["clear_true", "explicit_death"],
+      "label_status": "labeled",
+      "input": { "headline": "Confronto entre traficantes deixa um morto em favela da Zona Sul" },
+      "expected": { "is_violent_death": true },
+      "metadata": { "source_id": null, "notes": "" }
+    },
+    {
+      "id": "cls-seed-009",
+      "tags": ["clear_false"],
+      "label_status": "labeled",
+      "input": { "headline": "Polícia prende suspeito de roubo a transeunte na Tijuca" },
+      "expected": { "is_violent_death": false },
+      "metadata": { "source_id": null, "notes": "" }
+    },
+    {
+      "id": "cls-seed-010",
+      "tags": ["clear_false"],
+      "label_status": "labeled",
+      "input": { "headline": "Operação apreende drogas e armas em comunidade da Zona Norte" },
+      "expected": { "is_violent_death": false },
+      "metadata": { "source_id": null, "notes": "" }
+    },
+    {
+      "id": "cls-seed-011",
+      "tags": ["clear_false"],
+      "label_status": "labeled",
+      "input": { "headline": "Governo anuncia nova política de segurança pública para o Rio" },
+      "expected": { "is_violent_death": false },
+      "metadata": { "source_id": null, "notes": "" }
+    },
+    {
+      "id": "cls-seed-012",
+      "tags": ["clear_false"],
+      "label_status": "labeled",
+      "input": { "headline": "PM prende quadrilha especializada em assaltos a bancos" },
+      "expected": { "is_violent_death": false },
+      "metadata": { "source_id": null, "notes": "" }
+    },
+    {
+      "id": "cls-seed-013",
+      "tags": ["clear_false"],
+      "label_status": "labeled",
+      "input": { "headline": "Secretaria de Segurança divulga balanço de apreensões no mês" },
+      "expected": { "is_violent_death": false },
+      "metadata": { "source_id": null, "notes": "" }
+    },
+    {
+      "id": "cls-seed-014",
+      "tags": ["clear_false"],
+      "label_status": "labeled",
+      "input": { "headline": "Homem é detido após tentativa de furto em supermercado" },
+      "expected": { "is_violent_death": false },
+      "metadata": { "source_id": null, "notes": "" }
+    },
+    {
+      "id": "cls-seed-015",
+      "tags": ["clear_false"],
+      "label_status": "labeled",
+      "input": { "headline": "Justiça mantém prisão de acusado de tráfico de drogas" },
+      "expected": { "is_violent_death": false },
+      "metadata": { "source_id": null, "notes": "" }
+    },
+    {
+      "id": "cls-seed-016",
+      "tags": ["clear_false"],
+      "label_status": "labeled",
+      "input": { "headline": "Forças de segurança realizam operação integrada sem registros de mortes" },
+      "expected": { "is_violent_death": false },
+      "metadata": { "source_id": null, "notes": "" }
+    },
+    {
+      "id": "cls-seed-017",
+      "tags": ["injured_not_dead"],
+      "label_status": "labeled",
+      "input": { "headline": "Dois feridos em tiroteio no Complexo da Maré" },
+      "expected": { "is_violent_death": false },
+      "metadata": { "source_id": null, "notes": "" }
+    },
+    {
+      "id": "cls-seed-018",
+      "tags": ["injured_not_dead"],
+      "label_status": "labeled",
+      "input": { "headline": "Homem sobrevive após ser baleado na Zona Norte" },
+      "expected": { "is_violent_death": false },
+      "metadata": { "source_id": null, "notes": "" }
+    },
+    {
+      "id": "cls-seed-019",
+      "tags": ["injured_not_dead"],
+      "label_status": "labeled",
+      "input": { "headline": "Três pessoas ficam feridas após confronto entre grupos rivais" },
+      "expected": { "is_violent_death": false },
+      "metadata": { "source_id": null, "notes": "" }
+    },
+    {
+      "id": "cls-seed-020",
+      "tags": ["injured_not_dead"],
+      "label_status": "labeled",
+      "input": { "headline": "Adolescente baleado é hospitalizado em estado grave" },
+      "expected": { "is_violent_death": false },
+      "metadata": { "source_id": null, "notes": "" }
+    },
+    {
+      "id": "cls-seed-021",
+      "tags": ["injured_not_dead"],
+      "label_status": "labeled",
+      "input": { "headline": "Motorista fica ferido após ser atingido por disparos na Avenida Brasil" },
+      "expected": { "is_violent_death": false },
+      "metadata": { "source_id": null, "notes": "" }
+    },
+    {
+      "id": "cls-seed-022",
+      "tags": ["injured_not_dead"],
+      "label_status": "labeled",
+      "input": { "headline": "Policial fica ferido durante troca de tiros em operação" },
+      "expected": { "is_violent_death": false },
+      "metadata": { "source_id": null, "notes": "" }
+    },
+    {
+      "id": "cls-seed-023",
+      "tags": ["ambiguous"],
+      "label_status": "labeled",
+      "input": { "headline": "Operação policial mobiliza tropas em favelas da Zona Norte" },
+      "expected": { "is_violent_death": false },
+      "metadata": { "source_id": null, "notes": "" }
+    },
+    {
+      "id": "cls-seed-024",
+      "tags": ["ambiguous"],
+      "label_status": "labeled",
+      "input": { "headline": "Tiroteio interrompe trânsito na Linha Vermelha" },
+      "expected": { "is_violent_death": false },
+      "metadata": { "source_id": null, "notes": "" }
+    },
+    {
+      "id": "cls-seed-025",
+      "tags": ["ambiguous"],
+      "label_status": "labeled",
+      "input": { "headline": "Confronto entre PM e suspeitos mobiliza equipes no Jacarezinho" },
+      "expected": { "is_violent_death": false },
+      "metadata": { "source_id": null, "notes": "" }
+    },
+    {
+      "id": "cls-seed-026",
+      "tags": ["ambiguous"],
+      "label_status": "labeled",
+      "input": { "headline": "Disparos são ouvidos durante operação em comunidade da Baixada" },
+      "expected": { "is_violent_death": false },
+      "metadata": { "source_id": null, "notes": "" }
+    },
+    {
+      "id": "cls-seed-027",
+      "tags": ["ambiguous"],
+      "label_status": "labeled",
+      "input": { "headline": "Moradores relatam intenso tiroteio na madrugada em Belford Roxo" },
+      "expected": { "is_violent_death": false },
+      "metadata": { "source_id": null, "notes": "" }
+    },
+    {
+      "id": "cls-seed-028",
+      "tags": ["edge_false_positive"],
+      "label_status": "labeled",
+      "input": { "headline": "Prefeito de São Paulo anuncia medidas contra violência urbana" },
+      "expected": { "is_violent_death": false },
+      "metadata": { "source_id": null, "notes": "Non-RJ / policy headline" }
+    },
+    {
+      "id": "cls-seed-029",
+      "tags": ["edge_false_positive"],
+      "label_status": "labeled",
+      "input": { "headline": "Série sobre morte de personagem movimenta redes sociais" },
+      "expected": { "is_violent_death": false },
+      "metadata": { "source_id": null, "notes": "Metaphorical / entertainment" }
+    },
+    {
+      "id": "cls-seed-030",
+      "tags": ["edge_false_positive"],
+      "label_status": "labeled",
+      "input": { "headline": "Acidente de trânsito deixa motorista morto na BR-101" },
+      "expected": { "is_violent_death": false },
+      "metadata": { "source_id": null, "notes": "Non-violent death (culposo / accident)" }
+    }
+  ]
+}

--- a/backend/tests/test_classification_filters.py
+++ b/backend/tests/test_classification_filters.py
@@ -1,0 +1,175 @@
+"""Tests for headline classification filters (AQV-31)."""
+
+from unittest.mock import patch
+
+import pytest
+
+from app.services.classification import (
+    ViolentDeathClassification,
+    classify_source,
+)
+
+
+class _TestSessionMaker:
+    """Route classification DB calls through the pytest async_session."""
+
+    def __init__(self, session):
+        self._session = session
+
+    def __call__(self):
+        return self
+
+    async def __aenter__(self):
+        return self._session
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+@pytest.fixture
+def classification_db(async_session):
+    maker = _TestSessionMaker(async_session)
+    with patch("app.services.classification.async_session_maker", maker):
+        yield async_session
+
+
+def _source(**kwargs):
+    from app.models.source_google_news import SourceGoogleNews, SourceStatus
+
+    defaults = {
+        "google_news_id": "test-id",
+        "google_news_url": "https://news.example/article",
+        "headline": "Test headline",
+        "status": SourceStatus.classifying,
+    }
+    defaults.update(kwargs)
+    return SourceGoogleNews(**defaults)
+
+
+def _classification(**kwargs) -> ViolentDeathClassification:
+    defaults = {
+        "is_violent_death": True,
+        "is_single_incident": True,
+        "confidence": "alta",
+        "reasoning": "Incident headline",
+    }
+    defaults.update(kwargs)
+    return ViolentDeathClassification(**defaults)
+
+
+def test_schema_requires_single_incident_field():
+    result = ViolentDeathClassification(
+        is_violent_death=True,
+        is_single_incident=False,
+        confidence="alta",
+        reasoning="Aggregate stats headline",
+        content_class_hint="aggregate_statistics",
+    )
+    assert result.is_single_incident is False
+    assert result.content_class_hint == "aggregate_statistics"
+
+
+@pytest.mark.asyncio
+async def test_classify_source_passes_single_incident(classification_db):
+    from app.models.source_google_news import SourceStatus
+
+    source = _source(
+        google_news_id="pass-1",
+        headline="Homem é morto a tiros em operação policial no Rio",
+    )
+    classification_db.add(source)
+    await classification_db.commit()
+    await classification_db.refresh(source)
+
+    with patch(
+        "app.services.classification.classify_headline",
+        return_value=_classification(),
+    ):
+        result = await classify_source(source.id)
+
+    assert result is True
+    await classification_db.refresh(source)
+    assert source.status == SourceStatus.ready_for_download
+
+
+@pytest.mark.asyncio
+async def test_classify_source_discards_aggregate_headline(classification_db):
+    from app.models.source_google_news import SourceStatus
+
+    source = _source(
+        google_news_id="aggregate-1",
+        headline="CVLI: estado registra 4.241 mortes violentas em 2025",
+    )
+    classification_db.add(source)
+    await classification_db.commit()
+    await classification_db.refresh(source)
+
+    with patch(
+        "app.services.classification.classify_headline",
+        return_value=_classification(
+            is_single_incident=False,
+            content_class_hint="aggregate_statistics",
+            reasoning="Year-end statistics, not a single incident",
+        ),
+    ):
+        result = await classify_source(source.id)
+
+    assert result is False
+    await classification_db.refresh(source)
+    assert source.status == SourceStatus.discarded
+    assert "single_incident=false" in source.classification_reasoning
+
+
+@pytest.mark.asyncio
+async def test_classify_source_discards_foreign_disaster(classification_db):
+    from app.models.source_google_news import SourceStatus
+
+    source = _source(
+        google_news_id="foreign-1",
+        headline="Terremoto na Venezuela deixa centenas de mortos",
+    )
+    classification_db.add(source)
+    await classification_db.commit()
+    await classification_db.refresh(source)
+
+    with patch(
+        "app.services.classification.classify_headline",
+        return_value=_classification(
+            is_violent_death=True,
+            is_single_incident=False,
+            content_class_hint="foreign",
+            reasoning="Foreign disaster report",
+        ),
+    ):
+        result = await classify_source(source.id)
+
+    assert result is False
+    await classification_db.refresh(source)
+    assert source.status == SourceStatus.discarded
+
+
+@pytest.mark.asyncio
+async def test_classify_source_discards_non_violent_death(classification_db):
+    from app.models.source_google_news import SourceStatus
+
+    source = _source(
+        google_news_id="non-violent-1",
+        headline="Polícia prende suspeito de roubo",
+    )
+    classification_db.add(source)
+    await classification_db.commit()
+    await classification_db.refresh(source)
+
+    with patch(
+        "app.services.classification.classify_headline",
+        return_value=_classification(
+            is_violent_death=False,
+            is_single_incident=False,
+            reasoning="No death mentioned",
+        ),
+    ):
+        result = await classify_source(source.id)
+
+    assert result is False
+    await classification_db.refresh(source)
+    assert source.status == SourceStatus.discarded

--- a/backend/tests/test_dedup_title_blocking.py
+++ b/backend/tests/test_dedup_title_blocking.py
@@ -1,0 +1,134 @@
+"""Tests for dedup title fuzzy blocking (AQV-38)."""
+
+from datetime import datetime
+
+import pytest
+
+from app.services.enrichment import (
+    FUZZY_TITLE_THRESHOLD,
+    LLM_MATCH_CONFIDENCE_THRESHOLD,
+    TITLE_DATE_TOLERANCE_DAYS,
+    block_by_title_fuzzy,
+    fuzzy_title_match,
+    normalize_title,
+)
+
+
+def test_normalize_title_strips_accents_and_case():
+    assert normalize_title("  Homicídio em Juiz de Fora  ") == "homicidio em juiz de fora"
+
+
+def test_fuzzy_title_match_exact():
+    title = "Tiroteio deixa dois mortos na Zona Norte"
+    assert fuzzy_title_match(title, title)
+
+
+def test_fuzzy_title_match_similar_headlines():
+    a = "Homem é morto a tiros em operação policial no Rio"
+    b = "Homem morto a tiros em operacao policial no Rio de Janeiro"
+    assert fuzzy_title_match(a, b, threshold=0.85)
+
+
+def test_fuzzy_title_match_rejects_unrelated():
+    a = "CVLI: estado registra 4.241 mortes violentas em 2025"
+    b = "Homem é morto a tiros em operação policial no Rio"
+    assert not fuzzy_title_match(a, b, threshold=FUZZY_TITLE_THRESHOLD)
+
+
+def test_tuned_constants():
+    assert TITLE_DATE_TOLERANCE_DAYS == 3
+    assert FUZZY_TITLE_THRESHOLD == 0.85
+    assert LLM_MATCH_CONFIDENCE_THRESHOLD == 0.6
+
+
+@pytest.mark.asyncio
+async def test_block_by_title_fuzzy_finds_similar_event(async_session):
+    from app.models.unique_event import UniqueEvent
+    from app.models.raw_event import RawEvent
+
+    unique = UniqueEvent(
+        title="Tiroteio deixa dois mortos na Zona Norte do Rio",
+        event_date=datetime(2025, 1, 15),
+        city="Rio de Janeiro",
+        state="RJ",
+        victim_count=2,
+        source_count=1,
+    )
+    async_session.add(unique)
+    await async_session.commit()
+    await async_session.refresh(unique)
+
+    raw = RawEvent(
+        title="Tiroteio deixa 2 mortos na Zona Norte",
+        event_date=datetime(2025, 1, 16),
+        city="Rio de Janeiro",
+        state="RJ",
+        victim_count=2,
+        source_google_news_id=1,
+    )
+
+    from unittest.mock import patch
+
+    class _TestSessionMaker:
+        def __init__(self, session):
+            self._session = session
+
+        def __call__(self):
+            return self
+
+        async def __aenter__(self):
+            return self._session
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    with patch("app.services.enrichment.async_session_maker", _TestSessionMaker(async_session)):
+        candidates = await block_by_title_fuzzy(raw)
+
+    assert len(candidates) == 1
+    assert candidates[0].id == unique.id
+
+
+@pytest.mark.asyncio
+async def test_block_by_title_fuzzy_respects_date_window(async_session):
+    from app.models.unique_event import UniqueEvent
+    from app.models.raw_event import RawEvent
+    from unittest.mock import patch
+
+    unique = UniqueEvent(
+        title="Homicidio em Juiz de Fora deixa um morto",
+        event_date=datetime(2025, 1, 1),
+        city="Juiz de Fora",
+        state="MG",
+        victim_count=1,
+        source_count=1,
+    )
+    async_session.add(unique)
+    await async_session.commit()
+
+    raw = RawEvent(
+        title="Homicidio em Juiz de Fora deixa um morto",
+        event_date=datetime(2025, 1, 10),
+        city="Juiz de Fora",
+        state="MG",
+        victim_count=1,
+        source_google_news_id=1,
+    )
+
+    class _TestSessionMaker:
+        def __init__(self, session):
+            self._session = session
+
+        def __call__(self):
+            return self
+
+        async def __aenter__(self):
+            return self._session
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    with patch("app.services.enrichment.async_session_maker", _TestSessionMaker(async_session)):
+        candidates = await block_by_title_fuzzy(raw)
+
+    assert candidates == []

--- a/backend/tests/test_eval_classification.py
+++ b/backend/tests/test_eval_classification.py
@@ -1,0 +1,95 @@
+"""Tests for classification eval harness (no LLM)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from eval.schemas import CaseResult, load_fixture
+from eval.stages.classification.score import score_case_results
+from eval.stages.classification.validate import validate_fixture
+
+SEED_FIXTURE = (
+    Path(__file__).resolve().parent / "fixtures" / "eval" / "classification_seed.json"
+)
+HARD_FIXTURE = (
+    Path(__file__).resolve().parent / "fixtures" / "eval" / "classification_hard.json"
+)
+
+
+@pytest.fixture
+def seed_fixture():
+    return load_fixture(json.loads(SEED_FIXTURE.read_text()))
+
+
+def test_validate_seed_fixture(seed_fixture):
+    result = validate_fixture(seed_fixture)
+    assert result.valid is True
+    assert result.labeled_count == 30
+    assert result.pending_count == 0
+    assert result.issues == []
+
+
+def test_validate_hard_fixture():
+    fixture = load_fixture(json.loads(HARD_FIXTURE.read_text()))
+    result = validate_fixture(fixture)
+    assert result.valid is True
+    assert result.labeled_count == 30
+    assert result.pending_count == 0
+
+
+def test_validate_fails_on_labeled_without_expected():
+    data = json.loads(SEED_FIXTURE.read_text())
+    data["cases"][0]["expected"] = None
+    fixture = load_fixture(data)
+    result = validate_fixture(fixture)
+    assert any("missing expected" in issue.message for issue in result.issues)
+
+
+def test_validate_flags_pending_with_expected():
+    data = json.loads(SEED_FIXTURE.read_text())
+    data["cases"].append(
+        {
+            "id": "cls-pending-bad",
+            "tags": ["negative"],
+            "label_status": "pending",
+            "input": {"headline": "Test headline"},
+            "expected": {"is_violent_death": False},
+            "metadata": {"source_id": None, "notes": ""},
+        }
+    )
+    fixture = load_fixture(data)
+    result = validate_fixture(fixture)
+    assert any("pending case should have expected=null" in i.message for i in result.issues)
+
+
+def test_score_perfect_run():
+    results = [
+        CaseResult(id="a", passed=True, expected=True, actual=True, tags=["clear_true"]),
+        CaseResult(id="b", passed=True, expected=False, actual=False, tags=["clear_false"]),
+    ]
+    summary = score_case_results(results)
+    assert summary.total == 2
+    assert summary.passed == 2
+    assert summary.accuracy == 1.0
+    assert summary.precision == 1.0
+    assert summary.recall == 1.0
+    assert summary.f1 == 1.0
+    assert summary.by_tag["clear_true"]["accuracy"] == 1.0
+
+
+def test_score_false_positive_and_negative():
+    results = [
+        CaseResult(id="tp", passed=True, expected=True, actual=True),
+        CaseResult(id="fp", passed=False, expected=False, actual=True),
+        CaseResult(id="fn", passed=False, expected=True, actual=False),
+        CaseResult(id="tn", passed=True, expected=False, actual=False),
+    ]
+    summary = score_case_results(results)
+    assert summary.passed == 2
+    assert summary.accuracy == 0.5
+    assert summary.precision == 0.5
+    assert summary.recall == 0.5
+    assert summary.f1 == 0.5

--- a/backend/tests/test_export_streaming.py
+++ b/backend/tests/test_export_streaming.py
@@ -1,0 +1,39 @@
+"""Tests for streaming CSV export (row completeness)."""
+
+from datetime import datetime
+from decimal import Decimal
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import AsyncClient
+
+from app.models.unique_event import UniqueEvent
+
+
+@pytest.mark.asyncio
+async def test_export_csv_returns_all_geocoded_rows(app, async_session, client: AsyncClient):
+    """Streaming CSV path should include every matching row, not truncate early."""
+    for index in range(5):
+        async_session.add(
+            UniqueEvent(
+                title=f"Export event {index}",
+                event_date=datetime(2026, 1, index + 1),
+                state="RJ",
+                city="Rio de Janeiro",
+                latitude=Decimal("-22.9068"),
+                longitude=Decimal("-43.1729"),
+            )
+        )
+    await async_session.commit()
+
+    with patch(
+        "app.services.geocode_protection.enforce_export_rate_limit",
+        AsyncMock(return_value=None),
+    ):
+        response = await client.get("/api/public/events/export", params={"days": 3650})
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/csv")
+
+    lines = [line for line in response.text.splitlines() if line.strip()]
+    assert len(lines) == 6  # header + 5 data rows

--- a/backend/tests/test_extraction_validators.py
+++ b/backend/tests/test_extraction_validators.py
@@ -1,0 +1,132 @@
+"""Tests for extraction validators and security_force mapping (AQV-30)."""
+
+import pytest
+from pydantic import ValidationError
+
+from app.services.extraction import derive_security_force_involved
+from app.services.extraction_schemas import (
+    DateTime,
+    DateVerification,
+    HomicideDynamic,
+    IdentifiablePerpetrator,
+    IdentifiableVictim,
+    Location,
+    Perpetrators,
+    UnidentifiedVictimGroup,
+    Victims,
+    ViolentDeathEvent,
+)
+
+
+def _date_time(**kwargs) -> DateTime:
+    defaults = {
+        "date_verification": DateVerification(
+            has_explicit_date=False,
+            date_source="none",
+            year_explicitly_mentioned=False,
+            verification_reasoning="No date in text",
+        ),
+        "date": None,
+    }
+    defaults.update(kwargs)
+    return DateTime(**defaults)
+
+
+def _minimal_event(**victim_kwargs) -> ViolentDeathEvent:
+    victim_defaults = {
+        "identifiable_victims": [IdentifiableVictim(name="João")],
+        "number_of_identifiable_victims": 1,
+        "number_of_victims": 1,
+    }
+    victim_defaults.update(victim_kwargs)
+    victims = Victims(**victim_defaults)
+    return ViolentDeathEvent(
+        location_info=Location(city="Rio de Janeiro", state="RJ"),
+        date_time=_date_time(),
+        victims=victims,
+        homicide_dynamic=HomicideDynamic(
+            title="HOMICÍDIO - RIO DE JANEIRO - DATA NÃO INFORMADA",
+            homicide_type="Homicídio",
+            chronological_description="Vítima foi morta a tiros.",
+        ),
+    )
+
+
+def test_victims_rejects_count_above_20():
+    with pytest.raises(ValidationError):
+        Victims(
+            identifiable_victims=[],
+            number_of_identifiable_victims=0,
+            number_of_victims=21,
+        )
+
+
+def test_victims_rejects_mismatched_identifiable_count():
+    with pytest.raises(ValidationError, match="identifiable_victims list length"):
+        Victims(
+            identifiable_victims=[IdentifiableVictim(name="A")],
+            number_of_identifiable_victims=2,
+            number_of_victims=2,
+        )
+
+
+def test_victims_rejects_inconsistent_total():
+    with pytest.raises(ValidationError, match="number_of_victims"):
+        Victims(
+            identifiable_victims=[IdentifiableVictim(name="A")],
+            number_of_identifiable_victims=1,
+            unidentified_groups=[UnidentifiedVictimGroup(count=5, description="moradores")],
+            number_of_unidentified_victims=5,
+            number_of_victims=10,
+        )
+
+
+def test_victims_allows_tolerance_of_one():
+    victims = Victims(
+        identifiable_victims=[IdentifiableVictim(name="A"), IdentifiableVictim(name="B")],
+        number_of_identifiable_victims=2,
+        number_of_victims=3,
+    )
+    assert victims.number_of_victims == 3
+
+
+def test_derive_security_force_from_identifiable_victim():
+    event = _minimal_event()
+    event.victims.identifiable_victims[0].is_security_force = True
+    assert derive_security_force_involved(event) is True
+
+
+def test_derive_security_force_from_unidentified_group():
+    event = _minimal_event(
+        identifiable_victims=[],
+        number_of_identifiable_victims=0,
+        unidentified_groups=[
+            UnidentifiedVictimGroup(count=2, description="policiais", is_security_force=True)
+        ],
+        number_of_unidentified_victims=2,
+        number_of_victims=2,
+    )
+    assert derive_security_force_involved(event) is True
+
+
+def test_derive_security_force_from_perpetrator():
+    event = _minimal_event()
+    event.perpetrators = Perpetrators(
+        identifiable_perpetrators=[
+            IdentifiablePerpetrator(name="PM", is_security_force=True)
+        ],
+        number_of_identifiable_perpetrators=1,
+        number_of_perpetrators=1,
+    )
+    assert derive_security_force_involved(event) is True
+
+
+def test_derive_security_force_returns_none_when_unmentioned():
+    event = _minimal_event()
+    assert derive_security_force_involved(event) is None
+
+
+def test_derive_security_force_returns_false_when_explicitly_civilian():
+    event = _minimal_event()
+    event.victims.identifiable_victims[0].is_security_force = False
+    assert derive_security_force_involved(event) is False

--- a/backend/tests/test_public_filters.py
+++ b/backend/tests/test_public_filters.py
@@ -1,0 +1,122 @@
+"""Tests for public incident guardrail filters (AQV-29 Phase A)."""
+
+from datetime import datetime, timedelta
+from decimal import Decimal
+
+import pytest
+from httpx import AsyncClient
+from sqlmodel import select, func
+
+from app.models.unique_event import UniqueEvent
+from app.services.public_filters import BR_UFS, apply_public_incident_filter
+
+
+def _make_event(**kwargs) -> UniqueEvent:
+    defaults = {
+        "title": "Test event",
+        "event_date": datetime.utcnow() - timedelta(days=1),
+        "state": "RJ",
+        "city": "Rio de Janeiro",
+        "victim_count": 1,
+        "latitude": Decimal("-22.9068"),
+        "longitude": Decimal("-43.1729"),
+    }
+    defaults.update(kwargs)
+    return UniqueEvent(**defaults)
+
+
+@pytest.mark.asyncio
+async def test_filter_excludes_high_victim_count(async_session):
+    valid = _make_event(title="Valid", victim_count=10)
+    inflated = _make_event(title="Inflated", victim_count=11)
+    async_session.add(valid)
+    async_session.add(inflated)
+    await async_session.commit()
+
+    query = apply_public_incident_filter(select(func.count(UniqueEvent.id)))
+    result = await async_session.exec(query)
+    assert result.one() == 1
+
+
+@pytest.mark.asyncio
+async def test_filter_excludes_foreign_state(async_session):
+    br_event = _make_event(title="Brazil", state="SP")
+    foreign = _make_event(title="Foreign", state="US")
+    async_session.add(br_event)
+    async_session.add(foreign)
+    await async_session.commit()
+
+    query = apply_public_incident_filter(select(func.count(UniqueEvent.id)))
+    result = await async_session.exec(query)
+    assert result.one() == 1
+
+
+@pytest.mark.asyncio
+async def test_filter_includes_null_state(async_session):
+    event = _make_event(title="Unknown state", state=None)
+    async_session.add(event)
+    await async_session.commit()
+
+    query = apply_public_incident_filter(select(func.count(UniqueEvent.id)))
+    result = await async_session.exec(query)
+    assert result.one() == 1
+
+
+@pytest.mark.asyncio
+async def test_filter_excludes_null_victim_count(async_session):
+    event = _make_event(title="No count", victim_count=None)
+    async_session.add(event)
+    await async_session.commit()
+
+    query = apply_public_incident_filter(select(func.count(UniqueEvent.id)))
+    result = await async_session.exec(query)
+    assert result.one() == 0
+
+
+@pytest.mark.asyncio
+async def test_public_stats_excludes_inflated_rows(client: AsyncClient, async_session):
+    async_session.add(_make_event(title="Valid"))
+    async_session.add(_make_event(title="Inflated", victim_count=100))
+    async_session.add(_make_event(title="Foreign", state="MX"))
+    await async_session.commit()
+
+    response = await client.get("/api/public/stats")
+    assert response.status_code == 200
+    assert response.json()["total"] == 1
+
+
+@pytest.mark.asyncio
+async def test_map_points_excludes_inflated_rows(client: AsyncClient, async_session):
+    async_session.add(_make_event(title="Valid"))
+    async_session.add(_make_event(title="Inflated", victim_count=50))
+    await async_session.commit()
+
+    response = await client.get("/api/public/map-points?days=365")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_unique_events_stats_summary_excludes_inflated(async_session, app):
+    from app.database import get_session
+
+    async_session.add(_make_event(title="Valid", victim_count=2))
+    async_session.add(_make_event(title="Inflated", victim_count=20))
+    await async_session.commit()
+
+    async def override_get_session():
+        yield async_session
+
+    app.dependency_overrides[get_session] = override_get_session
+
+    async with AsyncClient(transport=__import__("httpx").ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get("/api/unique-events/stats/summary")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 1
+        assert data["total_victims"] == 2
+
+
+def test_br_ufs_has_27_states():
+    assert len(BR_UFS) == 27

--- a/backend/tests/test_public_stats.py
+++ b/backend/tests/test_public_stats.py
@@ -65,19 +65,22 @@ async def test_stats_total_multiple_events(app, async_session):
         title="Event 1",
         event_date=datetime(2024, 1, 15, 10, 0, 0),
         state="RJ",
-        city="Rio de Janeiro"
+        city="Rio de Janeiro",
+        victim_count=1,
     )
     event2 = UniqueEvent(
         title="Event 2",
         event_date=datetime(2024, 2, 20, 14, 0, 0),
         state="SP",
-        city="São Paulo"
+        city="São Paulo",
+        victim_count=1,
     )
     event3 = UniqueEvent(
         title="Event 3",
         event_date=None,  # Null event_date should still be counted in total
         state="MG",
-        city="Belo Horizonte"
+        city="Belo Horizonte",
+        victim_count=1,
     )
     
     async_session.add(event1)
@@ -109,7 +112,8 @@ async def test_stats_last_7_days_no_events_last_7_days(app, async_session):
         title="Event 8 Days Ago",
         event_date=event_8_days_ago,
         state="RJ",
-        city="Rio de Janeiro"
+        city="Rio de Janeiro",
+        victim_count=1,
     )
     
     async_session.add(event)
@@ -140,13 +144,15 @@ async def test_stats_last_7_days_includes_recent_events(app, async_session):
         title="Event 1 Day Ago",
         event_date=event_1_day_ago,
         state="RJ",
-        city="Rio de Janeiro"
+        city="Rio de Janeiro",
+        victim_count=1,
     )
     event_recent2 = UniqueEvent(
         title="Event 3 Days Ago",
         event_date=event_3_days_ago,
         state="SP",
-        city="São Paulo"
+        city="São Paulo",
+        victim_count=1,
     )
     
     async_session.add(event_recent1)
@@ -178,13 +184,15 @@ async def test_stats_last_7_days_excludes_future_events(app, async_session):
         title="Event 1 Day Ago",
         event_date=event_1_day_ago,
         state="RJ",
-        city="Rio de Janeiro"
+        city="Rio de Janeiro",
+        victim_count=1,
     )
     event_future_event = UniqueEvent(
         title="Event Future",
         event_date=event_future,
         state="SP",
-        city="São Paulo"
+        city="São Paulo",
+        victim_count=1,
     )
     
     async_session.add(event_recent)
@@ -215,13 +223,15 @@ async def test_stats_last_7_days_excludes_null_event_date(app, async_session):
         title="Event 2 Days Ago",
         event_date=event_2_days_ago,
         state="RJ",
-        city="Rio de Janeiro"
+        city="Rio de Janeiro",
+        victim_count=1,
     )
     event_null = UniqueEvent(
         title="Event Null Date",
         event_date=None,
         state="SP",
-        city="São Paulo"
+        city="São Paulo",
+        victim_count=1,
     )
     
     async_session.add(event_recent)
@@ -253,13 +263,15 @@ async def test_stats_last_7_days_edge_case_boundary(app, async_session):
         title="Event Within 7 Days",
         event_date=event_6_days_ago,
         state="RJ",
-        city="Rio de Janeiro"
+        city="Rio de Janeiro",
+        victim_count=1,
     )
     event_outside = UniqueEvent(
         title="Event Outside 7 Days",
         event_date=event_7_days_1h_ago,
         state="SP",
-        city="São Paulo"
+        city="São Paulo",
+        victim_count=1,
     )
     
     async_session.add(event_within)
@@ -293,19 +305,22 @@ async def test_stats_last_7_days_multiple_events(app, async_session):
         title="Event 1 Day Ago",
         event_date=event_1_day_ago,
         state="RJ",
-        city="Rio de Janeiro"
+        city="Rio de Janeiro",
+        victim_count=1,
     )
     event2 = UniqueEvent(
         title="Event 3 Days Ago",
         event_date=event_3_days_ago,
         state="SP",
-        city="São Paulo"
+        city="São Paulo",
+        victim_count=1,
     )
     event3 = UniqueEvent(
         title="Event 6 Days Ago",
         event_date=event_6_days_ago,
         state="MG",
-        city="Belo Horizonte"
+        city="Belo Horizonte",
+        victim_count=1,
     )
     
     async_session.add(event1)
@@ -338,7 +353,8 @@ async def test_stats_last_30_days_no_events_last_30_days(app, async_session):
         title="Event 31 Days Ago",
         event_date=event_31_days_ago,
         state="RJ",
-        city="Rio de Janeiro"
+        city="Rio de Janeiro",
+        victim_count=1,
     )
     
     async_session.add(event)
@@ -370,19 +386,22 @@ async def test_stats_last_30_days_includes_recent_events(app, async_session):
         title="Event 5 Days Ago",
         event_date=event_5_days_ago,
         state="RJ",
-        city="Rio de Janeiro"
+        city="Rio de Janeiro",
+        victim_count=1,
     )
     event2 = UniqueEvent(
         title="Event 15 Days Ago",
         event_date=event_15_days_ago,
         state="SP",
-        city="São Paulo"
+        city="São Paulo",
+        victim_count=1,
     )
     event3 = UniqueEvent(
         title="Event 25 Days Ago",
         event_date=event_25_days_ago,
         state="MG",
-        city="Belo Horizonte"
+        city="Belo Horizonte",
+        victim_count=1,
     )
     
     async_session.add(event1)
@@ -415,13 +434,15 @@ async def test_stats_last_30_days_excludes_future_events(app, async_session):
         title="Event 10 Days Ago",
         event_date=event_10_days_ago,
         state="RJ",
-        city="Rio de Janeiro"
+        city="Rio de Janeiro",
+        victim_count=1,
     )
     event_future_event = UniqueEvent(
         title="Event Future",
         event_date=event_future,
         state="SP",
-        city="São Paulo"
+        city="São Paulo",
+        victim_count=1,
     )
     
     async_session.add(event_recent)
@@ -452,13 +473,15 @@ async def test_stats_last_30_days_excludes_null_event_date(app, async_session):
         title="Event 10 Days Ago",
         event_date=event_10_days_ago,
         state="RJ",
-        city="Rio de Janeiro"
+        city="Rio de Janeiro",
+        victim_count=1,
     )
     event_null = UniqueEvent(
         title="Event Null Date",
         event_date=None,
         state="SP",
-        city="São Paulo"
+        city="São Paulo",
+        victim_count=1,
     )
     
     async_session.add(event_recent)
@@ -490,13 +513,15 @@ async def test_stats_last_30_days_edge_case_boundary(app, async_session):
         title="Event Within 30 Days",
         event_date=event_29_days_ago,
         state="RJ",
-        city="Rio de Janeiro"
+        city="Rio de Janeiro",
+        victim_count=1,
     )
     event_outside = UniqueEvent(
         title="Event Outside 30 Days",
         event_date=event_30_days_1h_ago,
         state="SP",
-        city="São Paulo"
+        city="São Paulo",
+        victim_count=1,
     )
     
     async_session.add(event_within)

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -12,6 +12,22 @@ server {
     gzip_types text/plain text/css application/json application/javascript text/xml application/xml;
     gzip_min_length 1000;
     
+    # CSV export streams the full dataset — needs longer timeout and no buffering
+    location /api/public/events/export {
+        set $backend "http://api:8000";
+        proxy_pass $backend;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        proxy_buffering off;
+        proxy_connect_timeout 300s;
+        proxy_send_timeout 300s;
+        proxy_read_timeout 300s;
+    }
+
     # API proxy - passes full URI to backend (backend expects /api/ prefix)
     location /api/ {
         set $backend "http://api:8000";

--- a/frontend/nginx.staging.conf
+++ b/frontend/nginx.staging.conf
@@ -15,6 +15,22 @@ server {
     gzip_types text/plain text/css application/json application/javascript text/xml application/xml;
     gzip_min_length 1000;
     
+    # CSV export streams the full dataset — needs longer timeout and no buffering
+    location /api/public/events/export {
+        set $backend "http://api:8000";
+        proxy_pass $backend;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        proxy_buffering off;
+        proxy_connect_timeout 300s;
+        proxy_send_timeout 300s;
+        proxy_read_timeout 300s;
+    }
+
     # API proxy - passes full URI to backend (backend expects /api/ prefix)
     location /api/ {
         set $backend "http://api:8000";

--- a/frontend/src/components/map/CrimeMap.tsx
+++ b/frontend/src/components/map/CrimeMap.tsx
@@ -311,7 +311,8 @@ export function CrimeMap({
                 .join('\n'),
             };
           }
-          const count = (object as { points?: unknown[] }).points?.length ?? 0;
+          const cell = object as { count?: number; points?: unknown[] };
+          const count = cell.count ?? cell.points?.length ?? 0;
           return { text: `${count} ${count === 1 ? 'evento' : 'eventos'}` };
         }}
       >

--- a/frontend/src/components/portal/RightPanel.tsx
+++ b/frontend/src/components/portal/RightPanel.tsx
@@ -1,6 +1,6 @@
 import { memo, useMemo, useState, useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { ChevronLeft, RotateCcw, SlidersHorizontal, MapPin, Clock, FileText, Download } from 'lucide-react';
+import { ChevronLeft, RotateCcw, SlidersHorizontal, MapPin, Clock, FileText, Download, ExternalLink } from 'lucide-react';
 import { useI18n } from '@/contexts/I18nContext';
 import { fetchPublicEventById, getExportUrl, type MapPoint } from '@/lib/api';
 import { cn } from '@/lib/utils';
@@ -719,6 +719,7 @@ function DetailView({ id, onClose }: { id: number; onClose: () => void }) {
   const cityLine = [event.city, ufName(event.state)].filter(Boolean).join(' · ');
   const srcCount = event.source_count ?? 0;
   const sourceWord = srcCount > 1 ? t.newsSources : t.newsSource;
+  const displayableSources = (event.sources ?? []).filter((source) => source.url);
 
   return (
     <div className="av-fade px-5 pb-7 pt-[18px]">
@@ -794,10 +795,51 @@ function DetailView({ id, onClose }: { id: number; onClose: () => void }) {
         </>
       )}
 
+      {displayableSources.length > 0 && (
+        <>
+          <div className="mb-[7px] font-mono text-[9.5px] uppercase tracking-[.1em]" style={{ color: 'var(--color-text-subtle)' }}>
+            {t.sourcesSection}
+          </div>
+          <ul className="mb-[18px] flex flex-col overflow-hidden rounded-[10px]" style={{ border: '1px solid var(--stone-200)' }}>
+            {displayableSources.map((source) => {
+              const title = source.headline || source.publisher_name || t.sourceFallback;
+              const showPublisher = Boolean(source.publisher_name && source.headline);
+              return (
+                <li key={source.id} style={{ borderBottom: '1px solid var(--stone-100)' }} className="last:border-b-0">
+                  <a
+                    href={source.url!}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="flex items-start gap-2.5 px-[13px] py-[11px] no-underline transition-colors hover:bg-[var(--stone-50)]"
+                  >
+                    <ExternalLink className="mt-0.5 h-4 w-4 flex-none" style={{ color: 'var(--blue-600)' }} />
+                    <div className="min-w-0 flex-1">
+                      <div style={{ fontSize: 13.5, fontWeight: 500, color: 'var(--blue-600)', lineHeight: 1.35 }}>
+                        {title}
+                      </div>
+                      {showPublisher && (
+                        <div style={{ fontSize: 12, color: 'var(--color-text-muted)' }}>{source.publisher_name}</div>
+                      )}
+                      {source.published_at && (
+                        <div style={{ fontSize: 11.5, color: 'var(--color-text-subtle)' }}>
+                          {fmtDateShort(source.published_at, lang)}
+                        </div>
+                      )}
+                    </div>
+                  </a>
+                </li>
+              );
+            })}
+          </ul>
+        </>
+      )}
+
+      {srcCount > 0 && (
       <div className="flex items-center gap-2 pt-3.5" style={{ borderTop: '1px solid var(--stone-100)', fontSize: 12, color: 'var(--color-text-muted)' }}>
         <FileText className="h-[15px] w-[15px]" />
         {`${t.reportedBy}${srcCount}${sourceWord} · #${event.id}`}
       </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/lib/i18n.ts
+++ b/frontend/src/lib/i18n.ts
@@ -68,6 +68,8 @@ export interface Strings {
   reportedBy: string;
   newsSource: string;
   newsSources: string;
+  sourcesSection: string;
+  sourceFallback: string;
   victim: string;
   victimsLower: string;
   loadingEvent: string;
@@ -140,6 +142,8 @@ const PT: Strings = {
   reportedBy: 'Reportado por ',
   newsSource: ' fonte jornalística',
   newsSources: ' fontes jornalísticas',
+  sourcesSection: 'Fontes jornalísticas',
+  sourceFallback: 'Matéria jornalística',
   victim: 'vítima',
   victimsLower: 'vítimas',
   loadingEvent: 'Carregando evento',
@@ -215,6 +219,8 @@ const EN: Strings = {
   reportedBy: 'Reported by ',
   newsSource: ' news source',
   newsSources: ' news sources',
+  sourcesSection: 'News sources',
+  sourceFallback: 'News article',
   victim: 'victim',
   victimsLower: 'victims',
   loadingEvent: 'Loading event',

--- a/infra/nginx/arquivo-violencia.conf
+++ b/infra/nginx/arquivo-violencia.conf
@@ -40,6 +40,23 @@ server {
     access_log /var/log/nginx/staging-arquivo-access.log;
     error_log /var/log/nginx/staging-arquivo-error.log;
 
+    location /api/public/events/export {
+        proxy_pass http://127.0.0.1:8080;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_cache_bypass $http_upgrade;
+
+        proxy_buffering off;
+        proxy_connect_timeout 300s;
+        proxy_send_timeout 300s;
+        proxy_read_timeout 300s;
+    }
+
     location / {
         proxy_pass http://127.0.0.1:8080;
         proxy_http_version 1.1;
@@ -92,6 +109,23 @@ server {
 
     access_log /var/log/nginx/arquivo-access.log;
     error_log /var/log/nginx/arquivo-error.log;
+
+    location /api/public/events/export {
+        proxy_pass http://127.0.0.1:9080;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_cache_bypass $http_upgrade;
+
+        proxy_buffering off;
+        proxy_connect_timeout 300s;
+        proxy_send_timeout 300s;
+        proxy_read_timeout 300s;
+    }
 
     location / {
         proxy_pass http://127.0.0.1:9080;


### PR DESCRIPTION
## Release summary

Promotes `develop` to production (`master`). **Do not merge until human review checklist below is complete.**

Closes AQV-24
Closes AQV-25
Closes AQV-27
Closes AQV-29
Closes AQV-30
Closes AQV-31
Closes AQV-38

### Commits (`master..develop`)

| Commit | Feature PR | Issue |
|--------|------------|-------|
| `3114573` | [#28](https://github.com/JoaoCarabetta/arquivo-da-violencia/pull/28) | AQV-24 |
| `388059a` | [#29](https://github.com/JoaoCarabetta/arquivo-da-violencia/pull/29) | AQV-25 |
| `5478e07` | [#31](https://github.com/JoaoCarabetta/arquivo-da-violencia/pull/31) | AQV-29 |
| `8508733` | [#33](https://github.com/JoaoCarabetta/arquivo-da-violencia/pull/33) | AQV-27 |
| `3cebf51` | [#34](https://github.com/JoaoCarabetta/arquivo-da-violencia/pull/34) | AQV-30, AQV-31 |
| `d940179` | [#35](https://github.com/JoaoCarabetta/arquivo-da-violencia/pull/35) | AQV-38 |
| `7af81c3` | (direct to develop) | AQV-31 follow-up |
| `6e5c2b1` | (direct to develop) | Extraction eval harness |

### Staged issues awaiting release

| Issue | Title | Labels | Feature PR |
|-------|-------|--------|------------|
| **AQV-24** | The label is showing 0 eventos in heatmap | type/bug · S | [#28](https://github.com/JoaoCarabetta/arquivo-da-violencia/pull/28) |
| **AQV-25** | I need to be able to see and open the sources | type/feature · M | [#29](https://github.com/JoaoCarabetta/arquivo-da-violencia/pull/29) |
| **AQV-27** | Fix CSV export truncation — streaming response + nginx timeout | type/bug · M | [#33](https://github.com/JoaoCarabetta/arquivo-da-violencia/pull/33) |
| **AQV-29** | Public API guardrails — exclude inflated/non-incident rows from stats | type/feature · M | [#31](https://github.com/JoaoCarabetta/arquivo-da-violencia/pull/31) |
| **AQV-30** | Extraction validators + security_force_involved mapping | type/bug · M | [#34](https://github.com/JoaoCarabetta/arquivo-da-violencia/pull/34) |
| **AQV-31** | Classification: reject aggregate/foreign/non-incident headlines | type/feature · M | [#34](https://github.com/JoaoCarabetta/arquivo-da-violencia/pull/34) |
| **AQV-38** | Dedup tuning — title fuzzy blocking and match threshold adjustments | type/feature · L | [#35](https://github.com/JoaoCarabetta/arquivo-da-violencia/pull/35) |

### Needs closer human attention

| Issue | Title | Reason |
|-------|-------|--------|
| **AQV-38** | Dedup tuning — title fuzzy blocking and match threshold adjustments | Originally `route/ai+review`: LLM match threshold lowered 0.7→0.6; manual review of 20 high-risk merge cases on staging recommended before release |

### Human review checklist

- [ ] Review each feature staged since the last release (AQV-24, AQV-25, AQV-27, AQV-29, AQV-30, AQV-31, AQV-38)
- [ ] Extra scrutiny on AQV-38 (ai+review): sample dedup merges on staging for false positives
- [ ] Confirm the `develop` staging deploy is green
- [ ] Check for risky DB migrations or breaking changes (no migrations in this batch)
- [ ] After deploy: verify CSV export row count on staging (`curl -sf 'https://staging.arquivodaviolencia.com.br/api/public/events/export?days=3650' | wc -l`)
- [ ] Approve and merge to `master` to release

### Notes

- AQV-29 Phase A adds interim public API filters (`victim_count <= 10`, BR state guard). Public stats totals on staging should drop significantly (~13–14k victim context vs ~400k).
- AQV-27 extends nginx export timeouts to 300s with `proxy_buffering off` across frontend container and host reverse-proxy configs.
- AQV-30/31 tighten pipeline data quality: extraction victim-count cap (≤20) with discard on validation failure; headline classification rejects aggregate/foreign/non-incident content before download.
- AQV-38 adds title-fuzzy blocking (SequenceMatcher ≥0.85, ±3 day window) and lowers LLM dedup confidence threshold to 0.6. Ship before AQV-39 merge backfill.
- **`7af81c3` classification eval harness:** adds `python -m eval classification` CLI with seed + adversarial fixtures (`classification_seed.json`, `classification_hard.json`), DB sampling for manual labeling, and variant A/B runs. Prompt hardened for Brazil-only scope, surviving victims, and foreign-news false positives while keeping the `is_single_incident` gate. Benchmark: 30/30 on both fixtures with `gemini-2.5-flash-lite`.
- **`6e5c2b1` extraction eval harness:** `python -m eval extraction` with DB build, field-level scoring (date/city/state/victims/type/method), adversarial `extraction_hard.json` (20 cases), variant support.
