### PR TITLE
Release: pipeline Grafana dashboard and observability metrics

### DIFF
--- a/backend/app/metrics.py
+++ b/backend/app/metrics.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import time
 
 import httpx
 from loguru import logger
@@ -85,6 +86,42 @@ pipeline_redis_connected = Gauge(
     registry=REGISTRY,
 )
 
+pipeline_open_failure_issues = Gauge(
+    "pipeline_open_failure_issues",
+    "Number of open GitHub issues labeled pipeline-failure.",
+    registry=REGISTRY,
+)
+
+pipeline_cron_last_success_timestamp = Gauge(
+    "pipeline_cron_last_success_timestamp",
+    "Unix timestamp of the last successful cron run, by cron name.",
+    labelnames=["cron"],
+    registry=WORKER_REGISTRY,
+)
+
+pipeline_cron_runs_total = Counter(
+    "pipeline_cron_runs_total",
+    "Total cron executions, by cron name and outcome.",
+    labelnames=["cron", "outcome"],
+    registry=WORKER_REGISTRY,
+)
+
+pipeline_failure_issues_created_total = Counter(
+    "pipeline_failure_issues_created_total",
+    "Total new GitHub pipeline-failure issues created, by task.",
+    labelnames=["task"],
+    registry=WORKER_REGISTRY,
+)
+
+pipeline_failure_issue_recurrences_total = Counter(
+    "pipeline_failure_issue_recurrences_total",
+    "Total recurrence comments added to existing pipeline-failure issues.",
+    labelnames=["task"],
+    registry=WORKER_REGISTRY,
+)
+
+CRON_TASKS = frozenset({"ingest_cities_hourly", "process_cities_backlog"})
+
 
 def generate_worker_metrics() -> bytes:
     """Prometheus exposition format for the worker metrics HTTP server."""
@@ -157,6 +194,36 @@ def set_redis_connected(connected: bool) -> None:
         pipeline_redis_connected.set(1 if connected else 0)
     except Exception as e:  # pragma: no cover
         logger.warning(f"[metrics] set_redis_connected failed: {e}")
+
+
+def set_open_failure_issues(count: int) -> None:
+    try:
+        pipeline_open_failure_issues.set(count)
+    except Exception as e:  # pragma: no cover
+        logger.warning(f"[metrics] set_open_failure_issues failed: {e}")
+
+
+def record_cron_outcome(cron_name: str, outcome: str) -> None:
+    try:
+        pipeline_cron_runs_total.labels(cron=cron_name, outcome=outcome).inc()
+        if outcome == "success":
+            pipeline_cron_last_success_timestamp.labels(cron=cron_name).set(time.time())
+    except Exception as e:  # pragma: no cover
+        logger.warning(f"[metrics] record_cron_outcome failed: {e}")
+
+
+def record_failure_issue_created(task_name: str) -> None:
+    try:
+        pipeline_failure_issues_created_total.labels(task=task_name).inc()
+    except Exception as e:  # pragma: no cover
+        logger.warning(f"[metrics] record_failure_issue_created failed: {e}")
+
+
+def record_failure_issue_recurrence(task_name: str) -> None:
+    try:
+        pipeline_failure_issue_recurrences_total.labels(task=task_name).inc()
+    except Exception as e:  # pragma: no cover
+        logger.warning(f"[metrics] record_failure_issue_recurrence failed: {e}")
 
 
 def _is_push_configured() -> bool:

--- a/backend/app/services/github.py
+++ b/backend/app/services/github.py
@@ -12,6 +12,7 @@ import httpx
 from loguru import logger
 
 from app.config import get_settings
+from app.metrics import record_failure_issue_created, record_failure_issue_recurrence
 
 
 class GitHubIssueCreator:
@@ -146,8 +147,9 @@ class GitHubIssueCreator:
                 for key, value in details.items():
                     comment += f"- `{key}`: {value}\n"
             
-            await self._add_comment(existing["number"], comment)
-            logger.info(f"[GitHub] Updated existing issue #{existing['number']}")
+            if await self._add_comment(existing["number"], comment):
+                record_failure_issue_recurrence(task_name)
+                logger.info(f"[GitHub] Updated existing issue #{existing['number']}")
             return existing
         
         # Create new issue
@@ -187,6 +189,7 @@ class GitHubIssueCreator:
                 
                 if response.status_code == 201:
                     issue_data = response.json()
+                    record_failure_issue_created(task_name)
                     logger.info(f"[GitHub] ✅ Created issue #{issue_data['number']}: {title}")
                     return issue_data
                 else:
