### PR TITLE
fix(frontend): route nginx API proxy to explicit container names

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -14,7 +14,7 @@ server {
     
     # CSV export streams the full dataset — needs longer timeout and no buffering
     location /api/public/events/export {
-        set $backend "http://api:8000";
+        set $backend "http://arquivo-api:8000";
         proxy_pass $backend;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
@@ -30,7 +30,7 @@ server {
 
     # API proxy - passes full URI to backend (backend expects /api/ prefix)
     location /api/ {
-        set $backend "http://api:8000";
+        set $backend "http://arquivo-api:8000";
         proxy_pass $backend;
         proxy_http_version 1.1;
         proxy_set_header Host $host;

--- a/frontend/nginx.staging.conf
+++ b/frontend/nginx.staging.conf
@@ -17,7 +17,7 @@ server {
     
     # CSV export streams the full dataset — needs longer timeout and no buffering
     location /api/public/events/export {
-        set $backend "http://api:8000";
+        set $backend "http://staging-arquivo-api:8000";
         proxy_pass $backend;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
@@ -33,7 +33,7 @@ server {
 
     # API proxy - passes full URI to backend (backend expects /api/ prefix)
     location /api/ {
-        set $backend "http://api:8000";
+        set $backend "http://staging-arquivo-api:8000";
         proxy_pass $backend;
         proxy_http_version 1.1;
         proxy_set_header Host $host;


### PR DESCRIPTION
## Summary
- Point prod frontend nginx at `arquivo-api:8000` instead of ambiguous `api:8000`
- Point staging frontend nginx at `staging-arquivo-api:8000`
- Fixes prod admin login loop caused by requests randomly hitting staging API on the shared Docker network

## Test plan
- [x] Verified on VPS: 8/8 login + `/api/stats` requests return 200 after nginx hotfix
- [ ] After staging deploy: log in at https://staging.arquivodaviolencia.com.br/admin/login
- [ ] After prod deploy: log in at https://arquivodaviolencia.com.br/admin/login and confirm dashboard stays loaded


Made with [Cursor](https://cursor.com)