### PR TITLE
Release: fix admin nginx API routing

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -14,7 +14,7 @@ server {
     
     # CSV export streams the full dataset — needs longer timeout and no buffering
     location /api/public/events/export {
-        set $backend "http://api:8000";
+        set $backend "http://arquivo-api:8000";
         proxy_pass $backend;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
@@ -30,7 +30,7 @@ server {
 
     # API proxy - passes full URI to backend (backend expects /api/ prefix)
     location /api/ {
-        set $backend "http://api:8000";
+        set $backend "http://arquivo-api:8000";
         proxy_pass $backend;
         proxy_http_version 1.1;
         proxy_set_header Host $host;

--- a/frontend/nginx.staging.conf
+++ b/frontend/nginx.staging.conf
@@ -17,7 +17,7 @@ server {
     
     # CSV export streams the full dataset — needs longer timeout and no buffering
     location /api/public/events/export {
-        set $backend "http://api:8000";
+        set $backend "http://staging-arquivo-api:8000";
         proxy_pass $backend;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
@@ -33,7 +33,7 @@ server {
 
     # API proxy - passes full URI to backend (backend expects /api/ prefix)
     location /api/ {
-        set $backend "http://api:8000";
+        set $backend "http://staging-arquivo-api:8000";
         proxy_pass $backend;
         proxy_http_version 1.1;
         proxy_set_header Host $host;


### PR DESCRIPTION
## Summary
- Merges nginx upstream fix so prod/staging frontends no longer route `/api/` to the wrong backend container
- Resolves recurring prod admin login loop after deploys

## Test plan
- [x] Hotfix verified on VPS (login + stats stable)
- [ ] Confirm prod frontend redeploy completes
- [ ] Log in at https://arquivodaviolencia.com.br/admin/login


Made with [Cursor](https://cursor.com)