@@ -195,6 +198,35 @@ class GitHubIssueCreator:
                     
         except Exception as e:
             logger.error(f"[GitHub] ❌ Error creating issue: {e}")
+            return None
+
+
+    async def count_open_failure_issues(self) -> int | None:
+        """Return the number of open pipeline-failure issues, or None if unavailable."""
+        if not self.enabled:
+            return None
+
+        try:
+            query = f"repo:{self.repo} is:issue is:open label:pipeline-failure"
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                response = await client.get(
+                    self.search_url,
+                    headers={
+                        "Authorization": f"Bearer {self.token}",
+                        "Accept": "application/vnd.github+json",
+                        "X-GitHub-Api-Version": "2022-11-28",
+                    },
+                    params={"q": query, "per_page": 1},
+                )
+
+            if response.status_code == 200:
+                return int(response.json().get("total_count", 0))
+            logger.warning(
+                f"[GitHub] Failed to count open failure issues: HTTP {response.status_code}"
+            )
+            return None
+        except Exception as e:
+            logger.error(f"[GitHub] Error counting open failure issues: {e}")
             return None
 
 

--- a/backend/app/services/worker_monitor.py
+++ b/backend/app/services/worker_monitor.py
@@ -18,15 +18,20 @@ from loguru import logger
 from app.metrics import (
     set_cron_enabled,
     set_heartbeat_misses,
+    set_open_failure_issues,
     set_queue_depth,
     set_redis_connected,
     set_worker_alive,
 )
 from app.routers.pipeline import collect_pipeline_status
+from app.services.github import get_github_creator
 from app.services.telegram import notify_worker_down, notify_worker_recovered
 
 # How often to poll the heartbeat key.
 CHECK_INTERVAL_SECONDS = 60
+
+# How often to refresh the open GitHub failure-issue gauge.
+GITHUB_POLL_INTERVAL_SECONDS = 300
 
 # Consecutive missed heartbeats before declaring the worker down. Kept high
 # enough to ride out a normal deploy (graceful worker shutdown can take ~120s)
@@ -48,6 +53,7 @@ async def monitor_worker_health(stop_event: asyncio.Event) -> None:
     """Poll the worker heartbeat until ``stop_event`` is set."""
     consecutive_misses = 0
     alerted_down = False
