### PR TITLE
feat(observability): self-hosted Prometheus/Grafana + CI/CD

### DIFF
--- a/.github/workflows/deploy-observability.yml
+++ b/.github/workflows/deploy-observability.yml
@@ -1,0 +1,53 @@
+# =============================================================================
+# Observability stack deployment (Prometheus + Grafana on dedicated VPS)
+# =============================================================================
+# Triggers on master only when infra/observability changes.
+# Scrapes production API (:8000) and worker (:9091) metrics.
+# =============================================================================
+
+name: Deploy Observability
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'infra/observability/**'
+      - '.github/workflows/deploy-observability.yml'
+  workflow_dispatch:
+
+jobs:
+  deploy-observability:
+    name: Deploy to Observability VPS
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Deploy observability stack
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.OBS_VPS_HOST }}
+          username: ${{ secrets.OBS_VPS_USER }}
+          key: ${{ secrets.OBS_VPS_SSH_KEY }}
+          script_stop: true
+          script: |
+            set -euo pipefail
+            cd /root/arquivo-da-violencia
+            git fetch origin master
+            git checkout master
+            git reset --hard origin/master
+            export GRAFANA_ADMIN_PASSWORD='${{ secrets.GRAFANA_ADMIN_PASSWORD }}'
+            export PROD_HOST='${{ secrets.VPS_HOST }}'
+            bash infra/observability/deploy-remote.sh
+
+      - name: Allow observability VPS scrape on production firewall
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.VPS_HOST }}
+          username: ${{ secrets.VPS_USER }}
+          key: ${{ secrets.VPS_SSH_KEY }}
+          script: |
+            set -euo pipefail
+            OBS_IP='${{ secrets.OBS_VPS_HOST }}'
+            ufw allow from "$OBS_IP" to any port 8000 proto tcp comment 'Prometheus scrape API' >/dev/null 2>&1 || true
+            ufw allow from "$OBS_IP" to any port 9091 proto tcp comment 'Prometheus scrape worker' >/dev/null 2>&1 || true
+            echo "UFW rules for $OBS_IP → :8000/:9091 applied"

