### PR TITLE
Release: develop -> master

### DIFF
--- a/backend/app/services/extraction.py
+++ b/backend/app/services/extraction.py
@@ -16,6 +16,15 @@ from app.services import diagnostics
 from app.services.extraction_schemas import ViolentDeathEvent
 
 
+def content_class_failure_reason(content_class: str) -> str:
+    """Map extraction content_class to diagnostics failure reason."""
+    if content_class == "aggregate_statistics":
+        return diagnostics.AGGREGATE_CONTENT
+    if content_class == "foreign":
+        return diagnostics.FOREIGN_CONTENT
+    return diagnostics.NON_INCIDENT_CONTENT
+
+
 def derive_security_force_involved(event: ViolentDeathEvent) -> bool | None:
     """Return True if any party is flagged as security force, False if explicitly not, else None."""
     flags: list[bool | None] = []
@@ -119,9 +128,16 @@ SOBRE homicide_type - SEJA CONSERVADOR:
   de familiares, ocultação de cadáver, ou quando a polícia/imprensa classifica como
   "homicídio qualificado". Mera hipótese de "execução" SEM outros indícios NÃO conta.
 - "Latrocínio": morte durante roubo/assalto (ainda que a notícia use "assassinado").
-- "Feminicídio": mulher morta por razão de gênero / violência doméstica.
-- Mortes em confronto/troca de tiros com a polícia ou intervenção policial são
-  "Homicídio" (a morte é violenta e intencional, ainda que legal).
+- "Feminicídio": mulher morta por razão de gênero ou violência doméstica. Use quando o
+  texto menciona ex-marido, marido, companheiro, namorado, violência doméstica, Lei
+  Maria da Penha, agressão por parceiro íntimo, ou feminicídio explicitamente — mesmo
+  que a polícia ainda não tenha tipificado legalmente.
+- "Intervenção policial": morte durante operação policial, confronto ou troca de tiros
+  com PM/PC/Bope/PRF, ou quando a vítima é "neutralizada" pela polícia. Prefira este
+  tipo em vez de "Homicídio" genérico quando a morte ocorre no contexto de ação policial.
+- "Morte no trânsito": homicídio doloso com veículo como meio principal (atropelamento
+  intencional, emboscada com carro, perseguição fatal). NÃO use para acidentes de
+  trânsito sem dolo (esses são content_class = accident_disaster, não incident).
 - "Outro": use APENAS quando o texto não estabelece nem sugere morte violenta
   intencional (ex.: "corpo achado em terreno, causa não divulgada", sem qualquer
   indício de crime). Se o texto trata a morte como crime sob investigação
@@ -130,6 +146,27 @@ SOBRE homicide_type - SEJA CONSERVADOR:
   absolvição não muda o tipo: registre "Homicídio" simples se não há qualificadora.
 - Não eleve a classificação por suposição: na dúvida entre "Homicídio" e
   "Homicídio Qualificado", use "Homicídio".
+
+SOBRE content_class — OBRIGATÓRIO EM TODA EXTRAÇÃO:
+Defina content_class em todo JSON de saída. Valores permitidos:
+- "incident": um evento único de morte violenta no Brasil descrito na notícia (padrão
+  quando a matéria trata de um caso concreto).
+- "aggregate_statistics": balanço anual, CVLI, totais estaduais/nacionais, "X mortes em
+  2025", painéis e estudos sem caso concreto como foco principal.
+- "non_incident": suicídio, crueldade contra animais, coluna de opinião, matéria
+  jurídica sobre processo antigo sem óbito novo, ou conteúdo fora do escopo de homicídio.
+- "accident_disaster": acidente de trânsito culposo, queda, afogamento, desastre natural
+  sem homicídio doloso.
+- "foreign": evento ocorre fora do Brasil ou a matéria trata primariamente de mortes no
+  exterior (EUA, Europa, etc.).
+
+SOBRE number_of_victims — NUNCA USE TOTAIS AGREGADOS:
+- Conte APENAS as vítimas do incidente específico descrito (máximo 20).
+- NUNCA use totais anuais, CVLI, "4.241 mortes em 2025", balanço estadual ou estatísticas
+  de painel como number_of_victims — mesmo que sejam o tema da matéria.
+- Se a matéria é estatística agregada sem incidente único, use content_class =
+  "aggregate_statistics" e number_of_victims = 1 apenas se houver um caso concreto
+  embutido; caso contrário a extração será descartada downstream.
 
 SOBRE TÍTULOS:
 - Se não há data completa verificada, use "DATA NÃO INFORMADA" no título
