### PR TITLE
Release: promote develop to production

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,8 +6,9 @@
 # =============================================================================
 
 # --- Pipeline scheduling -----------------------------------------------------
-# MUST be "true" in production, otherwise the hourly ingestion cron never runs
-# and nothing gets downloaded or classified (the queue just stays empty).
+# MUST be "true" in production. Enables two crons on the worker:
+#   :05 UTC — hourly city ingest (ingest_cities_hourly)
+#   :35 UTC — hourly backlog processing (classify/download/extract/dedup)
 ENABLE_CRON=true
 
 # --- LLM (Gemini) ------------------------------------------------------------

--- a/backend/app/services/ingestion.py
+++ b/backend/app/services/ingestion.py
@@ -7,20 +7,20 @@ from datetime import datetime
 import feedparser
 import googlenewsdecoder
 from loguru import logger
+from sqlalchemy.exc import IntegrityError
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.database import async_session_maker
-from app.models import SourceGoogleNews, SourceStatus, CityStats
+from app.models import CityStats, SourceGoogleNews, SourceStatus
 from app.services.cities import (
-    CITIES,
     BRAZILIAN_NEWS_SOURCES,
+    CITIES,
+    DEFAULT_WHEN,
     REQUEST_INTERVAL_SECONDS,
     REQUESTS_PER_MINUTE,
     SHARDING_THRESHOLD,
-    DEFAULT_WHEN,
 )
-
 
 # Google News RSS configuration for Brazil
 GOOGLE_NEWS_BASE_URL = "https://news.google.com/rss/search"
