### PR TITLE
Fix map reload on incident click and hex count mismatch

### DIFF
--- a/frontend/src/components/map/CrimeMap.tsx
+++ b/frontend/src/components/map/CrimeMap.tsx
@@ -19,7 +19,7 @@ import {
   peakH3Count,
   type H3GridCell,
 } from '@/lib/h3Grid';
-import { capPoints, pointsInBounds, SCATTER_ZOOM_THRESHOLD } from '@/components/portal/types';
+import { capPoints, pointsForHexGrid, pointsInBounds, SCATTER_ZOOM_THRESHOLD } from '@/components/portal/types';
 import { useI18n } from '@/contexts/I18nContext';
 import { formatPointLabel } from '@/lib/taxonomy';
 
@@ -45,6 +45,8 @@ export interface ViewportSnapshot {
 interface CrimeMapProps {
   points: MapPoint[];
   viewState: MapViewState;
+  /** Settled viewport zoom from parent — drives hex/scatter mode without mid-animation swaps. */
+  settledZoom?: number;
   /** Called when the viewport stops moving (debounced). Drives panel stats. */
   onViewportSettled?: (snapshot: ViewportSnapshot) => void;
   onPointClick: (id: number) => void;
@@ -114,6 +116,7 @@ function viewStateKey(vs: MapViewState): string {
 export function CrimeMap({
   points,
   viewState: viewStateProp,
+  settledZoom,
   onViewportSettled,
   onPointClick,
   onCellClick,
@@ -128,7 +131,10 @@ export function CrimeMap({
   const onViewportSettledRef = useRef(onViewportSettled);
   const onPointClickRef = useRef(onPointClick);
   const onCellClickRef = useRef(onCellClick);
+  const selectedIdRef = useRef(selectedId);
   const externalViewKeyRef = useRef(viewStateKey(viewStateProp));
+
+  selectedIdRef.current = selectedId;
 
   // Local view state keeps zoom/pan off the React root — MapExplorer no longer
   // re-renders RightPanel on every animation frame.
@@ -148,8 +154,9 @@ export function CrimeMap({
     }
   }, [viewStateProp]);
 
-  const showScatter = localViewState.zoom >= SCATTER_ZOOM_THRESHOLD;
-  const gridZoom = Math.floor(localViewState.zoom);
+  const layerZoom = settledZoom ?? localViewState.zoom;
+  const showScatter = layerZoom >= SCATTER_ZOOM_THRESHOLD;
+  const gridZoom = Math.floor(layerZoom);
   const h3Resolution = h3ResolutionForZoom(gridZoom);
 
   const emitViewportSettled = useCallback((vs: MapViewState) => {
@@ -192,15 +199,15 @@ export function CrimeMap({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [emitViewportSettled]);
 
-  // Layer data updates on viewport settle (not every zoom frame).
-  const culledGridPoints = useMemo(
-    () => (showScatter ? [] : cullPointsToBounds(points, renderBounds)),
+  // Hex aggregation uses strict viewport bounds (matches side panel stats/feed).
+  const gridPoints = useMemo(
+    () => (showScatter ? [] : pointsForHexGrid(points, renderBounds)),
     [points, showScatter, renderBounds]
   );
 
   const aggregatedCells = useMemo(
-    () => (showScatter ? [] : aggregatePointsToH3Cells(culledGridPoints, h3Resolution)),
-    [culledGridPoints, showScatter, h3Resolution]
+    () => (showScatter ? [] : aggregatePointsToH3Cells(gridPoints, h3Resolution)),
+    [gridPoints, showScatter, h3Resolution]
   );
 
   const gridPeakCount = useMemo(() => peakH3Count(aggregatedCells), [aggregatedCells]);
@@ -210,90 +217,101 @@ export function CrimeMap({
     return capPoints(cullPointsToBounds(points, renderBounds));
   }, [points, showScatter, renderBounds]);
 
+  const scatterLayer = useMemo(
+    () =>
+      showScatter
+        ? new ScatterplotLayer<MapPoint>({
+            id: 'events-scatter',
+            data: scatterData,
+            getPosition: (d) => [d.lng, d.lat],
+            getRadius: (d) => 4 + Math.min(d.v ?? 1, 5) * 1.6,
+            radiusUnits: 'pixels',
+            radiusMinPixels: 3,
+            getFillColor: (d) =>
+              d.id === selectedIdRef.current ? [47, 102, 207, 235] : [200, 71, 63, 225],
+            getLineColor: (d) =>
+              d.id === selectedIdRef.current ? [27, 68, 144, 255] : [255, 255, 255, 220],
+            lineWidthUnits: 'pixels',
+            getLineWidth: (d) => (d.id === selectedIdRef.current ? 2.5 : 1.2),
+            stroked: true,
+            pickable: true,
+            updateTriggers: {
+              getFillColor: [selectedId],
+              getLineColor: [selectedId],
+              getLineWidth: [selectedId],
+            },
+            onClick: (info: PickingInfo) => {
+              if (info.object) onPointClickRef.current((info.object as MapPoint).id);
+              return true;
+            },
+          })
+        : null,
+    [scatterData, showScatter, selectedId]
+  );
+
+  const gridLayer = useMemo(
+    () =>
+      !showScatter
+        ? new H3HexagonLayer<H3GridCell>({
+            id: 'events-grid',
+            data: aggregatedCells,
+            getHexagon: (d) => d.hexagon,
+            getFillColor: (d) => colorForH3Count(d.count, gridPeakCount, COLOR_RANGE),
+            extruded: false,
+            pickable: true,
+            opacity: 0.78,
+            highPrecision: true,
+            updateTriggers: {
+              getFillColor: [gridPeakCount],
+            },
+            onClick: (info: PickingInfo) => {
+              const cell = info.object as H3GridCell | undefined;
+              if (cell?.hexagon) {
+                const [lat, lng] = cellToLatLng(cell.hexagon);
+                onCellClickRef.current?.([lng, lat]);
+              }
+              return true;
+            },
+          })
+        : null,
+    [aggregatedCells, showScatter, gridPeakCount]
+  );
+
+  const searchLayer = useMemo(
+    () =>
+      searchedLocation
+        ? new ScatterplotLayer<{ lat: number; lng: number }>({
+            id: 'search-marker',
+            data: [searchedLocation],
+            getPosition: (d) => [d.lng, d.lat],
+            getRadius: 9,
+            radiusUnits: 'pixels',
+            getFillColor: [47, 102, 207, 255],
+            getLineColor: [255, 255, 255, 255],
+            lineWidthUnits: 'pixels',
+            getLineWidth: 2,
+            stroked: true,
+            pickable: false,
+          })
+        : null,
+    [searchedLocation]
+  );
+
   const layers = useMemo(() => {
     const result: Layer[] = [];
-
-    if (showScatter) {
-      result.push(
-        new ScatterplotLayer<MapPoint>({
-          id: 'events-scatter',
-          data: scatterData,
-          getPosition: (d) => [d.lng, d.lat],
-          getRadius: (d) => 4 + Math.min(d.v ?? 1, 5) * 1.6,
-          radiusUnits: 'pixels',
-          radiusMinPixels: 3,
-          getFillColor: (d) =>
-            d.id === selectedId ? [47, 102, 207, 235] : [200, 71, 63, 225],
-          getLineColor: (d) => (d.id === selectedId ? [27, 68, 144, 255] : [255, 255, 255, 220]),
-          lineWidthUnits: 'pixels',
-          getLineWidth: (d) => (d.id === selectedId ? 2.5 : 1.2),
-          stroked: true,
-          pickable: true,
-          updateTriggers: {
-            getFillColor: [selectedId],
-            getLineColor: [selectedId],
-            getLineWidth: [selectedId],
-          },
-          onClick: (info: PickingInfo) => {
-            if (info.object) onPointClickRef.current((info.object as MapPoint).id);
-            return true;
-          },
-        })
-      );
-    } else {
-      result.push(
-        new H3HexagonLayer<H3GridCell>({
-          id: 'events-grid',
-          data: aggregatedCells,
-          getHexagon: (d) => d.hexagon,
-          getFillColor: (d) => colorForH3Count(d.count, gridPeakCount, COLOR_RANGE),
-          extruded: false,
-          pickable: true,
-          opacity: 0.78,
-          highPrecision: true,
-          updateTriggers: {
-            getFillColor: [gridPeakCount],
-          },
-          onClick: (info: PickingInfo) => {
-            const cell = info.object as H3GridCell | undefined;
-            if (cell?.hexagon) {
-              const [lat, lng] = cellToLatLng(cell.hexagon);
-              onCellClickRef.current?.([lng, lat]);
-            }
-            return true;
-          },
-        })
-      );
-    }
-
-    if (searchedLocation) {
-      result.push(
-        new ScatterplotLayer<{ lat: number; lng: number }>({
-          id: 'search-marker',
-          data: [searchedLocation],
-          getPosition: (d) => [d.lng, d.lat],
-          getRadius: 9,
-          radiusUnits: 'pixels',
-          getFillColor: [47, 102, 207, 255],
-          getLineColor: [255, 255, 255, 255],
-          lineWidthUnits: 'pixels',
-          getLineWidth: 2,
-          stroked: true,
-          pickable: false,
-        })
-      );
-    }
-
+    if (scatterLayer) result.push(scatterLayer);
+    if (gridLayer) result.push(gridLayer);
+    if (searchLayer) result.push(searchLayer);
     return result;
-  }, [aggregatedCells, scatterData, showScatter, gridPeakCount, searchedLocation, selectedId]);
+  }, [scatterLayer, gridLayer, searchLayer]);
 
   return (
     <div ref={containerRef} className="absolute inset-0">
-      {!hasSize ? null : (
       <DeckGL
         viewState={localViewState as unknown as DeckViewState}
         controller={true}
         layers={layers}
+        style={{ visibility: hasSize ? 'visible' : 'hidden' }}
         onViewStateChange={(params) => {
           const vs = params.viewState as unknown as MapViewState;
           setLocalViewState(vs);
@@ -315,9 +333,8 @@ export function CrimeMap({
           return { text: `${count} ${unit}` };
         }}
       >
-        <Map mapStyle={MAP_STYLE} />
+        <Map mapStyle={MAP_STYLE} reuseMaps />
       </DeckGL>
-      )}
     </div>
   );
 }

--- a/frontend/src/components/portal/types.ts
+++ b/frontend/src/components/portal/types.ts
@@ -363,13 +363,19 @@ export function trendChartScale(peak: number): { scaleMax: number; ticks: number
 /** Zoom level at which the map switches from density grid to individual markers. */
 export const SCATTER_ZOOM_THRESHOLD = 12;
 
+/** Points included in H3 hex aggregation — strict viewport, no nationwide fallback. */
+export function pointsForHexGrid(points: MapPoint[], bounds: MapBounds | null): MapPoint[] {
+  if (!bounds) return [];
+  return pointsInBounds(points, bounds);
+}
+
 /** Peak fatal-victim count in any single H3 grid cell for the current viewport and zoom. */
 export function computeGridPeakCount(
   points: MapPoint[],
   bounds: MapBounds | null,
   zoom: number
 ): number {
-  const inView = bounds ? pointsInBounds(points, bounds) : points;
+  const inView = bounds ? pointsForHexGrid(points, bounds) : points;
   if (inView.length === 0) return 0;
   const resolution = h3ResolutionForZoom(zoom);
   const cells = aggregatePointsToH3Cells(inView, resolution);

--- a/frontend/src/lib/h3Grid.test.ts
+++ b/frontend/src/lib/h3Grid.test.ts
@@ -6,7 +6,7 @@ import {
   h3ResolutionForZoom,
   peakH3Count,
 } from '@/lib/h3Grid';
-import { computeGridPeakCount } from '@/components/portal/types';
+import { computeGridPeakCount, pointsForHexGrid } from '@/components/portal/types';
 
 function point(lat: number, lng: number, v = 1, id = 1): MapPoint {
   return {
@@ -73,6 +73,30 @@ describe('aggregatePointsToH3Cells', () => {
       resolution
     );
     expect(peakH3Count(cells)).toBe(5);
+  });
+});
+
+describe('pointsForHexGrid', () => {
+  it('returns empty when bounds are not ready', () => {
+    const points = [point(-23.55, -46.63, 2, 1)];
+    expect(pointsForHexGrid(points, null)).toEqual([]);
+  });
+
+  it('excludes out-of-bounds points so hex counts stay viewport-scoped', () => {
+    const bounds: [[number, number], [number, number]] = [
+      [-47, -24],
+      [-43, -22],
+    ];
+    const inView = point(-23.55, -46.63, 5, 1);
+    const outOfView = point(-10, -50, 99, 2);
+    const resolution = h3ResolutionForZoom(8);
+
+    const scoped = pointsForHexGrid([inView, outOfView], bounds);
+    const cells = aggregatePointsToH3Cells(scoped, resolution);
+
+    expect(scoped).toHaveLength(1);
+    expect(cells).toHaveLength(1);
+    expect(cells[0].count).toBe(5);
   });
 });
 

--- a/frontend/src/pages/public/MapExplorer.tsx
+++ b/frontend/src/pages/public/MapExplorer.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate, useParams, useLocation } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { FlyToInterpolator } from '@deck.gl/core';
@@ -22,6 +22,7 @@ import {
   hasActiveFilters,
   computeGeoCentroid,
   geoFlyZoom,
+  SCATTER_ZOOM_THRESHOLD,
   type FilterGroup,
   type PortalFilters,
   type PortalMode,
@@ -71,6 +72,7 @@ export function MapExplorer() {
   const [aboutOpen, setAboutOpen] = useState(aboutFromRoute);
   const [methodologyOpen, setMethodologyOpen] = useState(methodologyFromRoute);
   const [mobilePanelOpen, setMobilePanelOpen] = useState(false);
+  const flyInterpolatorRef = useRef(new FlyToInterpolator({ speed: 1.4 }));
 
   const { data, isLoading } = useQuery({
     queryKey: ['map-points', MAP_DAYS],
@@ -110,7 +112,7 @@ export function MapExplorer() {
       latitude: lat,
       zoom,
       transitionDuration: 900,
-      transitionInterpolator: new FlyToInterpolator({ speed: 1.4 }),
+      transitionInterpolator: flyInterpolatorRef.current,
     }));
   }, []);
 
@@ -151,21 +153,28 @@ export function MapExplorer() {
     (eventId: number) => {
       const point = allPoints.find((p) => p.id === eventId);
       if (point) {
-        setViewState((prev) => ({
-          ...prev,
-          longitude: point.lng,
-          latitude: point.lat,
-          zoom: Math.max(prev.zoom, 12.5),
-          transitionDuration: 900,
-          transitionInterpolator: new FlyToInterpolator({ speed: 1.4 }),
-        }));
+        const alreadyVisible =
+          panelZoom >= SCATTER_ZOOM_THRESHOLD &&
+          panelBounds != null &&
+          pointsInBounds([point], panelBounds).length > 0;
+
+        if (!alreadyVisible) {
+          setViewState((prev) => ({
+            ...prev,
+            longitude: point.lng,
+            latitude: point.lat,
+            zoom: Math.max(prev.zoom, 12.5),
+            transitionDuration: 900,
+            transitionInterpolator: flyInterpolatorRef.current,
+          }));
+        }
       }
       if (isMobile) {
         setMobilePanelOpen(true);
       }
       navigate(`/eventos/${eventId}`);
     },
-    [allPoints, navigate, isMobile]
+    [allPoints, navigate, isMobile, panelZoom, panelBounds]
   );
 
   const onCloseDetail = useCallback(() => {
@@ -188,7 +197,7 @@ export function MapExplorer() {
         latitude: coordinate[1],
         zoom: Math.min(prev.zoom + 2.5, 13),
         transitionDuration: 900,
-        transitionInterpolator: new FlyToInterpolator({ speed: 1.4 }),
+        transitionInterpolator: flyInterpolatorRef.current,
       }));
     },
     []
@@ -199,7 +208,7 @@ export function MapExplorer() {
     setViewState({
       ...BRAZIL_VIEW,
       transitionDuration: 700,
-      transitionInterpolator: new FlyToInterpolator({ speed: 1.4 }),
+      transitionInterpolator: flyInterpolatorRef.current,
     });
   }, []);
 
@@ -277,6 +286,7 @@ export function MapExplorer() {
           <CrimeMap
             points={filteredPoints}
             viewState={viewState}
+            settledZoom={panelZoom}
             onViewportSettled={handleViewportSettled}
             onPointClick={onSelect}
             onCellClick={onCellClick}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes two map portal UX bugs:

1. **Map reload on incident click** — Selecting a visible incident no longer triggers an unnecessary 900ms fly-to, mid-animation hex/scatter layer swaps, or MapLibre teardown from conditional `DeckGL` mounting.
2. **Hex count mismatch** — H3 hex tooltips now use strict viewport bounds (matching the side panel feed/stats) instead of summing victims nationwide when the dataset is small.

## Changes

- **`CrimeMap.tsx`**
  - Hex aggregation uses `pointsForHexGrid` (strict viewport bounds).
  - Scatter markers still use padded `cullPointsToBounds` for performance.
  - Layer mode (`hex` vs `scatter`) driven by `settledZoom` prop from parent, not animated zoom.
  - `DeckGL` stays mounted (`visibility: hidden` until sized); `reuseMaps` on MapLibre.
  - Split layer construction to limit churn on selection highlight.

- **`MapExplorer.tsx`**
  - Skips fly-to when incident is already visible at scatter zoom inside `panelBounds`.
  - Reuses a single `FlyToInterpolator` instance.
  - Passes `settledZoom={panelZoom}` to `CrimeMap`.

- **`types.ts`**
  - Added shared `pointsForHexGrid` helper used by hex aggregation and `computeGridPeakCount`.

- **`h3Grid.test.ts`**
  - Added tests ensuring out-of-bounds points do not inflate hex counts.

## Verification

- `npm run build` — pass
- `npm test -- --run src/lib/h3Grid.test.ts` — 7 tests pass
- `npm run lint` — pre-existing errors in unrelated files (not introduced by this PR)

## Manual QA

1. Zoom to scatter level (≥12), click a visible incident dot — map should highlight and open detail without basemap flash or camera jump.
2. Click an incident from the feed at low zoom — should still fly to the incident; hex layer should not flicker mid-animation.
3. Hover a hex cell in a zoomed-in area — tooltip victim count should align with visible incidents in the side panel.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1d0a20c4-48d5-45b4-aff3-33e618521727"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1d0a20c4-48d5-45b4-aff3-33e618521727"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