@@ -378,6 +415,38 @@ async def extract_source(source_id: int) -> RawEvent | None:
             return None
 
         await _mark_failed(reason, str(e), duration_ms)
+        return None
+
+    if event.content_class != "incident":
+        duration_ms = int((time.monotonic() - started) * 1000)
+        failure_reason = content_class_failure_reason(event.content_class)
+        reasoning = f"Extraction content_class={event.content_class}"
+        logger.info(
+            f"Discarding source {source_id}: {reasoning} ({failure_reason})"
+        )
+        async with async_session_maker() as session:
+            await session.execute(
+                text("""
+                    UPDATE source_google_news
+                    SET status = 'discarded',
+                        classification_reasoning = :reasoning,
+                        updated_at = CURRENT_TIMESTAMP
+                    WHERE id = :id
+                """),
+                {"id": source_id, "reasoning": reasoning},
+            )
+            await session.commit()
+        await diagnostics.record_attempt(
+            stage=diagnostics.STAGE_EXTRACTION,
+            outcome=diagnostics.OUTCOME_FAILURE,
+            source_google_news_id=source_id,
+            failure_reason=failure_reason,
+            failure_detail=reasoning,
+            model=model_name,
+            content_length=original_length,
+            duration_ms=duration_ms,
+            attempt_number=attempt_number,
+        )
         return None
 
     security_force_involved = derive_security_force_involved(event)

--- a/backend/app/services/extraction_schemas.py
+++ b/backend/app/services/extraction_schemas.py
@@ -15,6 +15,8 @@ HomicideType = Literal[
     "Latrocínio",
     "Feminicídio",
     "Infanticídio",
+    "Intervenção policial",
+    "Morte no trânsito",
     "Outro",
 ]
 
@@ -412,6 +414,8 @@ class HomicideDynamic(BaseModel):
         - "Latrocínio"
         - "Feminicídio"
         - "Infanticídio"
+        - "Intervenção policial"
+        - "Morte no trânsito"
         - "Outro"
         """,
     )

--- a/backend/app/tasks/pipeline.py
+++ b/backend/app/tasks/pipeline.py
@@ -474,9 +474,10 @@ async def run_full_pipeline(ctx: dict, query: str | None = None, when: str = "3d
 
 @notify_on_failure("ingest_cities")
 async def ingest_cities_task(
-    ctx: dict, 
-    cities: list[str] | None = None, 
-    when: str = "1h"
+    ctx: dict,
+    cities: list[str] | None = None,
+    when: str = "1h",
+    enqueue_classify: bool = True,
 ) -> dict:
     """
     Ingest news for all configured cities with adaptive sharding.