+    github_poll_counter = 0
 
     logger.info(
         f"[WorkerMonitor] Started (interval={CHECK_INTERVAL_SECONDS}s, "
@@ -59,6 +65,13 @@ async def monitor_worker_health(stop_event: asyncio.Event) -> None:
             status = await collect_pipeline_status()
             redis_ok = _apply_status_metrics(status)
             alive = bool(status.get("worker_alive")) if redis_ok else False
+
+            github_poll_counter += CHECK_INTERVAL_SECONDS
+            if github_poll_counter >= GITHUB_POLL_INTERVAL_SECONDS:
+                github_poll_counter = 0
+                open_issues = await get_github_creator().count_open_failure_issues()
+                if open_issues is not None:
+                    set_open_failure_issues(open_issues)
 
             if not redis_ok:
                 logger.warning(

--- a/backend/app/tasks/pipeline.py
+++ b/backend/app/tasks/pipeline.py
@@ -6,7 +6,7 @@ from typing import Any, Callable
 
 from loguru import logger
 
-from app.metrics import record_task_outcome
+from app.metrics import CRON_TASKS, record_cron_outcome, record_task_outcome
 from app.services.github import create_failure_issue
 from app.services.telegram import (
     notify_job_started,
@@ -32,9 +32,11 @@ def notify_on_failure(task_name: str):
         @functools.wraps(func)
         async def wrapper(*args, **kwargs) -> Any:
             start = time.monotonic()
-            outcome = "success"
+            outcome: str | None = None
             try:
-                return await func(*args, **kwargs)
+                result = await func(*args, **kwargs)
+                outcome = "success"
+                return result
             except Exception as e:
                 outcome = "failure"
                 # Extract context details from args/kwargs for the notification
@@ -68,7 +70,10 @@ def notify_on_failure(task_name: str):
                 
                 raise
             finally:
-                record_task_outcome(task_name, outcome, time.monotonic() - start)
+                if outcome is not None:
+                    record_task_outcome(task_name, outcome, time.monotonic() - start)
+                    if task_name in CRON_TASKS:
+                        record_cron_outcome(task_name, outcome)
         
         return wrapper
     return decorator

--- a/docs/observability-self-hosted.md
+++ b/docs/observability-self-hosted.md
@@ -12,10 +12,11 @@ visualized in Grafana.
 ## Architecture
 
 - **API** (`arquivo-api`) exposes health gauges (`pipeline_worker_alive`,
-  `pipeline_redis_connected`, etc.) on `/metrics` via `prometheus-fastapi-instrumentator`
-  bound to `REGISTRY`.
+  `pipeline_redis_connected`, `pipeline_open_failure_issues`, etc.) on `/metrics`
+  via `prometheus-fastapi-instrumentator` bound to `REGISTRY`.
 - **Worker** (`arquivo-worker`) exposes task/attempt counters on `:9091/metrics`
-  via a separate `WORKER_REGISTRY` (no health gauges — avoids duplicate dashboard stats).
+  via a separate `WORKER_REGISTRY` (cron timestamps, GitHub issue counters, task
+  metrics — no duplicate health gauges).
 - **Prometheus** on the obs VPS scrapes both targets every 30s.
 - **Grafana** is bound to `127.0.0.1:3000` and published via nginx + Let's Encrypt
   at `observability.carabetta.xyz`.
@@ -43,6 +44,31 @@ Backend metrics deploy via the existing
 when `backend/**` or `docker-compose.yml` change.
 
 Observability deploys on **master only** (staging has no scrape targets).
+
+## Dashboard sections
+
+The **Arquivo da Violência - Pipeline** dashboard is organized around three
+operational questions:
+
+| Section | Answers |
+|---------|---------|
+| **Infrastructure** | Worker heartbeat, Redis, queue depth, scrape health |
+| **Pipeline Steps** | Per-step success rate and throughput (ingest → geocode), attempt failures |
+| **Crons** | Minutes since last successful `ingest_cities_hourly` / `process_cities_backlog` |
+| **Bugs** | Open GitHub `pipeline-failure` issues, new bugs and recurrences in range |
+
+Default time range is **6 hours** (hourly crons). Performance panels (duration,
+content size) are in a collapsed row at the bottom.
+
+### Metrics reference
+
+| Metric | Registry | Source |
+|--------|----------|--------|
+| `pipeline_cron_last_success_timestamp{cron}` | Worker | Set when cron task succeeds |
+| `pipeline_cron_runs_total{cron,outcome}` | Worker | Every cron execution |
+| `pipeline_failure_issues_created_total{task}` | Worker | New GitHub issue created |
+| `pipeline_failure_issue_recurrences_total{task}` | Worker | Comment on existing issue |
+| `pipeline_open_failure_issues` | API | Polled from GitHub every 5 min |
 
 ### GitHub Actions secrets
 

--- a/infra/observability/docker-compose.preview.yml
+++ b/infra/observability/docker-compose.preview.yml
@@ -1,0 +1,11 @@
+# Local dashboard preview — no login required.
+# Usage:
+#   cd infra/observability
+#   GRAFANA_ADMIN_PASSWORD=admin docker compose -f docker-compose.yml -f docker-compose.preview.yml up -d
+services:
+  grafana:
+    environment:
+      - GF_SERVER_ROOT_URL=http://localhost:3000
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+      - GF_AUTH_DISABLE_LOGIN_FORM=false

--- a/infra/observability/grafana/dashboards/pipeline-overview.json
+++ b/infra/observability/grafana/dashboards/pipeline-overview.json
@@ -2,26 +2,29 @@
   "title": "Arquivo da Viol\u00eancia - Pipeline",
   "uid": "arquivo-pipeline",
   "schemaVersion": 39,
-  "version": 2,
+  "version": 3,
   "timezone": "browser",
   "refresh": "30s",
-  "tags": [
-    "arquivo",
-    "pipeline"
-  ],
+  "tags": ["arquivo", "pipeline"],
   "time": {
-    "from": "now-24h",
+    "from": "now-6h",
     "to": "now"
   },
+  "links": [
+    {
+      "title": "Open pipeline bugs on GitHub",
+      "url": "https://github.com/JoaoCarabetta/arquivo-da-violencia/issues?q=is%3Aissue+is%3Aopen+label%3Apipeline-failure",
+      "type": "link",
+      "icon": "external link",
+      "targetBlank": true
+    }
+  ],
   "templating": {
     "list": [
       {
         "name": "stage",
         "type": "query",
-        "datasource": {
-          "type": "prometheus",
-          "uid": "prometheus"
-        },
+        "datasource": { "type": "prometheus", "uid": "prometheus" },
         "query": "label_values(pipeline_attempts_total{service=\"worker\"}, stage)",
         "refresh": 2,
         "includeAll": true,
@@ -31,106 +34,56 @@
   },
   "panels": [
     {
+      "id": 100,
+      "type": "row",
+      "title": "Infrastructure",
+      "gridPos": { "x": 0, "y": 0, "w": 24, "h": 1 },
+      "collapsed": false
+    },
+    {
       "id": 1,
       "title": "Worker Alive",
       "type": "stat",
-      "gridPos": {
-        "x": 0,
-        "y": 0,
-        "w": 4,
-        "h": 4
-      },
+      "gridPos": { "x": 0, "y": 1, "w": 4, "h": 4 },
       "options": {
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
         "colorMode": "value",
         "textMode": "auto"
       },
-      "targets": [
-        {
-          "expr": "pipeline_worker_alive{service=\"api\"}",
-          "refId": "A"
-        }
-      ],
+      "targets": [{ "expr": "pipeline_worker_alive{service=\"api\"}", "refId": "A" }],
       "fieldConfig": {
         "defaults": {
           "mappings": [
             {
               "type": "value",
               "options": {
-                "0": {
-                  "text": "DOWN",
-                  "color": "red"
-                },
-                "1": {
-                  "text": "UP",
-                  "color": "green"
-                }
+                "0": { "text": "DOWN", "color": "red" },
+                "1": { "text": "UP", "color": "green" }
               }
             }
-          ],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "red",
-                "value": null
-              },
-              {
-                "color": "green",
-                "value": 1
-              }
-            ]
-          }
+          ]
         }
       }
     },
     {
-      "id": 2,
-      "title": "Cron Enabled",
+      "id": 4,
+      "title": "Redis Connected",
       "type": "stat",
-      "gridPos": {
-        "x": 4,
-        "y": 0,
-        "w": 4,
-        "h": 4
-      },
+      "gridPos": { "x": 4, "y": 1, "w": 4, "h": 4 },
       "options": {
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
         "colorMode": "value",
         "textMode": "auto"
       },
-      "targets": [
-        {
-          "expr": "pipeline_cron_enabled{service=\"api\"}",
-          "refId": "A"
-        }
-      ],
+      "targets": [{ "expr": "pipeline_redis_connected{service=\"api\"}", "refId": "A" }],
       "fieldConfig": {
         "defaults": {
           "mappings": [
             {
               "type": "value",
               "options": {
-                "0": {
-                  "text": "OFF",
-                  "color": "orange"
-                },
-                "1": {
-                  "text": "ON",
-                  "color": "green"
-                }
+                "0": { "text": "DISCONNECTED", "color": "red" },
+                "1": { "text": "OK", "color": "green" }
               }
             }
           ]
@@ -141,26 +94,408 @@
       "id": 3,
       "title": "Queue Depth",
       "type": "stat",
-      "gridPos": {
-        "x": 8,
-        "y": 0,
-        "w": 4,
-        "h": 4
-      },
+      "gridPos": { "x": 8, "y": 1, "w": 4, "h": 4 },
       "options": {
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "value",
+        "textMode": "auto"
+      },
+      "targets": [{ "expr": "pipeline_queue_depth{service=\"api\"}", "refId": "A" }],
+      "fieldConfig": {
+        "defaults": {
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 20 },
+              { "color": "red", "value": 50 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": 5,
+      "title": "Scrape Targets",
+      "type": "stat",
+      "gridPos": { "x": 12, "y": 1, "w": 4, "h": 4 },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "value",
+        "textMode": "auto"
+      },
+      "targets": [{ "expr": "min(up{job=~\"arquivo-prod.*\"})", "refId": "A" }],
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": { "text": "DOWN", "color": "red" },
+                "1": { "text": "UP", "color": "green" }
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": 6,
+      "title": "Heartbeat Misses",
+      "type": "stat",
+      "gridPos": { "x": 16, "y": 1, "w": 4, "h": 4 },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "value",
+        "textMode": "auto"
+      },
+      "targets": [{ "expr": "pipeline_worker_heartbeat_misses{service=\"api\"}", "refId": "A" }],
+      "fieldConfig": {
+        "defaults": {
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 2 },
+              { "color": "red", "value": 5 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": 2,
+      "title": "Cron Scheduling",
+      "description": "Whether the worker has cron jobs enabled (config flag, not proof of execution).",
+      "type": "stat",
+      "gridPos": { "x": 20, "y": 1, "w": 4, "h": 4 },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "value",
+        "textMode": "auto"
+      },
+      "targets": [{ "expr": "pipeline_cron_enabled{service=\"api\"}", "refId": "A" }],
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": { "text": "OFF", "color": "orange" },
+                "1": { "text": "ON", "color": "green" }
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": 101,
+      "type": "row",
+      "title": "Pipeline Steps",
+      "gridPos": { "x": 0, "y": 5, "w": 24, "h": 1 },
+      "collapsed": false
+    },
+    {
+      "id": 11,
+      "title": "Step Success Rate",
+      "description": "Share of successful task runs per pipeline step in the selected range. Grey when no runs occurred.",
+      "type": "stat",
+      "gridPos": { "x": 0, "y": 6, "w": 24, "h": 5 },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "value",
+        "textMode": "value_and_name",
+        "orientation": "horizontal"
+      },
+      "targets": [
+        {
+          "expr": "sum(increase(pipeline_task_total{service=\"worker\",task=\"ingest_cities_hourly\",outcome=\"success\"}[$__range])) / clamp_min(sum(increase(pipeline_task_total{service=\"worker\",task=\"ingest_cities_hourly\"}[$__range])), 1)",
+          "refId": "ingest",
+          "legendFormat": "ingest"
         },
+        {
+          "expr": "sum(increase(pipeline_task_total{service=\"worker\",task=\"classify_batch\",outcome=\"success\"}[$__range])) / clamp_min(sum(increase(pipeline_task_total{service=\"worker\",task=\"classify_batch\"}[$__range])), 1)",
+          "refId": "classify",
+          "legendFormat": "classify"
+        },
+        {
+          "expr": "sum(increase(pipeline_task_total{service=\"worker\",task=\"download_batch\",outcome=\"success\"}[$__range])) / clamp_min(sum(increase(pipeline_task_total{service=\"worker\",task=\"download_batch\"}[$__range])), 1)",
+          "refId": "download",
+          "legendFormat": "download"
+        },
+        {
+          "expr": "sum(increase(pipeline_task_total{service=\"worker\",task=\"extract_batch\",outcome=\"success\"}[$__range])) / clamp_min(sum(increase(pipeline_task_total{service=\"worker\",task=\"extract_batch\"}[$__range])), 1)",
+          "refId": "extract",
+          "legendFormat": "extract"
+        },
+        {
+          "expr": "sum(increase(pipeline_task_total{service=\"worker\",task=\"batch_dedup\",outcome=\"success\"}[$__range])) / clamp_min(sum(increase(pipeline_task_total{service=\"worker\",task=\"batch_dedup\"}[$__range])), 1)",
+          "refId": "dedup",
+          "legendFormat": "dedup"
+        },
+        {
+          "expr": "sum(increase(pipeline_task_total{service=\"worker\",task=\"batch_enrich\",outcome=\"success\"}[$__range])) / clamp_min(sum(increase(pipeline_task_total{service=\"worker\",task=\"batch_enrich\"}[$__range])), 1)",
+          "refId": "enrich",
+          "legendFormat": "enrich"
+        },
+        {
+          "expr": "sum(increase(pipeline_task_total{service=\"worker\",task=\"batch_geocode\",outcome=\"success\"}[$__range])) / clamp_min(sum(increase(pipeline_task_total{service=\"worker\",task=\"batch_geocode\"}[$__range])), 1)",
+          "refId": "geocode",
+          "legendFormat": "geocode"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "noValue": "no activity",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "text", "value": null },
+              { "color": "red", "value": 0.01 },
+              { "color": "yellow", "value": 0.8 },
+              { "color": "green", "value": 0.95 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": 12,
+      "title": "Step Throughput",
+      "description": "Successful task runs per second by pipeline step.",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 11, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "sum(rate(pipeline_task_total{service=\"worker\",outcome=\"success\",task=~\"ingest_cities_hourly|classify_batch|download_batch|extract_batch|batch_dedup|batch_enrich|batch_geocode\"}[15m])) by (task)",
+          "refId": "A",
+          "legendFormat": "{{task}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "ops", "noValue": "0" }
+      }
+    },
+    {
+      "id": 13,
+      "title": "Task Failures (selected range)",
+      "type": "bargauge",
+      "gridPos": { "x": 12, "y": 11, "w": 12, "h": 8 },
+      "options": {
+        "displayMode": "gradient",
+        "orientation": "horizontal",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "showUnfilled": true
+      },
+      "targets": [
+        {
+          "expr": "sum(increase(pipeline_task_total{service=\"worker\",outcome=\"failure\"}[$__range])) by (task)",
+          "refId": "A",
+          "legendFormat": "{{task}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "noValue": "none",
+          "min": 0,
+          "color": { "mode": "continuous-GrYlRd" }
+        }
+      }
+    },
+    {
+      "id": 30,
+      "title": "Attempt Success Rate",
+      "description": "Download/extraction attempt success by stage. Filter with the stage variable.",
+      "type": "stat",
+      "gridPos": { "x": 0, "y": 19, "w": 12, "h": 6 },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "value",
+        "textMode": "value_and_name"
+      },
+      "targets": [
+        {
+          "expr": "sum(increase(pipeline_attempts_total{service=\"worker\",outcome=\"success\",stage=~\"$stage\"}[$__range])) by (stage) / clamp_min(sum(increase(pipeline_attempts_total{service=\"worker\",stage=~\"$stage\"}[$__range])) by (stage), 1)",
+          "refId": "A",
+          "legendFormat": "{{stage}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "noValue": "no activity",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "text", "value": null },
+              { "color": "red", "value": 0.01 },
+              { "color": "yellow", "value": 0.8 },
+              { "color": "green", "value": 0.95 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": 40,
+      "title": "Failures by Reason",
+      "type": "piechart",
+      "gridPos": { "x": 12, "y": 19, "w": 12, "h": 6 },
+      "targets": [
+        {
+          "expr": "sum(increase(pipeline_attempts_total{service=\"worker\",outcome=\"failure\",stage=~\"$stage\"}[$__range])) by (failure_reason)",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "noValue": "none" }
+      }
+    },
+    {
+      "id": 102,
+      "type": "row",
+      "title": "Crons",
+      "gridPos": { "x": 0, "y": 25, "w": 24, "h": 1 },
+      "collapsed": false
+    },
+    {
+      "id": 21,
+      "title": "Last Hourly Ingest",
+      "description": "Minutes since ingest_cities_hourly last succeeded (:05 UTC).",
+      "type": "stat",
+      "gridPos": { "x": 0, "y": 26, "w": 6, "h": 4 },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
         "colorMode": "value",
         "textMode": "auto"
       },
       "targets": [
         {
-          "expr": "pipeline_queue_depth{service=\"api\"}",
+          "expr": "(time() - pipeline_cron_last_success_timestamp{service=\"worker\",cron=\"ingest_cities_hourly\"}) / 60",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "m",
+          "noValue": "never",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 90 },
+              { "color": "red", "value": 120 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": 22,
+      "title": "Last Backlog Run",
+      "description": "Minutes since process_cities_backlog last succeeded (:35 UTC, may run up to 2h).",
+      "type": "stat",
+      "gridPos": { "x": 6, "y": 26, "w": 6, "h": 4 },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "value",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "(time() - pipeline_cron_last_success_timestamp{service=\"worker\",cron=\"process_cities_backlog\"}) / 60",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "m",
+          "noValue": "never",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 150 },
+              { "color": "red", "value": 180 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": 23,
+      "title": "Cron Runs (selected range)",
+      "type": "bargauge",
+      "gridPos": { "x": 12, "y": 26, "w": 12, "h": 4 },
+      "options": {
+        "displayMode": "gradient",
+        "orientation": "horizontal",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "showUnfilled": true
+      },
+      "targets": [
+        {
+          "expr": "sum(increase(pipeline_cron_runs_total{service=\"worker\"}[$__range])) by (cron, outcome)",
+          "refId": "A",
+          "legendFormat": "{{cron}} / {{outcome}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "noValue": "0", "min": 0 }
+      }
+    },
+    {
+      "id": 103,
+      "type": "row",
+      "title": "Bugs",
+      "gridPos": { "x": 0, "y": 30, "w": 24, "h": 1 },
+      "collapsed": false
+    },
+    {
+      "id": 31,
+      "title": "Open Pipeline Bugs",
+      "description": "Open GitHub issues with label pipeline-failure (polled every 5 min).",
+      "type": "stat",
+      "gridPos": { "x": 0, "y": 31, "w": 6, "h": 4 },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "value",
+        "textMode": "auto"
+      },
+      "targets": [{ "expr": "pipeline_open_failure_issues{service=\"api\"}", "refId": "A" }],
+      "fieldConfig": {
+        "defaults": {
+          "noValue": "unknown",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1 },
+              { "color": "red", "value": 5 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": 32,
+      "title": "New Bugs (selected range)",
+      "type": "stat",
+      "gridPos": { "x": 6, "y": 31, "w": 6, "h": 4 },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "value",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "sum(increase(pipeline_failure_issues_created_total{service=\"worker\"}[$__range]))",
           "refId": "A"
         }
       ],
@@ -170,118 +505,69 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "yellow",
-                "value": 20
-              },
-              {
-                "color": "red",
-                "value": 50
-              }
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1 },
+              { "color": "red", "value": 3 }
             ]
           }
         }
       }
     },
     {
-      "id": 4,
-      "title": "Redis Connected",
+      "id": 33,
+      "title": "Bug Recurrences (selected range)",
+      "description": "Comments added to existing pipeline-failure issues.",
       "type": "stat",
-      "gridPos": {
-        "x": 12,
-        "y": 0,
-        "w": 4,
-        "h": 4
-      },
+      "gridPos": { "x": 12, "y": 31, "w": 6, "h": 4 },
       "options": {
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
         "colorMode": "value",
         "textMode": "auto"
       },
       "targets": [
         {
-          "expr": "pipeline_redis_connected{service=\"api\"}",
+          "expr": "sum(increase(pipeline_failure_issue_recurrences_total{service=\"worker\"}[$__range]))",
           "refId": "A"
         }
       ],
       "fieldConfig": {
-        "defaults": {
-          "mappings": [
-            {
-              "type": "value",
-              "options": {
-                "0": {
-                  "text": "DISCONNECTED",
-                  "color": "red"
-                },
-                "1": {
-                  "text": "OK",
-                  "color": "green"
-                }
-              }
-            }
-          ]
-        }
+        "defaults": { "noValue": "0" }
       }
     },
     {
-      "id": 10,
-      "title": "Task Outcomes (selected range)",
-      "description": "Total tasks completed in the selected time range. Populates once pipeline jobs run.",
+      "id": 34,
+      "title": "New Bugs by Task",
       "type": "bargauge",
-      "gridPos": {
-        "x": 0,
-        "y": 4,
-        "w": 24,
-        "h": 8
-      },
+      "gridPos": { "x": 18, "y": 31, "w": 6, "h": 4 },
       "options": {
         "displayMode": "gradient",
         "orientation": "horizontal",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
         "showUnfilled": true
       },
       "targets": [
         {
-          "expr": "sum(increase(pipeline_task_total{service=\"worker\"}[$__range])) by (task, outcome)",
+          "expr": "sum(increase(pipeline_failure_issues_created_total{service=\"worker\"}[$__range])) by (task)",
           "refId": "A",
-          "legendFormat": "{{task}} / {{outcome}}"
+          "legendFormat": "{{task}}"
         }
       ],
       "fieldConfig": {
-        "defaults": {
-          "noValue": "0",
-          "min": 0
-        }
+        "defaults": { "noValue": "none", "min": 0 }
       }
+    },
+    {
+      "id": 104,
+      "type": "row",
+      "title": "Performance Details",
+      "gridPos": { "x": 0, "y": 35, "w": 24, "h": 1 },
+      "collapsed": true
     },
     {
       "id": 20,
       "title": "Task Duration p50 / p95 by task",
-      "description": "Requires recent task activity on the worker.",
       "type": "timeseries",
-      "gridPos": {
-        "x": 0,
-        "y": 12,
-        "w": 12,
-        "h": 8
-      },
+      "gridPos": { "x": 0, "y": 36, "w": 12, "h": 8 },
       "targets": [
         {
           "expr": "histogram_quantile(0.5, sum(rate(pipeline_task_duration_seconds_bucket{service=\"worker\"}[10m])) by (task, le))",
@@ -295,121 +581,30 @@
         }
       ],
       "fieldConfig": {
-        "defaults": {
-          "unit": "s",
-          "noValue": "0"
-        }
-      }
-    },
-    {
-      "id": 30,
-      "title": "Success Rate by Stage",
-      "description": "Share of successful download/extraction attempts in the selected range.",
-      "type": "stat",
-      "gridPos": {
-        "x": 12,
-        "y": 12,
-        "w": 12,
-        "h": 8
-      },
-      "options": {
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "colorMode": "value",
-        "textMode": "auto"
-      },
-      "targets": [
-        {
-          "expr": "sum(increase(pipeline_attempts_total{service=\"worker\",outcome=\"success\"}[$__range])) by (stage) / clamp_min(sum(increase(pipeline_attempts_total{service=\"worker\"}[$__range])) by (stage), 1)",
-          "refId": "A",
-          "legendFormat": "{{stage}}"
-        }
-      ],
-      "fieldConfig": {
-        "defaults": {
-          "unit": "percentunit",
-          "noValue": "0",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "red",
-                "value": null
-              },
-              {
-                "color": "yellow",
-                "value": 0.8
-              },
-              {
-                "color": "green",
-                "value": 0.95
-              }
-            ]
-          }
-        }
-      }
-    },
-    {
-      "id": 40,
-      "title": "Failures by Reason",
-      "type": "piechart",
-      "gridPos": {
-        "x": 0,
-        "y": 20,
-        "w": 12,
-        "h": 8
-      },
-      "targets": [
-        {
-          "expr": "sum(increase(pipeline_attempts_total{service=\"worker\",outcome=\"failure\"}[$__range])) by (failure_reason)",
-          "refId": "A"
-        }
-      ],
-      "fieldConfig": {
-        "defaults": {
-          "noValue": "0"
-        }
+        "defaults": { "unit": "s", "noValue": "0" }
       }
     },
     {
       "id": 50,
       "title": "Attempt Duration p95 by Stage",
       "type": "timeseries",
-      "gridPos": {
-        "x": 12,
-        "y": 20,
-        "w": 12,
-        "h": 8
-      },
+      "gridPos": { "x": 12, "y": 36, "w": 12, "h": 8 },
       "targets": [
         {
-          "expr": "histogram_quantile(0.95, sum(rate(pipeline_attempt_duration_seconds_bucket{service=\"worker\"}[10m])) by (stage, le))",
+          "expr": "histogram_quantile(0.95, sum(rate(pipeline_attempt_duration_seconds_bucket{service=\"worker\",stage=~\"$stage\"}[10m])) by (stage, le))",
           "refId": "A",
           "legendFormat": "p95 {{stage}}"
         }
       ],
       "fieldConfig": {
-        "defaults": {
-          "unit": "s",
-          "noValue": "0"
-        }
+        "defaults": { "unit": "s", "noValue": "0" }
       }
     },
     {
       "id": 60,
       "title": "Downloaded Content Size",
       "type": "timeseries",
-      "gridPos": {
-        "x": 0,
-        "y": 28,
-        "w": 24,
-        "h": 8
-      },
+      "gridPos": { "x": 0, "y": 44, "w": 24, "h": 8 },
       "targets": [
         {
           "expr": "histogram_quantile(0.5, sum(rate(pipeline_attempt_content_length_bytes_bucket{service=\"worker\",stage=\"download\"}[15m])) by (le))",
@@ -423,10 +618,7 @@
         }
       ],
       "fieldConfig": {
-        "defaults": {
-          "unit": "bytes",
-          "noValue": "0"
-        }
+        "defaults": { "unit": "bytes", "noValue": "0" }
       }
     }
   ]