@@ -370,65 +370,68 @@ async def ingest_city(
         # Update city stats (this may enable sharding for next run)
         await update_city_stats(city, total_count, session)
     
-    # Now save the entries to database
+    # Now save the entries to database (one savepoint per row so parallel city
+    # ingests that hit the same google_news_id do not fail the whole batch).
     new_sources = []
-    
+
     async with async_session_maker() as session:
         for entry in all_entries:
-            # Extract Google News ID
             google_news_id = entry.get("id") or entry.get("link", "")
-            
-            # Check if already exists
-            existing = await session.exec(
-                select(SourceGoogleNews).where(
-                    SourceGoogleNews.google_news_id == google_news_id
-                )
-            )
-            if existing.first():
+            if not google_news_id:
                 continue
-            
-            # Parse headline and publisher
+
             title = entry.get("title", "")
             headline, publisher_name = parse_headline_and_publisher(title)
-            
-            # Get publisher URL
+
             source_info = entry.get("source", {})
             publisher_url = source_info.get("href") if isinstance(source_info, dict) else None
-            
-            # Parse publication date
+
             published_at = None
             if hasattr(entry, "published_parsed") and entry.published_parsed:
                 try:
                     published_at = datetime(*entry.published_parsed[:6])
                 except Exception:
                     pass
-            
-            # Resolve URL if requested
+
             google_news_url = entry.get("link", "")
             resolved_url = None
             if resolve_urls:
                 resolved_url = resolve_google_news_url(google_news_url)
 
-            if await _resolved_url_exists(session, resolved_url):
+            try:
+                async with session.begin_nested():
+                    existing = await session.exec(
+                        select(SourceGoogleNews).where(
+                            SourceGoogleNews.google_news_id == google_news_id
+                        )
+                    )
+                    if existing.first():
+                        continue
+
+                    if await _resolved_url_exists(session, resolved_url):
+                        continue
+
+                    source = SourceGoogleNews(
+                        google_news_id=google_news_id,
+                        google_news_url=google_news_url,
+                        resolved_url=resolved_url,
+                        headline=headline,
+                        publisher_name=publisher_name,
+                        publisher_url=publisher_url,
+                        published_at=published_at,
+                        search_query=entry.get("_search_query"),
+                        status=SourceStatus.ready_for_classification,
+                        fetched_at=datetime.utcnow(),
+                    )
+                    session.add(source)
+                    await session.flush()
+                    new_sources.append(source)
+            except IntegrityError:
+                logger.debug(
+                    f"[{city}] Skipping duplicate google_news_id (parallel ingest race)"
+                )
                 continue
-            
-            # Create source record
-            source = SourceGoogleNews(
-                google_news_id=google_news_id,
-                google_news_url=google_news_url,
-                resolved_url=resolved_url,
-                headline=headline,
-                publisher_name=publisher_name,
-                publisher_url=publisher_url,
-                published_at=published_at,
-                search_query=entry.get("_search_query"),
-                status=SourceStatus.ready_for_classification,
-                fetched_at=datetime.utcnow(),
-            )
-            
-            session.add(source)
-            new_sources.append(source)
-        
+
         if new_sources:
             await session.commit()
             for source in new_sources:
@@ -509,7 +512,7 @@ async def ingest_all_cities(
     errors = sum(1 for r in city_results.values() if r["status"] == "error")
     
     logger.info(f"\n{'='*60}")
-    logger.info(f"INGESTION COMPLETE")
+    logger.info("INGESTION COMPLETE")
     logger.info(f"Cities processed: {len(cities)}")
     logger.info(f"Total entries fetched: {total_entries}")
     logger.info(f"Total new sources created: {total_sources}")

--- a/backend/app/tasks/pipeline.py
+++ b/backend/app/tasks/pipeline.py
@@ -584,6 +584,102 @@ async def _run_classify_until_drained(
     return totals
 
 
+async def _run_pipeline_maintenance() -> None:
+    """Recover stuck rows and requeue transient failures. Best-effort, non-fatal."""
+    from app.services.maintenance import (
+        checkpoint_wal,
+        recover_stuck_sources,
+        requeue_retryable_failures,
+    )
+
+    try:
+        await checkpoint_wal()
+        await recover_stuck_sources(older_than_minutes=15)
+        await requeue_retryable_failures()
+    except Exception as e:
+        logger.warning(f"[PIPELINE_MAINTENANCE] Failed (continuing): {e}")
+
+
+async def _process_cities_backlog_steps(ctx: dict) -> dict:
+    """Run classify → download → extract → dedup → enrich → geocode (no ingest)."""
+    classify_result = await _run_classify_until_drained(
+        limit_per_batch=150,
+        max_batches=12,
+        concurrency=15,
+    )
+    download_result = await download_classified_task(ctx, limit=500, chain_next=False)
+    extract_result = await extract_ready_task(ctx, limit=100, chain_next=False)
+    dedup_result = await batch_dedup_task(ctx, limit=200, chain_next=False)
+    enrich_result = await batch_enrich_task(ctx, limit=50, chain_next=False)
+    geocode_result = await batch_geocode_task(ctx, limit=200)
+    return {
+        "classify": classify_result,
+        "download": download_result,
+        "extract": extract_result,
+        "dedup": dedup_result,
+        "enrich": enrich_result,
+        "geocode": geocode_result,
+    }
+
+
+@notify_on_failure("ingest_cities_hourly")
+async def ingest_cities_hourly(
+    ctx: dict,
+    cities: list[str] | None = None,
+    when: str = "1h",
+) -> dict:
+    """
+    Hourly cron: ingest only.
+
+    Kept short so the :05 tick always runs even while backlog processing from
+    a prior hour is still in progress (separate cron at :35).
+    """
+    logger.info("[INGEST_HOURLY] Starting hourly city ingest")
+    await _run_pipeline_maintenance()
+    return await ingest_cities_task(
+        ctx, cities=cities, when=when, enqueue_classify=False
+    )
+
+
+@notify_on_failure("process_cities_backlog")
+async def process_cities_backlog(ctx: dict) -> dict:
+    """
+    Hourly cron: drain classify/download/extract/dedup backlog.
+
+    Runs maintenance first, then processes accumulated sources from ingest and
+    prior runs. May take up to 2 hours at peak load; unique=True prevents overlap.
+    """
+    logger.info("[CITIES_BACKLOG] Starting backlog processing")
+    start_time = time.time()
+
+    await notify_job_started("process_cities_backlog", {})
+    await _run_pipeline_maintenance()
+
+    steps = await _process_cities_backlog_steps(ctx)
+    duration = time.time() - start_time
+
+    classify_result = steps["classify"]
+    download_result = steps["download"]
+    extract_result = steps["extract"]
+    dedup_result = steps["dedup"]
+
+    await notify_pipeline_summary(
+        total_sources=0,
+        sources_classified=classify_result.get("violent_death", 0),
+        sources_downloaded=download_result.get("successful", 0),
+        raw_events_extracted=extract_result.get("raw_events_created", 0),
+        unique_events_created=dedup_result.get("unique_events_created", 0),
+        duration_seconds=duration,
+    )
+
+    return {
+        "status": "completed",
+        "task": "process_cities_backlog",
+        "duration_seconds": duration,
+        **steps,
+    }
+
+
 @notify_on_failure("cities_full_pipeline")
 async def ingest_cities_full_pipeline(
     ctx: dict,
@@ -602,43 +698,21 @@ async def ingest_cities_full_pipeline(
     # Notify job started
     await notify_job_started("cities_full_pipeline", {"when": when})
     
-    # Step 0: Recover any sources stranded in a transient processing state by a
-    # previous run (e.g. due to a crash or DB contention), so they get reprocessed.
-    # Also requeue past failures whose cause was transient (timeouts, 5xx, rate
-    # limits) and that still have retry budget left. This is best-effort
-    # maintenance: a failure here must not abort the rest of the pipeline.
-    from app.services.maintenance import (
-        checkpoint_wal,
-        recover_stuck_sources,
-        requeue_retryable_failures,
-    )
-    try:
-        await checkpoint_wal()
-        await recover_stuck_sources(older_than_minutes=15)
-        await requeue_retryable_failures()
-    except Exception as e:
-        logger.warning(f"[CITIES_PIPELINE] Maintenance step failed (continuing): {e}")
-    
+    await _run_pipeline_maintenance()
+
     # Step 1: Ingest cities (classify runs inline in Step 2 — do not enqueue).
     ingest_result = await ingest_cities_task(
         ctx, cities=cities, when=when, enqueue_classify=False
     )
-    
-    # Steps 2-7 run inline on Postgres (no cross-job lock contention).
-    classify_result = await _run_classify_until_drained(
-        limit_per_batch=150,
-        max_batches=12,
-        concurrency=15,
-    )
-    download_result = await download_classified_task(ctx, limit=500, chain_next=False)
-    extract_result = await extract_ready_task(ctx, limit=100, chain_next=False)
-    dedup_result = await batch_dedup_task(ctx, limit=200, chain_next=False)
-    enrich_result = await batch_enrich_task(ctx, limit=50, chain_next=False)
-    geocode_result = await batch_geocode_task(ctx, limit=200)
-    
+
+    steps = await _process_cities_backlog_steps(ctx)
     duration = time.time() - start_time
-    
-    # Send pipeline summary notification
+
+    classify_result = steps["classify"]
+    download_result = steps["download"]
+    extract_result = steps["extract"]
+    dedup_result = steps["dedup"]
+
     await notify_pipeline_summary(
         total_sources=ingest_result.get("total_sources_created", 0),
         sources_classified=classify_result.get("violent_death", 0),
@@ -647,18 +721,13 @@ async def ingest_cities_full_pipeline(
         unique_events_created=dedup_result.get("unique_events_created", 0),
         duration_seconds=duration,
     )
-    
+
     return {
         "status": "completed",
         "task": "cities_full_pipeline",
         "duration_seconds": duration,
         "ingest": ingest_result,
-        "classify": classify_result,
-        "download": download_result,
-        "extract": extract_result,
-        "dedup": dedup_result,
-        "enrich": enrich_result,
-        "geocode": geocode_result,
+        **steps,
     }
 
 
@@ -673,6 +742,16 @@ ingest_cities_full_pipeline_job = func(
 ingest_cities_task_job = func(
     ingest_cities_task,
     timeout=1800,
+)
+ingest_cities_hourly_job = func(
+    ingest_cities_hourly,
+    timeout=1800,
+    max_tries=1,
+)
+process_cities_backlog_job = func(
+    process_cities_backlog,
+    timeout=7200,
+    max_tries=1,
 )
 
 # List of all task functions for the worker
@@ -691,4 +770,6 @@ TASK_FUNCTIONS = [
     run_full_pipeline,
     ingest_cities_task_job,
     ingest_cities_full_pipeline_job,
+    ingest_cities_hourly_job,
+    process_cities_backlog_job,
 ]

--- a/backend/app/tasks/worker.py
+++ b/backend/app/tasks/worker.py
@@ -87,22 +87,28 @@ def get_cron_jobs():
     
     Set ENABLE_CRON=true to enable scheduled jobs.
     """
-    from app.tasks.pipeline import ingest_cities_full_pipeline
-    
+    from app.tasks.pipeline import ingest_cities_hourly, process_cities_backlog
+
     # Only enable cron if explicitly requested
     if not is_cron_enabled():
         return []
-    
+
     return [
-        # Hourly FULL pipeline - runs at minute 5 of every hour
-        # Pipeline: ingest -> classify -> download -> extract -> dedup -> enrich
-        # cron() requires the raw coroutine; manual enqueues use the func() wrapper
-        # in TASK_FUNCTIONS for the same 7200s timeout.
+        # Hourly ingest only — short job so :05 always fires even when backlog
+        # processing from a prior hour is still running.
         cron(
-            ingest_cities_full_pipeline,
-            minute=5,  # Run at :05 every hour
-            timeout=7200,  # Full pipeline can exceed 60 minutes at peak load
-            unique=True,  # Prevent duplicate runs
+            ingest_cities_hourly,
+            minute=5,
+            timeout=1800,
+            unique=True,
+        ),
+        # Backlog drain every hour at :35 UTC (30 min after ingest at :05).
+        # May exceed 1 hour; unique=True prevents overlap but does not block ingest.
+        cron(
+            process_cities_backlog,
+            minute=35,
+            timeout=7200,
+            unique=True,
         ),
     ]
 

--- a/backend/tests/test_ingestion_dedup.py
+++ b/backend/tests/test_ingestion_dedup.py
@@ -1,0 +1,129 @@
+"""Tests for duplicate google_news_id handling during city ingest."""
+
+from datetime import datetime
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlmodel import select
+
+from app.models.source_google_news import SourceGoogleNews, SourceStatus
+from app.services.ingestion import ingest_city
+
+
+def _entry(*, entry_id: str, link: str, title: str = "Headline - Publisher"):
+    return {
+        "id": entry_id,
+        "link": link,
+        "title": title,
+        "source": {"href": "https://publisher.example"},
+        "published_parsed": (2026, 7, 7, 12, 0, 0),
+    }
+
+
+@pytest.mark.asyncio
+async def test_ingest_city_skips_existing_google_news_id(async_session):
+    existing = SourceGoogleNews(
+        google_news_id="dup-id",
+        google_news_url="https://news.google.com/existing",
+        headline="Existing",
+        status=SourceStatus.ready_for_classification,
+        fetched_at=datetime.utcnow(),
+    )
+    async_session.add(existing)
+    await async_session.commit()
+
+    class _SessionMaker:
+        def __call__(self):
+            return self
+
+        async def __aenter__(self):
+            return async_session
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    entries = [_entry(entry_id="dup-id", link="https://news.google.com/new")]
+
+    with (
+        patch("app.services.ingestion.async_session_maker", _SessionMaker()),
+        patch(
+            "app.services.ingestion.get_queries_for_city",
+            new_callable=AsyncMock,
+            return_value=["query"],
+        ),
+        patch(
+            "app.services.ingestion.rate_limited_fetch",
+            new_callable=AsyncMock,
+            return_value=entries,
+        ),
+        patch("app.services.ingestion.update_city_stats", new_callable=AsyncMock),
+        patch(
+            "app.services.ingestion.resolve_google_news_url",
+            return_value="https://article.example/1",
+        ),
+    ):
+        new_sources, total = await ingest_city("Test City", when="1h", resolve_urls=True)
+
+    assert total == 1
+    assert new_sources == []
+
+    rows = (
+        await async_session.exec(select(SourceGoogleNews))
+    ).all()
+    assert len(rows) == 1
+
+
+@pytest.mark.asyncio
+async def test_ingest_city_continues_after_integrity_error_on_flush(async_session):
+    class _SessionMaker:
+        def __call__(self):
+            return self
+
+        async def __aenter__(self):
+            return async_session
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    entries = [
+        _entry(entry_id="race-id", link="https://news.google.com/race"),
+        _entry(entry_id="ok-id", link="https://news.google.com/ok"),
+    ]
+
+    real_flush = async_session.flush
+    flush_calls = {"count": 0}
+
+    async def flush_with_race(*args, **kwargs):
+        flush_calls["count"] += 1
+        if flush_calls["count"] == 1:
+            from sqlalchemy.exc import IntegrityError
+
+            raise IntegrityError("duplicate", params=None, orig=Exception("dup"))
+        return await real_flush(*args, **kwargs)
+
+    with (
+        patch("app.services.ingestion.async_session_maker", _SessionMaker()),
+        patch(
+            "app.services.ingestion.get_queries_for_city",
+            new_callable=AsyncMock,
+            return_value=["query"],
+        ),
+        patch(
+            "app.services.ingestion.rate_limited_fetch",
+            new_callable=AsyncMock,
+            return_value=entries,
+        ),
+        patch("app.services.ingestion.update_city_stats", new_callable=AsyncMock),
+        patch(
+            "app.services.ingestion.resolve_google_news_url",
+            side_effect=[
+                "https://article.example/race",
+                "https://article.example/ok",
+            ],
+        ),
+        patch.object(async_session, "flush", side_effect=flush_with_race),
+    ):
+        new_sources, _total = await ingest_city("Test City", when="1h", resolve_urls=True)
+
+    assert len(new_sources) == 1
+    assert new_sources[0].google_news_id == "ok-id"

--- a/backend/tests/test_pipeline_cron_tasks.py
+++ b/backend/tests/test_pipeline_cron_tasks.py
@@ -1,0 +1,77 @@
+"""Tests for split hourly ingest / backlog cron tasks."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.tasks.pipeline import (
+    ingest_cities_hourly,
+    process_cities_backlog,
+)
+
+
+@pytest.mark.asyncio
+async def test_ingest_cities_hourly_does_not_enqueue_classify():
+    ctx = {"redis": AsyncMock()}
+    ingest_result = {"total_sources_created": 3, "status": "completed"}
+
+    with (
+        patch(
+            "app.tasks.pipeline._run_pipeline_maintenance",
+            new_callable=AsyncMock,
+        ) as mock_maint,
+        patch(
+            "app.tasks.pipeline.ingest_cities_task",
+            new_callable=AsyncMock,
+            return_value=ingest_result,
+        ) as mock_ingest,
+    ):
+        result = await ingest_cities_hourly(ctx, when="1h")
+
+    mock_maint.assert_awaited_once()
+    mock_ingest.assert_awaited_once_with(
+        ctx, cities=None, when="1h", enqueue_classify=False
+    )
+    assert result == ingest_result
+    ctx["redis"].enqueue_job.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_process_cities_backlog_runs_maintenance_and_steps():
+    ctx = {}
+    steps = {
+        "classify": {"violent_death": 2, "processed": 10},
+        "download": {"successful": 1},
+        "extract": {"raw_events_created": 1},
+        "dedup": {"unique_events_created": 1},
+        "enrich": {},
+        "geocode": {},
+    }
+
+    with (
+        patch(
+            "app.tasks.pipeline._run_pipeline_maintenance",
+            new_callable=AsyncMock,
+        ) as mock_maint,
+        patch(
+            "app.tasks.pipeline._process_cities_backlog_steps",
+            new_callable=AsyncMock,
+            return_value=steps,
+        ) as mock_steps,
+        patch(
+            "app.tasks.pipeline.notify_job_started",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "app.tasks.pipeline.notify_pipeline_summary",
+            new_callable=AsyncMock,
+        ) as mock_summary,
+    ):
+        result = await process_cities_backlog(ctx)
+
+    mock_maint.assert_awaited_once()
+    mock_steps.assert_awaited_once_with(ctx)
+    mock_summary.assert_awaited_once()
+    assert result["task"] == "process_cities_backlog"
+    assert result["status"] == "completed"
+    assert result["classify"]["violent_death"] == 2

--- a/backend/tests/test_worker_cron.py
+++ b/backend/tests/test_worker_cron.py
@@ -1,0 +1,42 @@
+"""Tests for ARQ worker cron configuration."""
+
+from unittest.mock import patch
+
+from app.tasks.worker import get_cron_jobs, is_cron_enabled
+
+
+def test_is_cron_enabled_false_by_default(monkeypatch):
+    monkeypatch.delenv("ENABLE_CRON", raising=False)
+    assert is_cron_enabled() is False
+
+
+def test_is_cron_enabled_true_when_set(monkeypatch):
+    monkeypatch.setenv("ENABLE_CRON", "true")
+    assert is_cron_enabled() is True
+
+
+def test_get_cron_jobs_empty_when_disabled():
+    with patch("app.tasks.worker.is_cron_enabled", return_value=False):
+        assert get_cron_jobs() == []
+
+
+def test_get_cron_jobs_split_ingest_and_backlog_when_enabled():
+    with patch("app.tasks.worker.is_cron_enabled", return_value=True):
+        jobs = get_cron_jobs()
+
+    assert len(jobs) == 2
+
+    by_name = {job.coroutine.__name__: job for job in jobs}
+    assert "ingest_cities_hourly" in by_name
+    assert "process_cities_backlog" in by_name
+
+    ingest = by_name["ingest_cities_hourly"]
+    backlog = by_name["process_cities_backlog"]
+
+    assert ingest.minute == 5
+    assert ingest.timeout_s == 1800
+    assert ingest.unique is True
+
+    assert backlog.minute == 35
+    assert backlog.timeout_s == 7200
+    assert backlog.unique is True

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@
 #
 # Environment variables (create .env file):
 #   OPENROUTER_API_KEY=your-api-key
-#   ENABLE_CRON=true  # Enable hourly ingestion
+#   ENABLE_CRON=true  # :05 ingest + :35 backlog (hourly)
 #   TELEGRAM_BOT_TOKEN=your-bot-token  # For notifications
 #   TELEGRAM_CHAT_ID=your-chat-id
 #   GITHUB_TOKEN=your-github-token  # For creating issues on failures

--- a/frontend/src/lib/methodology.ts
+++ b/frontend/src/lib/methodology.ts
@@ -149,7 +149,7 @@ const PT: MethodologyContent = {
       id: 'schedule',
       title: 'Atualização',
       paragraphs: [
-        'Quando ENABLE_CRON=true no worker, o pipeline completo roda automaticamente no minuto 5 de cada hora (:05). Timeout de 60 minutos por execução. Antes de cada run, o sistema recupera fontes presas e re-enfileira falhas transientes.',
+        'Quando ENABLE_CRON=true no worker, a ingestão roda no minuto 5 de cada hora (:05 UTC) e o processamento do backlog (classificar, baixar, extrair, deduplicar) no minuto 35 (:35 UTC), ambos a cada hora. A ingestão é independente do processamento, para que novas fontes entrem mesmo quando um run longo ainda está em andamento.',
         'O mapa público carrega eventos dos últimos 365 dias. A data "desde" exibida na interface corresponde ao evento mais antigo com data registrada no arquivo.',
       ],
     },
@@ -308,7 +308,7 @@ const EN: MethodologyContent = {
     id: 'schedule',
     title: 'Update schedule',
     paragraphs: [
-      'When ENABLE_CRON=true on the worker, the full pipeline runs automatically at minute 5 of every hour (:05). 60-minute timeout per run. Before each run, the system recovers stuck sources and re-queues transient failures.',
+      'When ENABLE_CRON=true on the worker, ingestion runs at minute 5 of every hour (:05 UTC) and backlog processing (classify, download, extract, dedup) at minute 35 (:35 UTC), both hourly. Ingest is decoupled from processing so new sources are fetched even while a long prior run is still in progress.',
       'The public map loads events from the last 365 days. The "since" date shown in the interface corresponds to the oldest dated event in the archive.',
     ],
   },

--- a/scripts/check-pipeline-health.sh
+++ b/scripts/check-pipeline-health.sh
@@ -137,20 +137,25 @@ FROM source_google_news
 WHERE status IN ('classifying', 'downloading', 'extracting')
   AND updated_at > now() - interval '${PIPELINE_ACTIVITY_MINUTES} minutes';
 " 2>/dev/null || echo "error")"
-  if echo "$worker_logs_age" | grep -qE 'cron:ingest_cities_full_pipeline|\[CITIES_PIPELINE\] Starting'; then
+  if echo "$worker_logs_age" | grep -qE 'cron:ingest_cities_hourly|cron:ingest_cities_full_pipeline|\[INGEST_HOURLY\]|\[CITIES_PIPELINE\] Starting|\[INGEST_CITIES\] Starting'; then
       recent_start=true
   fi
-  # Long runs (up to 2h) can outlive the start-log window; treat active stages as healthy.
+  # Long backlog runs (up to 2h) can outlive the start-log window; track processing separately.
   if echo "$worker_logs_activity" | grep -qE \
-      '\[CITIES_PIPELINE\]|cron:ingest_cities_full_pipeline|classify_source:|Classification complete:|\[Batch Dedup\]|\[Ingest\]|\[Download\]|\[Extract\]'; then
+      '\[CITIES_BACKLOG\]|\[CITIES_PIPELINE\]|\[INGEST_HOURLY\]|cron:ingest_cities_hourly|cron:process_cities_backlog|cron:ingest_cities_full_pipeline|classify_source:|Classification complete:|\[Batch Dedup\]|\[Ingest\]|\[Download\]|\[Extract\]'; then
       recent_activity=true
   fi
   if [ "$active_sources" != "error" ] && [ "${active_sources:-0}" -gt 0 ]; then
       recent_activity=true
       DETAILS+=("OK: active_pipeline_sources(${active_sources})")
   fi
-  if [ "$recent_start" = true ] || [ "$recent_activity" = true ]; then
-      DETAILS+=("OK: recent_pipeline_activity")
+  if [ "$recent_start" = true ]; then
+      DETAILS+=("OK: recent_ingest")
+      if [ "$recent_activity" = true ]; then
+          DETAILS+=("OK: recent_pipeline_activity")
+      fi
+  elif [ "$recent_activity" = true ]; then
+      record_failure "backlog_active_but_no_recent_ingest(within_${MAX_PIPELINE_AGE_MINUTES}m)"
   else
       record_failure "no_recent_pipeline_run(within_${MAX_PIPELINE_AGE_MINUTES}m)"
   fi


### PR DESCRIPTION
## Summary
- Split hourly pipeline cron: ingest at :05 UTC, backlog processing at :35 UTC (both every hour)
- Fix parallel city ingest duplicate-key races with savepoints
- Tighten pipeline health check to require recent ingest activity

## Staging verification
- [x] Deploy Backend (develop) green
- [x] Deploy Frontend (develop) green
- [x] Staging health endpoint OK

## Production test plan
- [ ] Deploy Backend (master) green
- [ ] Deploy Frontend (master) green
- [ ] Production health endpoints OK
- [ ] Worker logs show `cron:ingest_cities_hourly` and `cron:process_cities_backlog`

Made with [Cursor](https://cursor.com)