@@ -485,12 +486,15 @@ async def ingest_cities_task(
     Cities that hit the 100-result limit will automatically switch
     to source-based sharding on subsequent runs.
     
-    After ingestion, automatically enqueues classification tasks for all new sources.
+    After ingestion, optionally enqueues classification for new sources.
+    Callers that run classify inline (e.g. ``ingest_cities_full_pipeline``)
+    must pass ``enqueue_classify=False`` to avoid duplicate concurrent jobs.
     
     Args:
         ctx: ARQ context (contains redis connection)
         cities: Optional list of cities. If None, uses CITIES from config.
         when: Time filter (default "1h" for hourly)
+        enqueue_classify: When True, enqueue ``classify_pending_task`` after ingest.
     
     Returns:
         dict with ingestion results
@@ -508,9 +512,8 @@ async def ingest_cities_task(
     total_sources = result['total_sources_created']
     logger.info(f"[INGEST_CITIES] Complete: {total_sources} new sources")
     
-    # Enqueue classification tasks for all new sources
-    if total_sources > 0 and ctx.get("redis"):
-        # Batch classify all pending sources
+    # Enqueue classification tasks for all new sources (standalone runs only).
+    if enqueue_classify and total_sources > 0 and ctx.get("redis"):
         await ctx["redis"].enqueue_job("classify_pending_task", limit=total_sources + 50)
         logger.info(f"[INGEST_CITIES] Enqueued batch classification task")
     
@@ -554,8 +557,10 @@ async def ingest_cities_full_pipeline(
     except Exception as e:
         logger.warning(f"[CITIES_PIPELINE] Maintenance step failed (continuing): {e}")
     
-    # Step 1: Ingest cities
-    ingest_result = await ingest_cities_task(ctx, cities=cities, when=when)
+    # Step 1: Ingest cities (classify runs inline in Step 2 — do not enqueue).
+    ingest_result = await ingest_cities_task(
+        ctx, cities=cities, when=when, enqueue_classify=False
+    )
     
     # Step 2: Classify pending sources
     classify_result = await classify_pending_task(ctx, limit=500)

--- a/backend/tests/test_extraction_content_class.py
+++ b/backend/tests/test_extraction_content_class.py
@@ -1,0 +1,185 @@
+"""Tests for extraction content_class and taxonomy prompts (AQV-33)."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.services.extraction import content_class_failure_reason, extract_source
+from app.services.extraction_schemas import (
+    DateTime,
+    DateVerification,
+    HomicideDynamic,
+    IdentifiableVictim,
+    Location,
+    Victims,
+    ViolentDeathEvent,
+)
+from app.services import diagnostics
+
+
+class _TestSessionMaker:
+    def __init__(self, session):
+        self._session = session
+
+    def __call__(self):
+        return self
+
+    async def __aenter__(self):
+        return self._session
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+@pytest.fixture
+def extraction_db(async_session):
+    maker = _TestSessionMaker(async_session)
+    with patch("app.services.extraction.async_session_maker", maker):
+        with patch("app.services.diagnostics.async_session_maker", maker):
+            yield async_session
+
+
+def _minimal_event(**kwargs) -> ViolentDeathEvent:
+    defaults = {
+        "content_class": "incident",
+        "location_info": Location(city="Rio de Janeiro", state="RJ"),
+        "date_time": DateTime(
+            date_verification=DateVerification(
+                has_explicit_date=False,
+                date_source="none",
+                year_explicitly_mentioned=False,
+                verification_reasoning="No date in text",
+            ),
+            date=None,
+        ),
+        "victims": Victims(
+            identifiable_victims=[IdentifiableVictim(name="João")],
+            number_of_identifiable_victims=1,
+            number_of_victims=1,
+        ),
+        "homicide_dynamic": HomicideDynamic(
+            title="HOMICÍDIO - RIO DE JANEIRO - DATA NÃO INFORMADA",
+            homicide_type="Homicídio",
+            chronological_description="Vítima foi morta a tiros.",
+        ),
+    }
+    defaults.update(kwargs)
+    return ViolentDeathEvent(**defaults)
+
+
+def _source(**kwargs):
+    from app.models.source_google_news import SourceGoogleNews, SourceStatus
+
+    defaults = {
+        "google_news_id": "extract-test",
+        "google_news_url": "https://news.example/article",
+        "resolved_url": "https://news.example/article",
+        "headline": "Homem é morto a tiros em operação policial",
+        "content": "Um homem foi morto a tiros durante operação policial.",
+        "status": SourceStatus.ready_for_extraction,
+    }
+    defaults.update(kwargs)
+    return SourceGoogleNews(**defaults)
+
+
+@pytest.mark.parametrize(
+    "homicide_type",
+    ["Intervenção policial", "Morte no trânsito"],
+)
+def test_homicide_type_accepts_new_values(homicide_type):
+    event = _minimal_event(
+        homicide_dynamic=HomicideDynamic(
+            title="HOMICÍDIO - RIO DE JANEIRO - DATA NÃO INFORMADA",
+            homicide_type=homicide_type,
+            chronological_description="Vítima foi morta.",
+        )
+    )
+    assert event.homicide_dynamic.homicide_type == homicide_type
+
+
+@pytest.mark.parametrize(
+    ("content_class", "expected_reason"),
+    [
+        ("aggregate_statistics", diagnostics.AGGREGATE_CONTENT),
+        ("foreign", diagnostics.FOREIGN_CONTENT),
+        ("non_incident", diagnostics.NON_INCIDENT_CONTENT),
+        ("accident_disaster", diagnostics.NON_INCIDENT_CONTENT),
+    ],
+)
+def test_content_class_failure_reason_mapping(content_class, expected_reason):
+    assert content_class_failure_reason(content_class) == expected_reason
+
+
+@pytest.mark.asyncio
+async def test_extract_source_discards_non_incident_content_class(extraction_db):
+    from app.models.source_google_news import SourceStatus
+
+    source = _source(google_news_id="discard-foreign")
+    extraction_db.add(source)
+    await extraction_db.commit()
+    await extraction_db.refresh(source)
+
+    foreign_event = _minimal_event(content_class="foreign")
+
+    with patch(
+        "app.services.extraction.extract_event_from_content",
+        return_value=foreign_event,
+    ), patch(
+        "app.services.extraction.diagnostics.count_attempts",
+        new=AsyncMock(return_value=0),
+    ), patch(
+        "app.services.extraction.diagnostics.record_attempt",
+        new=AsyncMock(),
+    ) as mock_record:
+        result = await extract_source(source.id)
+
+    assert result is None
+    await extraction_db.refresh(source)
+    assert source.status == SourceStatus.discarded
+    assert "content_class=foreign" in source.classification_reasoning
+    mock_record.assert_called_once()
+    assert mock_record.call_args.kwargs["failure_reason"] == diagnostics.FOREIGN_CONTENT
+
+
+@pytest.mark.asyncio
+async def test_extract_source_persists_incident_with_content_class(extraction_db):
+    from app.models.raw_event import RawEvent
+    from app.models.source_google_news import SourceStatus
+    from sqlmodel import select
+
+    source = _source(google_news_id="persist-incident")
+    extraction_db.add(source)
+    await extraction_db.commit()
+    await extraction_db.refresh(source)
+
+    incident_event = _minimal_event(
+        homicide_dynamic=HomicideDynamic(
+            title="INTERVENÇÃO POLICIAL - ZONA NORTE - DATA NÃO INFORMADA",
+            homicide_type="Intervenção policial",
+            chronological_description="Suspeito foi morto em confronto com a polícia.",
+        )
+    )
+
+    with patch(
+        "app.services.extraction.extract_event_from_content",
+        return_value=incident_event,
+    ), patch(
+        "app.services.extraction.diagnostics.count_attempts",
+        new=AsyncMock(return_value=0),
+    ), patch(
+        "app.services.extraction.diagnostics.record_attempt",
+        new=AsyncMock(),
+    ):
+        raw_event = await extract_source(source.id)
+
+    assert raw_event is not None
+    assert raw_event.content_class == "incident"
+    assert raw_event.homicide_type == "Intervenção policial"
+
+    await extraction_db.refresh(source)
+    assert source.status == SourceStatus.extracted
+
+    stored = (
+        await extraction_db.exec(select(RawEvent).where(RawEvent.id == raw_event.id))
+    ).one()
+    assert stored.content_class == "incident"


### PR DESCRIPTION
## Release: develop → master

This PR is the **human release gate**. Merging it deploys everything on `develop` to production and moves staged issues to **Done**.

Closes AQV-33

---

## Staged issues awaiting release

| Issue | Title | Type / Size | Feature PR |
|-------|-------|-------------|------------|
| [AQV-33](https://linear.app/carabetta/issue/AQV-33) | Extraction prompts + taxonomy enum (content_class, new homicide types) | type/feature · L | [#42](https://github.com/JoaoCarabetta/arquivo-da-violencia/pull/42) |

**Total staged:** 1 issue

---

## Critical hotfix included

- **fix(pipeline):** prevent duplicate `classify_pending_task` in hourly full pipeline ([#44](https://github.com/JoaoCarabetta/arquivo-da-violencia/pull/44))
- Prod was manually recovered today (worker restart, WAL checkpoint, 264 stuck `classifying` rows reset). This release ships the code fix to prevent recurrence.

---

## Needs closer human attention

- **AQV-33** — labeled `ai+review`: changes LLM extraction prompts and taxonomy enums that affect classification/discard behavior in the ingestion pipeline. Review prompt wording and discard gate semantics before release.

---

## Human review checklist

- [x] Prod outage root-caused and manually recovered
- [x] Pipeline fix verified on staging (Deploy Backend run 28711703094)
- [ ] Extra scrutiny on the ai+review / security items listed above
- [ ] Confirm post-deploy hourly cron at `:05` completes without `database is locked`
- [ ] Approve and merge to `master` to release

---

## Notes

- AQV-33: extends `HomicideType`, updates `EXTRACTION_SYSTEM_PROMPT` for `content_class`/victim-count/feminicídio rules, and discards non-`incident` extractions before `RawEvent` creation.
- Pipeline fix: `ingest_cities_full_pipeline` passes `enqueue_classify=False` to avoid concurrent classify jobs that caused SQLite lock contention.
- No new DB migrations in this release.
- Staging deploys: ✅ AQV-33 (28706301609), ✅ pipeline fix (28711703094)