--- a/scripts/check-observability.sh
+++ b/scripts/check-observability.sh
@@ -65,16 +65,16 @@ else
   fi
 fi
 
-if curl -sf "${GRAFANA_URL}/api/health" | grep -q '"database":"ok"'; then
+if curl -sf "${GRAFANA_URL}/api/health" | grep -qE '"database":\s*"ok"'; then
   pass "Grafana HTTPS (${GRAFANA_URL})"
 else
   fail "Grafana not reachable at ${GRAFANA_URL}"
 fi
 
 if $PROD; then
-  prom_query=$(curl -sfG "${GRAFANA_URL}/api/datasources/proxy/uid/prometheus/api/v1/query" \
-    --data-urlencode 'query=count(pipeline_worker_alive{service="api"}==1)' 2>/dev/null || true)
-  if echo "$prom_query" | grep -q '"value":\["' ; then
+  prom_result=$(ssh -o BatchMode=yes -o ConnectTimeout=15 -i "$PROD_SSH_KEY" root@62.238.12.182 \
+    'docker exec obs-prometheus wget -qO- "http://localhost:9090/api/v1/query?query=pipeline_worker_alive%7Bservice%3D%22api%22%7D"' 2>/dev/null || true)
+  if echo "$prom_result" | grep -q '"status":"success"' && echo "$prom_result" | grep -q '"value"'; then
     pass 'Prometheus: pipeline_worker_alive{service="api"} series present'
   else
     fail 'Prometheus missing pipeline_worker_alive{service="api"} (check scrape + backend deploy)'


### PR DESCRIPTION
## Summary
- Rethink pipeline Grafana dashboard (steps, crons, bugs)
- Add cron last-run and GitHub failure metrics
- Poll open pipeline-failure issues for Grafana

## Staging verification
- [x] Deploy Backend (develop) green — run 28908937081
- [x] Staging `/api/health` OK

## Production test plan
- [ ] Deploy Backend (master) green
- [ ] Deploy Observability (master) green
- [ ] Production `/api/health` and `/metrics` expose new gauges
- [ ] Grafana dashboard shows new rows at https://observability.carabetta.xyz/d/arquivo-pipeline

Made with [Cursor](https://cursor.com)