--- a/.gitignore
+++ b/.gitignore
@@ -174,6 +174,7 @@ scripts/*
 !scripts/deploy-frontend.sh
 !scripts/sync-staging-db.sh
 !scripts/check-pipeline-health.sh
+!scripts/check-observability.sh
 !scripts/hash-env-passwords.py
 !scripts/preflight-auth.py
 !scripts/lib/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,3 +135,17 @@ docker compose -p prod up -d --no-deps api worker
 ```
 
 Public site: https://arquivodaviolencia.com.br
+
+## Observability (self-hosted)
+
+Pipeline metrics: Prometheus + Grafana on a dedicated VPS (`62.238.12.182`).
+
+| Resource | URL |
+|----------|-----|
+| Grafana dashboard | https://observability.carabetta.xyz/d/arquivo-pipeline |
+| Stack directory on obs VPS | `/opt/arquivo-observability` |
+
+- **Manual deploy:** `bash infra/observability/deploy.sh` (see [docs/observability-self-hosted.md](docs/observability-self-hosted.md))
+- **CI:** [`.github/workflows/deploy-observability.yml`](.github/workflows/deploy-observability.yml) on `master` when `infra/observability/**` changes
+- **Health check:** `bash scripts/check-observability.sh --prod`
+- API `/metrics` = health gauges; worker `:9091/metrics` = task metrics only

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -83,6 +83,17 @@ class Settings(BaseSettings):
     github_token: str | None = None
     github_repo: str | None = None  # Format: "owner/repo"
 
+    hetzner_api_token: str | None = None
+
+    grafana_cloud_prom_url: str | None = None
+    grafana_cloud_prom_user: str | None = None
+    grafana_cloud_prom_key: str | None = None
+    grafana_cloud_loki_url: str | None = None
+    grafana_cloud_loki_user: str | None = None
+    grafana_cloud_loki_key: str | None = None
+    metrics_push_interval_seconds: int = 30
+    metrics_enabled: bool = True
+
     @property
     def is_sqlite(self) -> bool:
         """True when the configured database URL targets SQLite."""

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -86,6 +86,15 @@ def create_app() -> FastAPI:
     app.include_router(pipeline.router, prefix=settings.api_prefix)
     app.include_router(stats.router, prefix=settings.api_prefix)
 
+    if settings.metrics_enabled:
+        from prometheus_fastapi_instrumentator import Instrumentator
+
+        from app.metrics import REGISTRY
+
+        Instrumentator(registry=REGISTRY).instrument(app).expose(
+            app, endpoint="/metrics", include_in_schema=False
+        )
+
     return app
 
 

--- a/backend/app/metrics.py
+++ b/backend/app/metrics.py
@@ -1,0 +1,209 @@
+"""Prometheus metrics for the pipeline."""
+
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+from loguru import logger
+from prometheus_client import REGISTRY as DEFAULT_REGISTRY
+from prometheus_client import CollectorRegistry, Counter, Gauge, Histogram, generate_latest
+
+from app.config import get_settings
+
+# API /metrics exposes health gauges (and HTTP metrics via instrumentator).
+REGISTRY: CollectorRegistry = DEFAULT_REGISTRY
+
+# Worker :9091/metrics exposes only task/attempt counters and histograms.
+WORKER_REGISTRY = CollectorRegistry()
+
+pipeline_task_total = Counter(
+    "pipeline_task_total",
+    "Total ARQ tasks executed, by task name and outcome.",
+    labelnames=["task", "outcome"],
+    registry=WORKER_REGISTRY,
+)
+
+pipeline_task_duration_seconds = Histogram(
+    "pipeline_task_duration_seconds",
+    "Wall-clock duration of ARQ tasks, by task name and outcome.",
+    labelnames=["task", "outcome"],
+    buckets=(0.5, 1, 2.5, 5, 10, 30, 60, 120, 300, 600, 1800, 3600),
+    registry=WORKER_REGISTRY,
+)
+
+pipeline_attempts_total = Counter(
+    "pipeline_attempts_total",
+    "Total download/extraction attempts recorded, by stage/outcome/failure_reason.",
+    labelnames=["stage", "outcome", "failure_reason"],
+    registry=WORKER_REGISTRY,
+)
+
+pipeline_attempt_duration_seconds = Histogram(
+    "pipeline_attempt_duration_seconds",
+    "Duration of individual download/extraction attempts, by stage/outcome.",
+    labelnames=["stage", "outcome"],
+    buckets=(0.5, 1, 2.5, 5, 10, 20, 30, 60, 120),
+    registry=WORKER_REGISTRY,
+)
+
+pipeline_attempt_content_length_bytes = Histogram(
+    "pipeline_attempt_content_length_bytes",
+    "Content length (bytes) of downloaded article text, by stage.",
+    labelnames=["stage"],
+    buckets=(512, 2048, 8192, 32768, 131072, 524288, 2097152),
+    registry=WORKER_REGISTRY,
+)
+
+pipeline_queue_depth = Gauge(
+    "pipeline_queue_depth",
+    "Number of jobs waiting in the ARQ queue.",
+    registry=REGISTRY,
+)
+
+pipeline_worker_alive = Gauge(
+    "pipeline_worker_alive",
+    "1 if the ARQ worker heartbeat key is present in Redis, else 0.",
+    registry=REGISTRY,
+)
+
+pipeline_cron_enabled = Gauge(
+    "pipeline_cron_enabled",
+    "1 if the worker has cron scheduling enabled, else 0.",
+    registry=REGISTRY,
+)
+
+pipeline_worker_heartbeat_misses = Gauge(
+    "pipeline_worker_heartbeat_misses",
+    "Consecutive heartbeat misses observed by the API-side worker monitor.",
+    registry=REGISTRY,
+)
+
+pipeline_redis_connected = Gauge(
+    "pipeline_redis_connected",
+    "1 if Redis is reachable from this process, else 0.",
+    registry=REGISTRY,
+)
+
+
+def generate_worker_metrics() -> bytes:
+    """Prometheus exposition format for the worker metrics HTTP server."""
+    return generate_latest(WORKER_REGISTRY)
+
+
+def record_task_outcome(task_name: str, outcome: str, duration_seconds: float) -> None:
+    try:
+        pipeline_task_total.labels(task=task_name, outcome=outcome).inc()
+        pipeline_task_duration_seconds.labels(task=task_name, outcome=outcome).observe(
+            duration_seconds
+        )
+    except Exception as e:  # pragma: no cover
+        logger.warning(f"[metrics] record_task_outcome failed: {e}")
+
+
+def record_attempt_metrics(
+    *,
+    stage: str,
+    outcome: str,
+    failure_reason: str | None = None,
+    duration_ms: int | None = None,
+    content_length: int | None = None,
+) -> None:
+    try:
+        reason = failure_reason or "none"
+        pipeline_attempts_total.labels(
+            stage=stage, outcome=outcome, failure_reason=reason
+        ).inc()
+        if duration_ms is not None:
+            pipeline_attempt_duration_seconds.labels(stage=stage, outcome=outcome).observe(
+                duration_ms / 1000
+            )
+        if content_length is not None:
+            pipeline_attempt_content_length_bytes.labels(stage=stage).observe(content_length)
+    except Exception as e:  # pragma: no cover
+        logger.warning(f"[metrics] record_attempt_metrics failed: {e}")
+
+
+def set_worker_alive(alive: bool) -> None:
+    try:
+        pipeline_worker_alive.set(1 if alive else 0)
+    except Exception as e:  # pragma: no cover
+        logger.warning(f"[metrics] set_worker_alive failed: {e}")
+
+
+def set_heartbeat_misses(misses: int) -> None:
+    try:
+        pipeline_worker_heartbeat_misses.set(misses)
+    except Exception as e:  # pragma: no cover
+        logger.warning(f"[metrics] set_heartbeat_misses failed: {e}")
+
+
+def set_queue_depth(depth: int) -> None:
+    try:
+        pipeline_queue_depth.set(depth)
+    except Exception as e:  # pragma: no cover
+        logger.warning(f"[metrics] set_queue_depth failed: {e}")
+
+
+def set_cron_enabled(enabled: bool) -> None:
+    try:
+        pipeline_cron_enabled.set(1 if enabled else 0)
+    except Exception as e:  # pragma: no cover
+        logger.warning(f"[metrics] set_cron_enabled failed: {e}")
+
+
+def set_redis_connected(connected: bool) -> None:
+    try:
+        pipeline_redis_connected.set(1 if connected else 0)
+    except Exception as e:  # pragma: no cover
+        logger.warning(f"[metrics] set_redis_connected failed: {e}")
+
+
+def _is_push_configured() -> bool:
+    s = get_settings()
+    return bool(
+        s.grafana_cloud_prom_url
+        and s.grafana_cloud_prom_user
+        and s.grafana_cloud_prom_key
+        and s.metrics_enabled
+    )
+
+
+async def push_to_grafana_cloud() -> bool:
+    if not _is_push_configured():
+        return False
+
+    s = get_settings()
+    try:
+        body = generate_latest(WORKER_REGISTRY)
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.post(
+                s.grafana_cloud_prom_url,
+                content=body,
+                headers={"Content-Type": "text/plain; version=0.0.4; charset=utf-8"},
+                auth=(s.grafana_cloud_prom_user, s.grafana_cloud_prom_key),
+            )
+        if resp.status_code >= 400:
+            logger.warning(
+                f"[metrics] Grafana Cloud push failed: HTTP {resp.status_code} {resp.text[:200]}"
+            )
+            return False
+        return True
+    except Exception as e:  # pragma: no cover
+        logger.warning(f"[metrics] push_to_grafana_cloud error: {e}")
+        return False
+
+
+async def push_loop(interval_seconds: int) -> None:
+    if not _is_push_configured():
+        logger.info("[metrics] Grafana Cloud push disabled (no URL/user/key)")
+        return
+    logger.info(f"[metrics] Pushing to Grafana Cloud every {interval_seconds}s")
+    while True:
+        try:
+            await push_to_grafana_cloud()
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:  # pragma: no cover
+            logger.warning(f"[metrics] push_loop error: {e}")
+        await asyncio.sleep(interval_seconds)

--- a/backend/app/routers/pipeline.py
+++ b/backend/app/routers/pipeline.py
@@ -7,6 +7,7 @@ from loguru import logger
 
 import json
 
+from app.metrics import set_cron_enabled, set_queue_depth, set_redis_connected, set_worker_alive
 from app.tasks.worker import (
     get_redis_settings,
     HEALTH_CHECK_KEY,
@@ -381,21 +382,24 @@ async def run_batch_geocoding(
 
 @router.get("/status")
 async def get_pipeline_status():
-    """Get queue status and worker health.
+    """Get queue status and worker health."""
+    status = await collect_pipeline_status()
+    try:
+        set_redis_connected(status.get("redis") == "connected")
+        set_worker_alive(bool(status.get("worker_alive")))
+        set_cron_enabled(bool(status.get("cron_enabled")))
+        set_queue_depth(int(status.get("queued_jobs", 0)))
+    except Exception:  # pragma: no cover
+        pass
+    return status
 
-    Redis connectivity alone does NOT mean the pipeline is working: the worker
-    process (which also runs the cron that enqueues jobs) can be down while Redis
-    stays reachable. We additionally read the worker's heartbeat key and report
-    whether cron is enabled so the UI can distinguish "healthy" from "stalled".
-    """
+
+async def collect_pipeline_status() -> dict:
+    """Collect worker/queue/cron status from Redis."""
     try:
         pool = await get_arq_pool()
         queued_jobs = await pool.queued_jobs()
-
-        # Worker heartbeat: arq refreshes this key on an interval; if it's
-        # missing the worker process is not running (or crashed).
         raw_health = await pool.get(HEALTH_CHECK_KEY)
-        # Worker-published config (cron is scheduled by the worker, not the API).
         raw_info = await pool.get(WORKER_INFO_KEY)
         await pool.close()
 
@@ -406,8 +410,6 @@ async def get_pipeline_status():
                 raw_health.decode() if isinstance(raw_health, bytes) else str(raw_health)
             )
 
-        # Prefer the worker's self-reported cron status; fall back to this
-        # process's env only if the worker has not published yet.
         cron_enabled = is_cron_enabled()
         worker_started_at = None
         if raw_info is not None:

--- a/backend/app/routers/pipeline.py
+++ b/backend/app/routers/pipeline.py
@@ -396,12 +396,12 @@ async def get_pipeline_status():
 
 async def collect_pipeline_status() -> dict:
     """Collect worker/queue/cron status from Redis."""
+    pool = None
     try:
         pool = await get_arq_pool()
         queued_jobs = await pool.queued_jobs()
         raw_health = await pool.get(HEALTH_CHECK_KEY)
         raw_info = await pool.get(WORKER_INFO_KEY)
-        await pool.close()
 
         worker_alive = raw_health is not None
         worker_health = None
@@ -450,6 +450,9 @@ async def collect_pipeline_status() -> dict:
             "error": str(e),
             "queued_jobs": 0,
         }
+    finally:
+        if pool is not None:
+            await pool.close()
 
 
 @router.get("/city-stats")

--- a/backend/app/services/diagnostics.py
+++ b/backend/app/services/diagnostics.py
@@ -231,3 +231,16 @@ async def record_attempt(
             await session.commit()
     except Exception as e:  # pragma: no cover - logging must not break pipeline
         logger.warning(f"Failed to record pipeline_attempt ({stage}/{outcome}): {e}")
+
+    try:
+        from app.metrics import record_attempt_metrics
+
+        record_attempt_metrics(
+            stage=stage,
+            outcome=outcome,
+            failure_reason=failure_reason,
+            duration_ms=duration_ms,
+            content_length=content_length,
+        )
+    except Exception as e:  # pragma: no cover
+        logger.debug(f"metrics mirror failed for {stage}/{outcome}: {e}")

--- a/backend/app/services/worker_monitor.py
+++ b/backend/app/services/worker_monitor.py
@@ -13,10 +13,16 @@ worker silently stalls the whole pipeline.
 
 import asyncio
 
-from arq import create_pool
 from loguru import logger
 
-from app.tasks.worker import get_redis_settings, HEALTH_CHECK_KEY
+from app.metrics import (
+    set_cron_enabled,
+    set_heartbeat_misses,
+    set_queue_depth,
+    set_redis_connected,
+    set_worker_alive,
+)
+from app.routers.pipeline import collect_pipeline_status
 from app.services.telegram import notify_worker_down, notify_worker_recovered
 
 # How often to poll the heartbeat key.
@@ -28,11 +34,20 @@ CHECK_INTERVAL_SECONDS = 60
 MISS_THRESHOLD = 5
 
 
+def _apply_status_metrics(status: dict) -> bool:
+    """Update Prometheus health gauges from a pipeline status dict."""
+    redis_ok = status.get("redis") == "connected"
+    set_redis_connected(redis_ok)
+    set_worker_alive(bool(status.get("worker_alive")))
+    set_cron_enabled(bool(status.get("cron_enabled")))
+    set_queue_depth(int(status.get("queued_jobs", 0)))
+    return redis_ok
+
+
 async def monitor_worker_health(stop_event: asyncio.Event) -> None:
     """Poll the worker heartbeat until ``stop_event`` is set."""
     consecutive_misses = 0
     alerted_down = False
-    pool = None
 
     logger.info(
         f"[WorkerMonitor] Started (interval={CHECK_INTERVAL_SECONDS}s, "
@@ -41,10 +56,9 @@ async def monitor_worker_health(stop_event: asyncio.Event) -> None:
 
     while not stop_event.is_set():
         try:
-            if pool is None:
-                pool = await create_pool(get_redis_settings())
-
-            alive = await pool.get(HEALTH_CHECK_KEY) is not None
+            status = await collect_pipeline_status()
+            redis_ok = _apply_status_metrics(status)
+            alive = bool(status.get("worker_alive")) if redis_ok else False
 
             if alive:
                 if alerted_down:
@@ -52,9 +66,11 @@ async def monitor_worker_health(stop_event: asyncio.Event) -> None:
                     logger.info("[WorkerMonitor] Worker heartbeat recovered")
                     await notify_worker_recovered(seconds_down)
                 consecutive_misses = 0
+                set_heartbeat_misses(0)
                 alerted_down = False
             else:
                 consecutive_misses += 1
+                set_heartbeat_misses(consecutive_misses)
                 logger.warning(
                     f"[WorkerMonitor] Missed heartbeat "
                     f"({consecutive_misses}/{MISS_THRESHOLD})"
@@ -65,25 +81,12 @@ async def monitor_worker_health(stop_event: asyncio.Event) -> None:
                     await notify_worker_down(seconds_silent)
                     alerted_down = True
         except Exception as e:
-            # Redis errors etc. - don't treat as "worker down" (that's a
-            # different failure mode). Drop the pool so we reconnect cleanly.
+            set_redis_connected(False)
             logger.error(f"[WorkerMonitor] Health check error: {e}")
-            if pool is not None:
-                try:
-                    await pool.close()
-                except Exception:
-                    pass
-                pool = None
 
         try:
             await asyncio.wait_for(stop_event.wait(), timeout=CHECK_INTERVAL_SECONDS)
         except asyncio.TimeoutError:
-            pass
-
-    if pool is not None:
-        try:
-            await pool.close()
-        except Exception:
             pass
 
     logger.info("[WorkerMonitor] Stopped")

--- a/backend/app/services/worker_monitor.py
+++ b/backend/app/services/worker_monitor.py
@@ -60,7 +60,11 @@ async def monitor_worker_health(stop_event: asyncio.Event) -> None:
             redis_ok = _apply_status_metrics(status)
             alive = bool(status.get("worker_alive")) if redis_ok else False
 
-            if alive:
+            if not redis_ok:
+                logger.warning(
+                    "[WorkerMonitor] Redis unavailable; skipping heartbeat check"
+                )
+            elif alive:
                 if alerted_down:
                     seconds_down = consecutive_misses * CHECK_INTERVAL_SECONDS
                     logger.info("[WorkerMonitor] Worker heartbeat recovered")

--- a/backend/app/tasks/pipeline.py
+++ b/backend/app/tasks/pipeline.py
@@ -6,6 +6,7 @@ from typing import Any, Callable
 
 from loguru import logger
 
+from app.metrics import record_task_outcome
 from app.services.github import create_failure_issue
 from app.services.telegram import (
     notify_job_started,
@@ -30,9 +31,12 @@ def notify_on_failure(task_name: str):
     def decorator(func: Callable) -> Callable:
         @functools.wraps(func)
         async def wrapper(*args, **kwargs) -> Any:
+            start = time.monotonic()
+            outcome = "success"
             try:
                 return await func(*args, **kwargs)
             except Exception as e:
+                outcome = "failure"
                 # Extract context details from args/kwargs for the notification
                 details = {}
                 
@@ -63,6 +67,8 @@ def notify_on_failure(task_name: str):
                 await create_failure_issue(task_name, str(e), details if details else None)
                 
                 raise
+            finally:
+                record_task_outcome(task_name, outcome, time.monotonic() - start)
         
         return wrapper
     return decorator

--- a/backend/app/tasks/worker.py
+++ b/backend/app/tasks/worker.py
@@ -1,5 +1,6 @@
 """ARQ worker configuration."""
 
+import asyncio
 import os
 import json
 from datetime import datetime, timezone
@@ -74,11 +75,39 @@ async def startup(ctx: dict) -> None:
     except Exception as e:  # pragma: no cover - best effort, non-fatal
         logger.warning(f"Failed to recover stuck sources on startup: {e}")
 
+    try:
+        from app.metrics import push_loop
+
+        ctx["metrics_task"] = asyncio.create_task(
+            push_loop(settings.metrics_push_interval_seconds)
+        )
+    except Exception as e:  # pragma: no cover
+        logger.warning(f"Failed to start metrics push loop: {e}")
+
+    if settings.metrics_enabled:
+        try:
+            from prometheus_client import start_http_server
+
+            from app.metrics import WORKER_REGISTRY
+
+            start_http_server(9091, registry=WORKER_REGISTRY)
+            logger.info("[metrics] Worker metrics HTTP server on :9091/metrics")
+        except Exception as e:  # pragma: no cover
+            logger.warning(f"Failed to start worker metrics HTTP server: {e}")
+
 
 async def shutdown(ctx: dict) -> None:
     """Worker shutdown handler."""
     from loguru import logger
     logger.info("ARQ Worker shutting down...")
+
+    metrics_task = ctx.get("metrics_task")
+    if metrics_task is not None and not metrics_task.done():
+        metrics_task.cancel()
+        try:
+            await metrics_task
+        except (asyncio.CancelledError, Exception):  # pragma: no cover
+            pass
 
 
 def get_cron_jobs():

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -39,6 +39,8 @@ dependencies = [
     "jsonref>=1.1.0",
     "tenacity>=9.0.0",
     "unidecode>=1.3.0",
+    "prometheus-client>=0.20.0",
+    "prometheus-fastapi-instrumentator>=7.0.0",
 ]
 
 [project.optional-dependencies]

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -229,6 +229,8 @@ dependencies = [
     { name = "jsonref" },
     { name = "loguru" },
     { name = "passlib", extra = ["bcrypt"] },
+    { name = "prometheus-client" },
+    { name = "prometheus-fastapi-instrumentator" },
     { name = "psycopg", extra = ["binary"] },
     { name = "pydantic-settings" },
     { name = "python-dateutil" },
@@ -276,6 +278,8 @@ requires-dist = [
     { name = "loguru", specifier = ">=0.7.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.13.0" },
     { name = "passlib", extras = ["bcrypt"], specifier = ">=1.7.4" },
+    { name = "prometheus-client", specifier = ">=0.20.0" },
+    { name = "prometheus-fastapi-instrumentator", specifier = ">=7.0.0" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.1.0" },
     { name = "pydantic-settings", specifier = ">=2.6.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
@@ -2516,6 +2520,28 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/40/f1/6d86a29246dfd2e9b6237f0b5823717f60cad94d47ddc26afa916d21f525/pre_commit-4.5.1.tar.gz", hash = "sha256:eb545fcff725875197837263e977ea257a402056661f09dae08e4b149b030a61", size = 198232, upload-time = "2025-12-16T21:14:33.552Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5d/19/fd3ef348460c80af7bb4669ea7926651d1f95c23ff2df18b9d24bab4f3fa/pre_commit-4.5.1-py2.py3-none-any.whl", hash = "sha256:3b3afd891e97337708c1674210f8eba659b52a38ea5f822ff142d10786221f77", size = 226437, upload-time = "2025-12-16T21:14:32.409Z" },
+]
+
+[[package]]
+name = "prometheus-client"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/fb/d9aa83ffe43ce1f19e557c0971d04b90561b0cfd50762aafb01968285553/prometheus_client-0.25.0.tar.gz", hash = "sha256:5e373b75c31afb3c86f1a52fa1ad470c9aace18082d39ec0d2f918d11cc9ba28", size = 86035, upload-time = "2026-04-09T19:53:42.359Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/9b/d4b1e644385499c8346fa9b622a3f030dce14cd6ef8a1871c221a17a67e7/prometheus_client-0.25.0-py3-none-any.whl", hash = "sha256:d5aec89e349a6ec230805d0df882f3807f74fd6c1a2fa86864e3c2279059fed1", size = 64154, upload-time = "2026-04-09T19:53:41.324Z" },
+]
+
+[[package]]
+name = "prometheus-fastapi-instrumentator"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "prometheus-client" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/69/6d/24d53033cf93826aa7857699a4450c1c67e5b9c710e925b1ed2b320c04df/prometheus_fastapi_instrumentator-7.1.0.tar.gz", hash = "sha256:be7cd61eeea4e5912aeccb4261c6631b3f227d8924542d79eaf5af3f439cbe5e", size = 20220, upload-time = "2025-03-19T19:35:05.351Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/72/0824c18f3bc75810f55dacc2dd933f6ec829771180245ae3cc976195dec0/prometheus_fastapi_instrumentator-7.1.0-py3-none-any.whl", hash = "sha256:978130f3c0bb7b8ebcc90d35516a6fe13e02d2eb358c8f83887cdef7020c31e9", size = 19296, upload-time = "2025-03-19T19:35:04.323Z" },
 ]
 
 [[package]]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,6 +93,12 @@ services:
       - CORS_ORIGINS=["http://localhost:5173","http://localhost:3000","http://localhost:80","https://arquivodaviolencia.com.br","https://www.arquivodaviolencia.com.br"]
       - TELEGRAM_BOT_TOKEN=${TELEGRAM_BOT_TOKEN:-}
       - TELEGRAM_CHAT_ID=${TELEGRAM_CHAT_ID:-}
+      - HETZNER_API_TOKEN=${HETZNER_API_TOKEN:-}
+      - GRAFANA_CLOUD_PROM_URL=${GRAFANA_CLOUD_PROM_URL:-}
+      - GRAFANA_CLOUD_PROM_USER=${GRAFANA_CLOUD_PROM_USER:-}
+      - GRAFANA_CLOUD_PROM_KEY=${GRAFANA_CLOUD_PROM_KEY:-}
+      - METRICS_PUSH_INTERVAL_SECONDS=${METRICS_PUSH_INTERVAL_SECONDS:-30}
+      - METRICS_ENABLED=${METRICS_ENABLED:-true}
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
       interval: 30s
@@ -109,6 +115,8 @@ services:
     build: ./backend
     container_name: arquivo-worker
     command: arq app.tasks.worker.WorkerSettings
+    ports:
+      - "9091:9091"
     depends_on:
       postgres:
         condition: service_healthy
@@ -133,6 +141,12 @@ services:
       - ENABLE_AUTH=true
       - TELEGRAM_BOT_TOKEN=${TELEGRAM_BOT_TOKEN:-}
       - TELEGRAM_CHAT_ID=${TELEGRAM_CHAT_ID:-}
+      - HETZNER_API_TOKEN=${HETZNER_API_TOKEN:-}
+      - GRAFANA_CLOUD_PROM_URL=${GRAFANA_CLOUD_PROM_URL:-}
+      - GRAFANA_CLOUD_PROM_USER=${GRAFANA_CLOUD_PROM_USER:-}
+      - GRAFANA_CLOUD_PROM_KEY=${GRAFANA_CLOUD_PROM_KEY:-}
+      - METRICS_PUSH_INTERVAL_SECONDS=${METRICS_PUSH_INTERVAL_SECONDS:-30}
+      - METRICS_ENABLED=${METRICS_ENABLED:-true}
     healthcheck:
       test: ["CMD-SHELL", "python -c 'import sys; sys.exit(0 if __import__(\"pathlib\").Path(\"/proc/1\").exists() else 1)'"]
       interval: 30s
@@ -141,6 +155,25 @@ services:
       retries: 3
     # Allow worker 120s to finish current job before forced shutdown
     stop_grace_period: 120s
+    restart: unless-stopped
+
+  promtail:
+    image: grafana/promtail:latest
+    container_name: arquivo-promtail
+    profiles: ["logs"]
+    depends_on:
+      - api
+      - worker
+    environment:
+      - GRAFANA_CLOUD_LOKI_URL=${GRAFANA_CLOUD_LOKI_URL:-}
+      - GRAFANA_CLOUD_LOKI_USER=${GRAFANA_CLOUD_LOKI_USER:-}
+      - GRAFANA_CLOUD_LOKI_KEY=${GRAFANA_CLOUD_LOKI_KEY:-}
+    volumes:
+      - ./promtail.yml:/etc/promtail/config.yml:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - /var/lib/docker/containers:/var/lib/docker/containers:ro
+      - promtail_positions:/tmp
+    command: -config.file=/etc/promtail/config.yml -config.expand-env=true
     restart: unless-stopped
 
   # ---------------------------------------------------------------------------
@@ -172,3 +205,5 @@ volumes:
     name: arquivo-postgres-data
   redis_data:
     name: arquivo-redis-data
+  promtail_positions:
+    name: arquivo-promtail-positions

--- a/docs/observability-self-hosted.md
+++ b/docs/observability-self-hosted.md
@@ -1,0 +1,111 @@
+# Self-hosted observability (Prometheus + Grafana)
+
+Production pipeline metrics are scraped by a dedicated observability VPS and
+visualized in Grafana.
+
+| Resource | URL / host |
+|----------|------------|
+| Grafana dashboard | https://observability.carabetta.xyz/d/arquivo-pipeline |
+| Observability VPS | `62.238.12.182` (`/opt/arquivo-observability`) |
+| Production scrape targets | `77.42.72.111:8000` (API `/metrics`), `:9091` (worker) |
+
+## Architecture
+
+- **API** (`arquivo-api`) exposes health gauges (`pipeline_worker_alive`,
+  `pipeline_redis_connected`, etc.) on `/metrics` via `prometheus-fastapi-instrumentator`
+  bound to `REGISTRY`.
+- **Worker** (`arquivo-worker`) exposes task/attempt counters on `:9091/metrics`
+  via a separate `WORKER_REGISTRY` (no health gauges — avoids duplicate dashboard stats).
+- **Prometheus** on the obs VPS scrapes both targets every 30s.
+- **Grafana** is bound to `127.0.0.1:3000` and published via nginx + Let's Encrypt
+  at `observability.carabetta.xyz`.
+
+## Local / manual deploy
+
+From your laptop (requires SSH to both VPSes):
+
+```bash
+# Set password to match existing Grafana DB (never rotate on redeploy without intent)
+export GRAFANA_ADMIN_PASSWORD='…'
+bash infra/observability/deploy.sh
+```
+
+`deploy.sh` rsyncs `infra/observability/` to the obs VPS, runs `deploy-remote.sh`,
+and opens prod UFW for obs → `:8000` / `:9091`.
+
+## CI/CD
+
+Pushing to **`master`** with changes under `infra/observability/**` triggers
+[`.github/workflows/deploy-observability.yml`](../.github/workflows/deploy-observability.yml).
+
+Backend metrics deploy via the existing
+[`.github/workflows/deploy-backend.yml`](../.github/workflows/deploy-backend.yml)
+when `backend/**` or `docker-compose.yml` change.
+
+Observability deploys on **master only** (staging has no scrape targets).
+
+### GitHub Actions secrets
+
+Add in **Settings → Secrets and variables → Actions**:
+
+| Secret | Value / notes |
+|--------|----------------|
+| `OBS_VPS_HOST` | `62.238.12.182` |
+| `OBS_VPS_USER` | `root` |
+| `OBS_VPS_SSH_KEY` | Private key with SSH access to obs VPS (can match `VPS_SSH_KEY` if the same key is authorized) |
+| `GRAFANA_ADMIN_PASSWORD` | Must match the password in Grafana's volume / `/opt/arquivo-observability/.env` |
+
+Existing secrets reused by the workflow:
+
+| Secret | Used for |
+|--------|----------|
+| `VPS_HOST` | Production app VPS (`77.42.72.111`) — UFW scrape rules |
+| `VPS_USER` | SSH user on prod |
+| `VPS_SSH_KEY` | SSH key for prod |
+
+### One-time observability VPS bootstrap
+
+Before the first CI run, on the **observability VPS**:
+
+```bash
+# Deploy key or PAT required for private repo
+git clone git@github.com:JoaoCarabetta/arquivo-da-violencia.git /root/arquivo-da-violencia
+
+mkdir -p /opt/arquivo-observability
+cat >/opt/arquivo-observability/.env <<'EOF'
+GRAFANA_ADMIN_USER=admin
+GRAFANA_ADMIN_PASSWORD=<same as GRAFANA_ADMIN_PASSWORD secret>
+GRAFANA_DOMAIN=observability.carabetta.xyz
+GRAFANA_ROOT_URL=https://observability.carabetta.xyz
+EOF
+chmod 600 /opt/arquivo-observability/.env
+
+# DNS: observability.carabetta.xyz → 62.238.12.182 (Hostinger)
+```
+
+Then add the GitHub secrets above and merge observability changes to `master`.
+
+## Verification
+
+```bash
+# Local dev stack
+bash scripts/check-observability.sh
+
+# Production API + Grafana + Prometheus series
+bash scripts/check-observability.sh --prod
+```
+
+Expected on prod after deploy:
+
+- `pipeline_worker_alive{service="api"}` — single series, value `1`
+- Worker `:9091` — `pipeline_task_total` present, no `pipeline_worker_alive`
+- Grafana dashboard top row — single UP/OK values (no duplicate UP+DOWN)
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---------|----------------|
+| Grafana login fails after redeploy | `deploy-remote.sh` overwrote password — ensure `GRAFANA_ADMIN_PASSWORD` secret matches live Grafana DB |
+| Duplicate stat values on dashboard | Health gauges scraped from both API and worker — worker must use `WORKER_REGISTRY` only |
+| Prometheus targets DOWN | Prod UFW blocking obs IP, or backend not deployed with `METRICS_ENABLED=true` |
+| TLS/nginx broken after redeploy | Cert exists but HTTP-only config installed — `deploy-remote.sh` picks HTTPS config when cert is present |

--- a/env.example
+++ b/env.example
@@ -64,3 +64,15 @@ VITE_SITE_URL=https://arquivodaviolencia.com.br
 # MapLibre basemap style URL (optional)
 # Carto Positron (default) is lighter/faster for zoom; OpenFreeMap Liberty has richer labels:
 # VITE_MAP_STYLE=https://tiles.openfreemap.org/styles/liberty
+
+# Prometheus metrics (API /metrics + worker :9091)
+METRICS_ENABLED=true
+METRICS_PUSH_INTERVAL_SECONDS=30
+
+# Optional Grafana Cloud push (legacy; production uses self-hosted Prometheus)
+# GRAFANA_CLOUD_PROM_URL=
+# GRAFANA_CLOUD_PROM_USER=
+# GRAFANA_CLOUD_PROM_KEY=
+
+# Self-hosted Grafana deploy (laptop manual deploy only)
+# GRAFANA_ADMIN_PASSWORD=

--- a/infra/observability/deploy-remote.sh
+++ b/infra/observability/deploy-remote.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# Runs on the observability VPS (or via CI SSH). Syncs stack from repo checkout,
+# preserves Grafana password, configures nginx/TLS, and smoke-checks Prometheus.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="${REPO_DIR:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
+OBS_DIR="${OBS_DIR:-/opt/arquivo-observability}"
+DOMAIN="${OBS_DOMAIN:-observability.carabetta.xyz}"
+OBS_IP="${OBS_VPS_IP:-62.238.12.182}"
+PROD_HOST="${PROD_HOST:-77.42.72.111}"
+
+log() { echo "[deploy-remote] $*"; }
+die() { echo "[deploy-remote] ERROR: $*" >&2; exit 1; }
+
+# --- Preserve Grafana credentials before any file sync ---
+existing_password=""
+if [[ -f "$OBS_DIR/.env" ]]; then
+  # shellcheck disable=SC1090
+  existing_password="$(grep -E '^GRAFANA_ADMIN_PASSWORD=' "$OBS_DIR/.env" 2>/dev/null | cut -d= -f2- || true)"
+fi
+if [[ -z "$existing_password" && -n "${GRAFANA_ADMIN_PASSWORD:-}" ]]; then
+  existing_password="$GRAFANA_ADMIN_PASSWORD"
+fi
+if [[ -z "$existing_password" ]]; then
+  die "GRAFANA_ADMIN_PASSWORD must be set (env or $OBS_DIR/.env) — never auto-generate on redeploy"
+fi
+
+log "Syncing stack from $REPO_DIR/infra/observability/ → $OBS_DIR/"
+mkdir -p "$OBS_DIR"
+rsync -a --delete \
+  --exclude '.env' \
+  --exclude 'prometheus_data' \
+  --exclude 'grafana_data' \
+  "$REPO_DIR/infra/observability/" "$OBS_DIR/"
+
+# Write .env without clobbering password if file already exists with same value
+cat >"$OBS_DIR/.env" <<EOF
+GRAFANA_ADMIN_USER=admin
+GRAFANA_ADMIN_PASSWORD=${existing_password}
+GRAFANA_DOMAIN=${DOMAIN}
+GRAFANA_ROOT_URL=https://${DOMAIN}
+EOF
+chmod 600 "$OBS_DIR/.env"
+
+# --- DNS precheck ---
+resolved_ip="$(getent ahosts "$DOMAIN" 2>/dev/null | awk '/STREAM/ {print $1; exit}' || true)"
+if [[ -z "$resolved_ip" ]]; then
+  resolved_ip="$(dig +short "$DOMAIN" 2>/dev/null | head -1 || true)"
+fi
+if [[ "$resolved_ip" != "$OBS_IP" ]]; then
+  die "DNS for $DOMAIN resolves to '${resolved_ip:-<none>}' — expected $OBS_IP"
+fi
+log "DNS OK: $DOMAIN → $OBS_IP"
+
+# --- Docker stack ---
+cd "$OBS_DIR"
+set -a
+# shellcheck disable=SC1091
+source .env
+set +a
+docker compose pull
+docker compose up -d
+
+# --- Nginx + TLS ---
+nginx_site="/etc/nginx/sites-available/observability"
+cert_path="/etc/letsencrypt/live/${DOMAIN}/fullchain.pem"
+
+if [[ -f "$cert_path" ]]; then
+  log "TLS cert exists — installing HTTPS nginx config"
+  cp "$OBS_DIR/nginx/observability.conf" "$nginx_site"
+else
+  log "No TLS cert yet — HTTP-only nginx + certbot"
+  cp "$OBS_DIR/nginx/observability-http-only.conf" "$nginx_site"
+fi
+ln -sf "$nginx_site" /etc/nginx/sites-enabled/observability
+nginx -t
+systemctl reload nginx
+
+if [[ ! -f "$cert_path" ]]; then
+  if command -v certbot >/dev/null 2>&1; then
+    certbot --nginx -d "$DOMAIN" --non-interactive --agree-tos -m admin@carabetta.xyz || true
+    if [[ -f "$cert_path" ]]; then
+      cp "$OBS_DIR/nginx/observability.conf" "$nginx_site"
+      nginx -t && systemctl reload nginx
+    fi
+  else
+    log "certbot not installed — skipping TLS bootstrap"
+  fi
+fi
+
+# --- UFW on obs VPS (public 80/443 only; Grafana localhost-bound) ---
+if command -v ufw >/dev/null 2>&1; then
+  ufw allow 80/tcp comment 'observability HTTP' >/dev/null 2>&1 || true
+  ufw allow 443/tcp comment 'observability HTTPS' >/dev/null 2>&1 || true
+  ufw deny 3000/tcp comment 'Grafana not public' >/dev/null 2>&1 || true
+fi
+
+# --- Smoke checks ---
+sleep 3
+if curl -sf "https://${DOMAIN}/api/health" >/dev/null 2>&1; then
+  log "Grafana HTTPS health OK"
+elif curl -sf "http://127.0.0.1:3000/api/health" >/dev/null 2>&1; then
+  log "Grafana local health OK (HTTPS may need cert)"
+else
+  die "Grafana not reachable"
+fi
+
+prom_up="$(docker exec obs-prometheus wget -qO- 'http://localhost:9090/api/v1/query?query=up%7Bjob%3D~%22arquivo-prod.*%22%7D' 2>/dev/null || true)"
+if echo "$prom_up" | grep -q '"status":"success"'; then
+  log "Prometheus scrape targets query OK"
+else
+  log "WARN: Prometheus scrape check inconclusive (prod metrics may not be deployed yet)"
+fi
+
+log "Deploy complete — https://${DOMAIN}/d/arquivo-pipeline"

--- a/infra/observability/deploy.sh
+++ b/infra/observability/deploy.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Laptop wrapper: sync observability stack to obs VPS and run deploy-remote.sh.
+# Also opens prod firewall for Prometheus scrape (idempotent).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+OBS_HOST="${OBS_SSH_HOST:-62.238.12.182}"
+OBS_USER="${OBS_SSH_USER:-root}"
+OBS_KEY="${OBS_SSH_KEY:-$HOME/.ssh/hetzner_arquivo_violencia_rsa}"
+
+PROD_HOST="${PROD_SSH_HOST:-hetzner-arv}"
+PROD_USER="${PROD_SSH_USER:-root}"
+PROD_KEY="${PROD_SSH_KEY:-$HOME/.ssh/hetzner_arquivo_violencia_rsa}"
+
+OBS_IP="${OBS_VPS_IP:-62.238.12.182}"
+DOMAIN="${OBS_DOMAIN:-observability.carabetta.xyz}"
+OBS_DIR="/opt/arquivo-observability"
+
+obs_ssh=(ssh -o BatchMode=yes -o ConnectTimeout=20 -i "$OBS_KEY" "${OBS_USER}@${OBS_HOST}")
+obs_rsync=(rsync -az --delete -e "ssh -i $OBS_KEY -o BatchMode=yes" \
+  --exclude '.env' \
+  --exclude 'prometheus_data' \
+  --exclude 'grafana_data')
+
+prod_ssh=(ssh -o BatchMode=yes -o ConnectTimeout=20 -i "$PROD_KEY" "${PROD_USER}@${PROD_HOST}")
+
+echo "=== Observability deploy (laptop) ==="
+
+# Ensure repo exists on obs VPS for deploy-remote.sh (CI uses git pull instead)
+"${obs_ssh[@]}" "mkdir -p /root/arquivo-da-violencia/infra/observability"
+"${obs_rsync[@]}" "$REPO_DIR/infra/observability/" "${OBS_USER}@${OBS_HOST}:/root/arquivo-da-violencia/infra/observability/"
+
+# Pass password from local .env if set
+grafana_pw="${GRAFANA_ADMIN_PASSWORD:-}"
+if [[ -z "$grafana_pw" && -f "$REPO_DIR/.env" ]]; then
+  grafana_pw="$(grep -E '^GRAFANA_ADMIN_PASSWORD=' "$REPO_DIR/.env" 2>/dev/null | cut -d= -f2- || true)"
+fi
+
+remote_env="REPO_DIR=/root/arquivo-da-violencia OBS_DIR=$OBS_DIR OBS_DOMAIN=$DOMAIN OBS_VPS_IP=$OBS_IP PROD_HOST=$PROD_HOST"
+if [[ -n "$grafana_pw" ]]; then
+  remote_env="$remote_env GRAFANA_ADMIN_PASSWORD=$(printf '%q' "$grafana_pw")"
+fi
+
+"${obs_ssh[@]}" "$remote_env bash /root/arquivo-da-violencia/infra/observability/deploy-remote.sh"
+
+echo "=== Prod firewall: allow obs VPS scrape ==="
+"${prod_ssh[@]}" bash -s "$OBS_IP" <<'REMOTE'
+set -euo pipefail
+OBS_IP="$1"
+ufw allow from "$OBS_IP" to any port 8000 proto tcp comment 'Prometheus scrape API' >/dev/null 2>&1 || true
+ufw allow from "$OBS_IP" to any port 9091 proto tcp comment 'Prometheus scrape worker' >/dev/null 2>&1 || true
+echo "UFW rules for $OBS_IP → :8000/:9091 applied"
+REMOTE
+
+echo "=== Done: https://${DOMAIN}/d/arquivo-pipeline ==="

--- a/infra/observability/docker-compose.yml
+++ b/infra/observability/docker-compose.yml
@@ -1,0 +1,43 @@
+services:
+  prometheus:
+    image: prom/prometheus:v3.2.1
+    container_name: obs-prometheus
+    restart: unless-stopped
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --storage.tsdb.path=/prometheus
+      - --storage.tsdb.retention.time=30d
+      - --web.enable-lifecycle
+    volumes:
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus_data:/prometheus
+    networks:
+      - obs
+
+  grafana:
+    image: grafana/grafana:11.5.2
+    container_name: obs-grafana
+    restart: unless-stopped
+    depends_on:
+      - prometheus
+    environment:
+      - GF_SECURITY_ADMIN_USER=${GRAFANA_ADMIN_USER:-admin}
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:?set GRAFANA_ADMIN_PASSWORD}
+      - GF_USERS_ALLOW_SIGN_UP=false
+      - GF_SERVER_DOMAIN=${GRAFANA_DOMAIN:-observability.carabetta.xyz}
+      - GF_SERVER_ROOT_URL=${GRAFANA_ROOT_URL:-https://observability.carabetta.xyz}
+    ports:
+      - "127.0.0.1:3000:3000"
+    volumes:
+      - grafana_data:/var/lib/grafana
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
+    networks:
+      - obs
+
+networks:
+  obs:
+
+volumes:
+  prometheus_data:
+  grafana_data:

--- a/infra/observability/grafana/dashboards/pipeline-overview.json
+++ b/infra/observability/grafana/dashboards/pipeline-overview.json
@@ -1,0 +1,433 @@
+{
+  "title": "Arquivo da Viol\u00eancia - Pipeline",
+  "uid": "arquivo-pipeline",
+  "schemaVersion": 39,
+  "version": 2,
+  "timezone": "browser",
+  "refresh": "30s",
+  "tags": [
+    "arquivo",
+    "pipeline"
+  ],
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "templating": {
+    "list": [
+      {
+        "name": "stage",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "query": "label_values(pipeline_attempts_total{service=\"worker\"}, stage)",
+        "refresh": 2,
+        "includeAll": true,
+        "multi": true
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Worker Alive",
+      "type": "stat",
+      "gridPos": {
+        "x": 0,
+        "y": 0,
+        "w": 4,
+        "h": 4
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "pipeline_worker_alive{service=\"api\"}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": {
+                  "text": "DOWN",
+                  "color": "red"
+                },
+                "1": {
+                  "text": "UP",
+                  "color": "green"
+                }
+              }
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": 2,
+      "title": "Cron Enabled",
+      "type": "stat",
+      "gridPos": {
+        "x": 4,
+        "y": 0,
+        "w": 4,
+        "h": 4
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "pipeline_cron_enabled{service=\"api\"}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": {
+                  "text": "OFF",
+                  "color": "orange"
+                },
+                "1": {
+                  "text": "ON",
+                  "color": "green"
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": 3,
+      "title": "Queue Depth",
+      "type": "stat",
+      "gridPos": {
+        "x": 8,
+        "y": 0,
+        "w": 4,
+        "h": 4
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "pipeline_queue_depth{service=\"api\"}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 20
+              },
+              {
+                "color": "red",
+                "value": 50
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": 4,
+      "title": "Redis Connected",
+      "type": "stat",
+      "gridPos": {
+        "x": 12,
+        "y": 0,
+        "w": 4,
+        "h": 4
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "pipeline_redis_connected{service=\"api\"}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": {
+                  "text": "DISCONNECTED",
+                  "color": "red"
+                },
+                "1": {
+                  "text": "OK",
+                  "color": "green"
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": 10,
+      "title": "Task Outcomes (selected range)",
+      "description": "Total tasks completed in the selected time range. Populates once pipeline jobs run.",
+      "type": "bargauge",
+      "gridPos": {
+        "x": 0,
+        "y": 4,
+        "w": 24,
+        "h": 8
+      },
+      "options": {
+        "displayMode": "gradient",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true
+      },
+      "targets": [
+        {
+          "expr": "sum(increase(pipeline_task_total{service=\"worker\"}[$__range])) by (task, outcome)",
+          "refId": "A",
+          "legendFormat": "{{task}} / {{outcome}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "noValue": "0",
+          "min": 0
+        }
+      }
+    },
+    {
+      "id": 20,
+      "title": "Task Duration p50 / p95 by task",
+      "description": "Requires recent task activity on the worker.",
+      "type": "timeseries",
+      "gridPos": {
+        "x": 0,
+        "y": 12,
+        "w": 12,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.5, sum(rate(pipeline_task_duration_seconds_bucket{service=\"worker\"}[10m])) by (task, le))",
+          "refId": "p50",
+          "legendFormat": "p50 {{task}}"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(pipeline_task_duration_seconds_bucket{service=\"worker\"}[10m])) by (task, le))",
+          "refId": "p95",
+          "legendFormat": "p95 {{task}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "noValue": "0"
+        }
+      }
+    },
+    {
+      "id": 30,
+      "title": "Success Rate by Stage",
+      "description": "Share of successful download/extraction attempts in the selected range.",
+      "type": "stat",
+      "gridPos": {
+        "x": 12,
+        "y": 12,
+        "w": 12,
+        "h": 8
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "sum(increase(pipeline_attempts_total{service=\"worker\",outcome=\"success\"}[$__range])) by (stage) / clamp_min(sum(increase(pipeline_attempts_total{service=\"worker\"}[$__range])) by (stage), 1)",
+          "refId": "A",
+          "legendFormat": "{{stage}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.8
+              },
+              {
+                "color": "green",
+                "value": 0.95
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": 40,
+      "title": "Failures by Reason",
+      "type": "piechart",
+      "gridPos": {
+        "x": 0,
+        "y": 20,
+        "w": 12,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "sum(increase(pipeline_attempts_total{service=\"worker\",outcome=\"failure\"}[$__range])) by (failure_reason)",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "noValue": "0"
+        }
+      }
+    },
+    {
+      "id": 50,
+      "title": "Attempt Duration p95 by Stage",
+      "type": "timeseries",
+      "gridPos": {
+        "x": 12,
+        "y": 20,
+        "w": 12,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(pipeline_attempt_duration_seconds_bucket{service=\"worker\"}[10m])) by (stage, le))",
+          "refId": "A",
+          "legendFormat": "p95 {{stage}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "noValue": "0"
+        }
+      }
+    },
+    {
+      "id": 60,
+      "title": "Downloaded Content Size",
+      "type": "timeseries",
+      "gridPos": {
+        "x": 0,
+        "y": 28,
+        "w": 24,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.5, sum(rate(pipeline_attempt_content_length_bytes_bucket{service=\"worker\",stage=\"download\"}[15m])) by (le))",
+          "refId": "p50",
+          "legendFormat": "p50 bytes"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(pipeline_attempt_content_length_bytes_bucket{service=\"worker\",stage=\"download\"}[15m])) by (le))",
+          "refId": "p95",
+          "legendFormat": "p95 bytes"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "noValue": "0"
+        }
+      }
+    }
+  ]
+}

--- a/infra/observability/grafana/provisioning/dashboards/dashboards.yml
+++ b/infra/observability/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+providers:
+  - name: arquivo-pipeline
+    orgId: 1
+    folder: Arquivo
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    options:
+      path: /var/lib/grafana/dashboards

--- a/infra/observability/grafana/provisioning/datasources/prometheus.yml
+++ b/infra/observability/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,10 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    uid: prometheus
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false

--- a/infra/observability/nginx/observability-http-only.conf
+++ b/infra/observability/nginx/observability-http-only.conf
@@ -1,0 +1,24 @@
+# HTTP-only bootstrap config (used before TLS certificate exists).
+# After certbot runs, deploy-remote.sh switches to observability.conf.
+
+server {
+    listen 80;
+    listen [::]:80;
+    server_name observability.carabetta.xyz;
+
+    location /.well-known/acme-challenge/ {
+        root /var/www/html;
+    }
+
+    location / {
+        proxy_pass http://127.0.0.1:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_cache_bypass $http_upgrade;
+    }
+}

--- a/infra/observability/nginx/observability.conf
+++ b/infra/observability/nginx/observability.conf
@@ -1,0 +1,45 @@
+# Grafana reverse proxy for observability.carabetta.xyz
+
+server {
+    listen 80;
+    listen [::]:80;
+    server_name observability.carabetta.xyz;
+
+    location /.well-known/acme-challenge/ {
+        root /var/www/html;
+    }
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+    server_name observability.carabetta.xyz;
+
+    ssl_certificate /etc/letsencrypt/live/observability.carabetta.xyz/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/observability.carabetta.xyz/privkey.pem;
+
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_prefer_server_ciphers on;
+    ssl_ciphers ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384;
+    ssl_session_cache shared:SSL:50m;
+    ssl_session_timeout 1d;
+
+    access_log /var/log/nginx/observability-access.log;
+    error_log /var/log/nginx/observability-error.log;
+
+    location / {
+        proxy_pass http://127.0.0.1:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_cache_bypass $http_upgrade;
+    }
+}

--- a/infra/observability/prometheus/prometheus.yml
+++ b/infra/observability/prometheus/prometheus.yml
@@ -1,0 +1,22 @@
+global:
+  scrape_interval: 30s
+  evaluation_interval: 30s
+
+scrape_configs:
+  - job_name: arquivo-prod-api
+    metrics_path: /metrics
+    scheme: http
+    static_configs:
+      - targets: ["77.42.72.111:8000"]
+        labels:
+          environment: production
+          service: api
+
+  - job_name: arquivo-prod-worker
+    metrics_path: /metrics
+    scheme: http
+    static_configs:
+      - targets: ["77.42.72.111:9091"]
+        labels:
+          environment: production
+          service: worker

--- a/scripts/check-observability.sh
+++ b/scripts/check-observability.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+# Verifies production metrics endpoints and the self-hosted Grafana stack.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+if [[ -f "$REPO_DIR/.env" ]]; then set -a; source "$REPO_DIR/.env"; set +a; fi
+
+PROD=false
+for arg in "$@"; do [[ "$arg" == "--prod" ]] && PROD=true; done
+
+PROD_SSH_HOST="${OBS_PROD_SSH_HOST:-hetzner-arv-public}"
+PROD_SSH_USER="${OBS_PROD_SSH_USER:-root}"
+PROD_SSH_KEY="${OBS_PROD_SSH_KEY:-$HOME/.ssh/hetzner_arquivo_violencia_rsa}"
+
+GRAFANA_URL="${OBS_GRAFANA_URL:-https://observability.carabetta.xyz}"
+
+failures=0
+pass() { echo "  OK  $1"; }
+fail() { echo "  FAIL $1"; failures=$((failures + 1)); }
+
+echo "=== Observability check ($($PROD && echo prod || echo local)) ==="
+
+if $PROD; then
+  ssh_cmd=(ssh -o BatchMode=yes -o ConnectTimeout=15 -i "$PROD_SSH_KEY" "${PROD_SSH_USER}@${PROD_SSH_HOST}")
+
+  if "${ssh_cmd[@]}" 'curl -sf http://localhost:8000/api/health | grep -q healthy'; then
+    pass "prod API /api/health"
+  else
+    fail "prod API /api/health"
+  fi
+
+  if "${ssh_cmd[@]}" 'bash /root/arquivo-da-violencia/scripts/check-pipeline-health.sh >/dev/null 2>&1'; then
+    pass "prod pipeline health script"
+  else
+    fail "prod pipeline health script"
+  fi
+
+  metrics=$("${ssh_cmd[@]}" 'curl -sf http://localhost:8000/metrics' 2>/dev/null || true)
+  if echo "$metrics" | grep -q 'pipeline_worker_alive'; then
+    pass "prod /metrics exposes pipeline_worker_alive"
+  else
+    fail "prod /metrics missing pipeline_worker_alive"
+  fi
+
+  worker_metrics=$("${ssh_cmd[@]}" 'curl -sf http://localhost:9091/metrics' 2>/dev/null || true)
+  if echo "$worker_metrics" | grep -q 'pipeline_task_total'; then
+    pass "prod worker :9091 exposes task metrics"
+  else
+    fail "prod worker :9091 missing task metrics"
+  fi
+  if echo "$worker_metrics" | grep -q 'pipeline_worker_alive'; then
+    fail "prod worker :9091 should not expose health gauges"
+  else
+    pass "prod worker :9091 has no health gauges"
+  fi
+else
+  API_BASE="${OBS_API_BASE:-http://localhost:8010}"
+  curl -sf "$API_BASE/api/health" | grep -q healthy && pass "GET /api/health" || fail "GET /api/health"
+  metrics=$(curl -sf "$API_BASE/metrics" 2>/dev/null || true)
+  if echo "$metrics" | grep -q pipeline_worker_alive; then
+    pass "/metrics pipeline_* metrics"
+  else
+    fail "/metrics missing pipeline metrics"
+  fi
+fi
+
+if curl -sf "${GRAFANA_URL}/api/health" | grep -q '"database":"ok"'; then
+  pass "Grafana HTTPS (${GRAFANA_URL})"
+else
+  fail "Grafana not reachable at ${GRAFANA_URL}"
+fi
+
+if $PROD; then
+  prom_query=$(curl -sfG "${GRAFANA_URL}/api/datasources/proxy/uid/prometheus/api/v1/query" \
+    --data-urlencode 'query=count(pipeline_worker_alive{service="api"}==1)' 2>/dev/null || true)
+  if echo "$prom_query" | grep -q '"value":\["' ; then
+    pass 'Prometheus: pipeline_worker_alive{service="api"} series present'
+  else
+    fail 'Prometheus missing pipeline_worker_alive{service="api"} (check scrape + backend deploy)'
+  fi
+fi
+
+echo "=== $failures failure(s) ==="
+exit "$((failures > 0))"


### PR DESCRIPTION
## Summary

- Add backend Prometheus instrumentation (`metrics.py`, `WORKER_REGISTRY`, API health gauges, worker `:9091` task metrics).
- Add self-hosted observability stack under `infra/observability/` with password-safe `deploy-remote.sh`, nginx/TLS configs, and hardened Grafana bind.
- Add `deploy-observability.yml` (master-only) plus docs and `scripts/check-observability.sh` for self-hosted verification.

Excludes unrelated frontend map changes from `feat/pipeline-observability`.

## Test plan

- [ ] CI: backend image build passes on this PR
- [ ] Staging deploy (`develop` merge): no regression in API/worker
- [ ] Before first obs CI run: bootstrap obs VPS git clone + GitHub secrets (`OBS_VPS_*`, `GRAFANA_ADMIN_PASSWORD`)
- [ ] After `develop` → `master`: `deploy-backend.yml` deploys prod metrics; `deploy-observability.yml` updates obs stack
- [ ] `bash scripts/check-observability.sh --prod` passes
- [ ] Dashboard https://observability.carabetta.xyz/d/arquivo-pipeline shows single UP/OK stat values


Made with [Cursor](https://cursor.com)