### PR TITLE
fix(pipeline): harden full pipeline against timeouts and SQLite locks

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -32,6 +32,8 @@ class Settings(BaseSettings):
 
     # Database
     database_url: str = "sqlite+aiosqlite:///./instance/violence.db"
+    db_pool_size: int = 30
+    db_pool_overflow: int = 70
     
     # Redis (for ARQ task queue)
     redis_url: str = "redis://localhost:6379"

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -64,8 +64,8 @@ def get_engine() -> AsyncEngine:
             # default pool (5 + 10 overflow) is far too small for that and leads
             # to "QueuePool limit ... connection timed out" errors. Size the pool
             # generously; WAL mode + busy_timeout handle write serialization.
-            pool_size=30,
-            max_overflow=70,
+            pool_size=settings.db_pool_size,
+            max_overflow=settings.db_pool_overflow,
             pool_timeout=60,
             pool_recycle=1800,
             connect_args={

--- a/backend/app/services/classification.py
+++ b/backend/app/services/classification.py
@@ -405,6 +405,25 @@ async def classify_source(source_id: int) -> bool:
     return passes_gate
 
 
+async def _reset_unfinished_classifying(source_ids: list[int]) -> int:
+    """Return claimed sources still in classifying back to the queue."""
+    if not source_ids:
+        return 0
+    from sqlalchemy import text
+
+    id_list = ",".join(str(source_id) for source_id in source_ids)
+    async with async_session_maker() as session:
+        result = await session.execute(
+            text(f"""
+                UPDATE source_google_news
+                SET status = 'ready_for_classification', updated_at = CURRENT_TIMESTAMP
+                WHERE id IN ({id_list}) AND status = 'classifying'
+            """)
+        )
+        await session.commit()
+        return result.rowcount or 0
+
+
 async def classify_pending_sources(limit: int = 50, concurrency: int = 10) -> dict:
     """
     Batch classify all sources that are ready for classification (in parallel).
@@ -479,10 +498,17 @@ async def classify_pending_sources(limit: int = 50, concurrency: int = 10) -> di
     
     # Run classifications in parallel with concurrency limit
     logger.info(f"Starting parallel classification with concurrency={concurrency}")
-    results = await asyncio.gather(
-        *[classify_with_limit(sid) for sid in source_ids],
-        return_exceptions=True
-    )
+    try:
+        results = await asyncio.gather(
+            *[classify_with_limit(sid) for sid in source_ids],
+            return_exceptions=True
+        )
+    finally:
+        reset_count = await _reset_unfinished_classifying(source_ids)
+        if reset_count:
+            logger.warning(
+                f"Reset {reset_count} source(s) still in classifying back to ready_for_classification"
+            )
     
     violent_death_count = 0
     discarded_count = 0

--- a/backend/app/services/enrichment.py
+++ b/backend/app/services/enrichment.py
@@ -1284,7 +1284,7 @@ async def process_pending_deduplication(limit: int = 200) -> dict:
     }
 
 
-async def run_pending_enrichments(limit: int = 50, concurrency: int = 5) -> dict:
+async def run_pending_enrichments(limit: int = 50, concurrency: int = 2) -> dict:
     """
     Process all UniqueEvents with needs_enrichment=True.
     
@@ -1468,10 +1468,23 @@ async def enrich_unique_event(unique_event_id: int) -> bool:
         settings = get_settings()
         result = synthesize_unique_event(current_state, sources_info)
         
-        # Update UniqueEvent with enriched data
-        async with async_session_maker() as session:
-            await session.execute(
-                text("""
+        # Update UniqueEvent with enriched data (retry transient SQLite locks).
+        import asyncio
+        from sqlalchemy.exc import OperationalError
+
+        update_params = {
+            "id": unique_event_id,
+            "title": result.title,
+            "city": result.city,
+            "state": result.state,
+            "neighborhood": result.neighborhood,
+            "street": result.street,
+            "victims_summary": result.victims_summary,
+            "victim_count": result.victim_count,
+            "chronological_description": result.chronological_description,
+            "enrichment_model": settings.enrichment_model,
+        }
+        update_sql = text("""
                     UPDATE unique_event 
                     SET title = COALESCE(:title, title),
                         city = COALESCE(:city, city),
@@ -1486,21 +1499,17 @@ async def enrich_unique_event(unique_event_id: int) -> bool:
                         enrichment_model = :enrichment_model,
                         updated_at = CURRENT_TIMESTAMP
                     WHERE id = :id
-                """),
-                {
-                    "id": unique_event_id,
-                    "title": result.title,
-                    "city": result.city,
-                    "state": result.state,
-                    "neighborhood": result.neighborhood,
-                    "street": result.street,
-                    "victims_summary": result.victims_summary,
-                    "victim_count": result.victim_count,
-                    "chronological_description": result.chronological_description,
-                    "enrichment_model": settings.enrichment_model,
-                }
-            )
-            await session.commit()
+                """)
+        for attempt in range(3):
+            try:
+                async with async_session_maker() as session:
+                    await session.execute(update_sql, update_params)
+                    await session.commit()
+                break
+            except OperationalError as exc:
+                if "database is locked" not in str(exc).lower() or attempt == 2:
+                    raise
+                await asyncio.sleep(1 + attempt)
         
         logger.info(f"[Enrich] ✅ Enriched UniqueEvent {unique_event_id}")
         return True

--- a/backend/app/services/maintenance.py
+++ b/backend/app/services/maintenance.py
@@ -78,6 +78,13 @@ def pick_survivor_id(event_ids: list[dict[str, Any]]) -> int:
     return min(event_ids, key=lambda row: (-row["source_count"], row["id"]))["id"]
 
 
+async def checkpoint_wal() -> None:
+    """Best-effort passive WAL checkpoint to limit lock contention on SQLite."""
+    async with async_session_maker() as session:
+        await session.execute(text("PRAGMA wal_checkpoint(PASSIVE)"))
+        await session.commit()
+
+
 async def recover_stuck_sources(older_than_minutes: int = 15) -> dict:
     """
     Requeue sources stranded in transient processing states.

--- a/backend/app/tasks/pipeline.py
+++ b/backend/app/tasks/pipeline.py
@@ -147,11 +147,13 @@ async def classify_task(ctx: dict, source_id: int) -> dict:
 
 
 @notify_on_failure("classify_batch")
-async def classify_pending_task(ctx: dict, limit: int = 50) -> dict:
+async def classify_pending_task(
+    ctx: dict, limit: int = 50, chain_next: bool = True
+) -> dict:
     """
     Batch task: Classify headlines for all pending sources.
     
-    After classification, automatically enqueues batch download for sources
+    After classification, optionally enqueues batch download for sources
     that passed classification (marked as ready_for_download).
     """
     logger.info(f"[CLASSIFY_BATCH] Starting for up to {limit} sources")
@@ -162,8 +164,12 @@ async def classify_pending_task(ctx: dict, limit: int = 50) -> dict:
     
     logger.info(f"[CLASSIFY_BATCH] Complete: {result}")
     
-    # Chain to download if we have sources ready
-    if result.get("violent_death", 0) > 0 and ctx.get("redis"):
+    # Chain to download if we have sources ready (standalone runs only).
+    if (
+        chain_next
+        and result.get("violent_death", 0) > 0
+        and ctx.get("redis")
+    ):
         await ctx["redis"].enqueue_job("download_classified_task", limit=result["violent_death"] + 50)
         logger.info(f"[CLASSIFY_BATCH] Enqueued batch download task")
     
@@ -298,11 +304,13 @@ async def enrich_task(ctx: dict, raw_event_id: int) -> dict:
 
 
 @notify_on_failure("download_batch")
-async def download_classified_task(ctx: dict, limit: int = 50) -> dict:
+async def download_classified_task(
+    ctx: dict, limit: int = 50, chain_next: bool = True
+) -> dict:
     """
     Batch task: Download content for all classified sources (ready for download).
     
-    After download, automatically enqueues batch extraction for sources
+    After download, optionally enqueues batch extraction for sources
     that were successfully downloaded (marked as ready_for_extraction).
     """
     logger.info(f"[DOWNLOAD_BATCH] Starting for up to {limit} sources")
@@ -313,8 +321,12 @@ async def download_classified_task(ctx: dict, limit: int = 50) -> dict:
     
     logger.info(f"[DOWNLOAD_BATCH] Complete: {result}")
     
-    # Chain to extraction if we have successful downloads
-    if result.get("successful", 0) > 0 and ctx.get("redis"):
+    # Chain to extraction if we have successful downloads (standalone runs only).
+    if (
+        chain_next
+        and result.get("successful", 0) > 0
+        and ctx.get("redis")
+    ):
         await ctx["redis"].enqueue_job("extract_ready_task", limit=result["successful"] + 10)
         logger.info(f"[DOWNLOAD_BATCH] Enqueued batch extraction task")
     
@@ -326,11 +338,13 @@ async def download_classified_task(ctx: dict, limit: int = 50) -> dict:
 
 
 @notify_on_failure("extract_batch")
-async def extract_ready_task(ctx: dict, limit: int = 10) -> dict:
+async def extract_ready_task(
+    ctx: dict, limit: int = 10, chain_next: bool = True
+) -> dict:
     """
     Batch task: Extract events from all sources ready for extraction.
     
-    After extraction, enqueues enrichment for each created RawEvent.
+    After extraction, optionally enqueues enrichment for each created RawEvent.
     """
     logger.info(f"[EXTRACT_BATCH] Starting for up to {limit} sources")
     
@@ -340,9 +354,9 @@ async def extract_ready_task(ctx: dict, limit: int = 10) -> dict:
     
     logger.info(f"[EXTRACT_BATCH] Complete: {result}")
     
-    # Enqueue enrichment tasks for each created RawEvent
+    # Enqueue per-raw-event enrichment (standalone runs only; full pipeline uses batch dedup).
     raw_event_ids = result.get("raw_event_ids", [])
-    if raw_event_ids and ctx.get("redis"):
+    if chain_next and raw_event_ids and ctx.get("redis"):
         for raw_event_id in raw_event_ids:
             await ctx["redis"].enqueue_job("enrich_task", raw_event_id)
         logger.info(f"[EXTRACT_BATCH] Enqueued {len(raw_event_ids)} enrichment tasks")
@@ -355,7 +369,9 @@ async def extract_ready_task(ctx: dict, limit: int = 10) -> dict:
 
 
 @notify_on_failure("batch_dedup")
-async def batch_dedup_task(ctx: dict, limit: int = 200) -> dict:
+async def batch_dedup_task(
+    ctx: dict, limit: int = 200, chain_next: bool = True
+) -> dict:
     """
     Periodic: Process pending RawEvents through batch clustering.
     
@@ -375,8 +391,12 @@ async def batch_dedup_task(ctx: dict, limit: int = 200) -> dict:
     
     logger.info(f"[BATCH_DEDUP] Complete: {result}")
     
-    # Enqueue enrichment for newly created UniqueEvents
-    if result.get("unique_events_created", 0) > 0 and ctx.get("redis"):
+    # Enqueue enrichment for newly created UniqueEvents (standalone runs only).
+    if (
+        chain_next
+        and result.get("unique_events_created", 0) > 0
+        and ctx.get("redis")
+    ):
         await ctx["redis"].enqueue_job("batch_enrich_task", limit=result["unique_events_created"] + 10)
         logger.info(f"[BATCH_DEDUP] Enqueued batch enrichment task")
     
@@ -387,7 +407,9 @@ async def batch_dedup_task(ctx: dict, limit: int = 200) -> dict:
 
 
 @notify_on_failure("batch_enrich")
-async def batch_enrich_task(ctx: dict, limit: int = 50) -> dict:
+async def batch_enrich_task(
+    ctx: dict, limit: int = 50, chain_next: bool = True
+) -> dict:
     """
     Periodic: Enrich UniqueEvents that need enrichment.
     
@@ -406,8 +428,8 @@ async def batch_enrich_task(ctx: dict, limit: int = 50) -> dict:
     
     logger.info(f"[BATCH_ENRICH] Complete: {result}")
     
-    # Chain to geocoding so newly enriched events get coordinates.
-    if ctx.get("redis"):
+    # Chain to geocoding (standalone runs only).
+    if chain_next and ctx.get("redis"):
         await ctx["redis"].enqueue_job("batch_geocode_task", limit=limit + 10)
         logger.info("[BATCH_ENRICH] Enqueued batch geocode task")
     
@@ -550,8 +572,13 @@ async def ingest_cities_full_pipeline(
     # Also requeue past failures whose cause was transient (timeouts, 5xx, rate
     # limits) and that still have retry budget left. This is best-effort
     # maintenance: a failure here must not abort the rest of the pipeline.
-    from app.services.maintenance import recover_stuck_sources, requeue_retryable_failures
+    from app.services.maintenance import (
+        checkpoint_wal,
+        recover_stuck_sources,
+        requeue_retryable_failures,
+    )
     try:
+        await checkpoint_wal()
         await recover_stuck_sources(older_than_minutes=15)
         await requeue_retryable_failures()
     except Exception as e:
@@ -562,22 +589,12 @@ async def ingest_cities_full_pipeline(
         ctx, cities=cities, when=when, enqueue_classify=False
     )
     
-    # Step 2: Classify pending sources
-    classify_result = await classify_pending_task(ctx, limit=500)
-    
-    # Step 3: Download classified sources
-    download_result = await download_classified_task(ctx, limit=500)
-    
-    # Step 4: Extract ready sources
-    extract_result = await extract_ready_task(ctx, limit=100)
-    
-    # Step 5: Batch deduplication (creates UniqueEvents from pending RawEvents)
-    dedup_result = await batch_dedup_task(ctx, limit=200)
-    
-    # Step 6: Batch enrichment (enriches UniqueEvents that need it)
-    enrich_result = await batch_enrich_task(ctx, limit=50)
-    
-    # Step 7: Batch geocoding (populates coordinates for new UniqueEvents)
+    # Steps 2-7 run inline — do not enqueue shadow jobs that compete for SQLite locks.
+    classify_result = await classify_pending_task(ctx, limit=500, chain_next=False)
+    download_result = await download_classified_task(ctx, limit=500, chain_next=False)
+    extract_result = await extract_ready_task(ctx, limit=100, chain_next=False)
+    dedup_result = await batch_dedup_task(ctx, limit=200, chain_next=False)
+    enrich_result = await batch_enrich_task(ctx, limit=50, chain_next=False)
     geocode_result = await batch_geocode_task(ctx, limit=200)
     
     duration = time.time() - start_time
@@ -606,6 +623,19 @@ async def ingest_cities_full_pipeline(
     }
 
 
+# ARQ function wrappers with per-job timeouts (manual enqueues inherit these).
+from arq.worker import func
+
+ingest_cities_full_pipeline_job = func(
+    ingest_cities_full_pipeline,
+    timeout=3600,
+    max_tries=1,
+)
+ingest_cities_task_job = func(
+    ingest_cities_task,
+    timeout=1800,
+)
+
 # List of all task functions for the worker
 TASK_FUNCTIONS = [
     ingest_task,
@@ -620,6 +650,6 @@ TASK_FUNCTIONS = [
     batch_enrich_task,
     batch_geocode_task,
     run_full_pipeline,
-    ingest_cities_task,
-    ingest_cities_full_pipeline,
+    ingest_cities_task_job,
+    ingest_cities_full_pipeline_job,
 ]

--- a/backend/app/tasks/worker.py
+++ b/backend/app/tasks/worker.py
@@ -86,7 +86,7 @@ def get_cron_jobs():
     
     Set ENABLE_CRON=true to enable scheduled jobs.
     """
-    from app.tasks.pipeline import ingest_cities_full_pipeline
+    from app.tasks.pipeline import ingest_cities_full_pipeline_job
     
     # Only enable cron if explicitly requested
     if not is_cron_enabled():
@@ -96,7 +96,7 @@ def get_cron_jobs():
         # Hourly FULL pipeline - runs at minute 5 of every hour
         # Pipeline: ingest -> classify -> download -> extract -> dedup -> enrich
         cron(
-            ingest_cities_full_pipeline,
+            ingest_cities_full_pipeline_job,
             minute=5,  # Run at :05 every hour
             timeout=3600,  # 60 minutes timeout (full pipeline takes longer)
             unique=True,  # Prevent duplicate runs

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -48,6 +48,8 @@ services:
     environment:
       - REDIS_URL=redis://redis:6379
       - DATABASE_URL=sqlite+aiosqlite:///./instance/violence.db
+      - DB_POOL_SIZE=5
+      - DB_POOL_OVERFLOW=5
       - OPENROUTER_API_KEY=${OPENROUTER_API_KEY:-}
       - DEBUG=true
       - ENVIRONMENT=development
@@ -77,6 +79,8 @@ services:
     environment:
       - REDIS_URL=redis://redis:6379
       - DATABASE_URL=sqlite+aiosqlite:///./instance/violence.db
+      - DB_POOL_SIZE=15
+      - DB_POOL_OVERFLOW=15
       - OPENROUTER_API_KEY=${OPENROUTER_API_KEY:-}
       - ENABLE_CRON=false
       - DEBUG=true

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -36,6 +36,8 @@ services:
     environment:
       - REDIS_URL=redis://redis:6379
       - DATABASE_URL=sqlite+aiosqlite:///./instance/violence.db
+      - DB_POOL_SIZE=5
+      - DB_POOL_OVERFLOW=5
       - OPENROUTER_API_KEY=${STAGING_OPENROUTER_API_KEY:-${OPENROUTER_API_KEY:-}}
       - EXTRACTION_MODEL=${STAGING_EXTRACTION_MODEL:-${EXTRACTION_MODEL:-deepseek/deepseek-v4-flash}}
       - SELECTION_MODEL=${STAGING_SELECTION_MODEL:-${SELECTION_MODEL:-openai/gpt-oss-120b}}
@@ -64,6 +66,8 @@ services:
     environment:
       - REDIS_URL=redis://redis:6379
       - DATABASE_URL=sqlite+aiosqlite:///./instance/violence.db
+      - DB_POOL_SIZE=15
+      - DB_POOL_OVERFLOW=15
       - OPENROUTER_API_KEY=${STAGING_OPENROUTER_API_KEY:-${OPENROUTER_API_KEY:-}}
       - EXTRACTION_MODEL=${STAGING_EXTRACTION_MODEL:-${EXTRACTION_MODEL:-deepseek/deepseek-v4-flash}}
       - SELECTION_MODEL=${STAGING_SELECTION_MODEL:-${SELECTION_MODEL:-openai/gpt-oss-120b}}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,6 +53,8 @@ services:
     environment:
       - REDIS_URL=redis://redis:6379
       - DATABASE_URL=sqlite+aiosqlite:///./instance/violence.db
+      - DB_POOL_SIZE=5
+      - DB_POOL_OVERFLOW=5
       - OPENROUTER_API_KEY=${OPENROUTER_API_KEY:-}
       - EXTRACTION_MODEL=${EXTRACTION_MODEL:-deepseek/deepseek-v4-flash}
       - SELECTION_MODEL=${SELECTION_MODEL:-openai/gpt-oss-120b}
@@ -94,6 +96,8 @@ services:
     environment:
       - REDIS_URL=redis://redis:6379
       - DATABASE_URL=sqlite+aiosqlite:///./instance/violence.db
+      - DB_POOL_SIZE=15
+      - DB_POOL_OVERFLOW=15
       - OPENROUTER_API_KEY=${OPENROUTER_API_KEY:-}
       - EXTRACTION_MODEL=${EXTRACTION_MODEL:-deepseek/deepseek-v4-flash}
       - SELECTION_MODEL=${SELECTION_MODEL:-openai/gpt-oss-120b}


### PR DESCRIPTION
## Summary
- Add `chain_next=False` to all inline steps in `ingest_cities_full_pipeline` so the hourly run does not spawn parallel shadow ARQ jobs (classify → download → extract → dedup → enrich → geocode)
- Wrap `ingest_cities_full_pipeline` with ARQ `func(timeout=3600, max_tries=1)` so manual/API triggers survive long backlogs
- Reduce SQLite contention: smaller API/worker connection pools, enrich concurrency 5→2, WAL checkpoint on pipeline startup, retry enrich writes on lock
- Reset sources still in `classifying` when batch classification is cancelled or errors mid-batch

## Test plan
- [ ] Deploy to staging and trigger `/api/pipeline/ingest-cities-pipeline`; confirm it runs >10 min and completes
- [ ] Worker logs during full pipeline: no `Enqueued batch download/extraction/enrichment` lines
- [ ] `grep "database is locked"` empty during a full staging run
- [ ] Standalone `/api/pipeline/classify?limit=50` still chains to download (`chain_next=True` default)


Made with [Cursor](https://cursor.com)