### PR TITLE
Release: fix classification stall after split cron

### DIFF
--- a/backend/app/tasks/pipeline.py
+++ b/backend/app/tasks/pipeline.py
@@ -640,15 +640,16 @@ async def ingest_cities_hourly(
     when: str = "1h",
 ) -> dict:
     """
-    Hourly cron: ingest only.
+    Hourly cron: ingest, then enqueue headline classification.
 
-    Kept short so the :05 tick always runs even while backlog processing from
-    a prior hour is still in progress (separate cron at :35).
+    Ingest stays short (no inline LLM). Classification is queued immediately so
+    new sources are not left waiting until the :35 backlog cron — which can be
+    delayed when a prior backlog run is still in progress (unique=True, 2h cap).
     """
     logger.info("[INGEST_HOURLY] Starting hourly city ingest")
     await _run_pipeline_maintenance()
     return await ingest_cities_task(
-        ctx, cities=cities, when=when, enqueue_classify=False
+        ctx, cities=cities, when=when, enqueue_classify=True
     )
 
 

--- a/backend/tests/test_pipeline_cron_tasks.py
+++ b/backend/tests/test_pipeline_cron_tasks.py
@@ -11,7 +11,7 @@ from app.tasks.pipeline import (
 
 
 @pytest.mark.asyncio
-async def test_ingest_cities_hourly_does_not_enqueue_classify():
+async def test_ingest_cities_hourly_enqueues_classify_after_ingest():
     ctx = {"redis": AsyncMock()}
     ingest_result = {"total_sources_created": 3, "status": "completed"}
 
@@ -30,10 +30,9 @@ async def test_ingest_cities_hourly_does_not_enqueue_classify():
 
     mock_maint.assert_awaited_once()
     mock_ingest.assert_awaited_once_with(
-        ctx, cities=None, when="1h", enqueue_classify=False
+        ctx, cities=None, when="1h", enqueue_classify=True
     )
     assert result == ingest_result
-    ctx["redis"].enqueue_job.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/frontend/src/components/SourcesPerHourChart.tsx
+++ b/frontend/src/components/SourcesPerHourChart.tsx
@@ -17,7 +17,7 @@ import {
 import { fetchSourcesByHour } from "@/lib/api"
 import { Loader2 } from "lucide-react"
 
-// Status labels and colors
+// Status labels and colors (see index.css --chart-* tokens)
 const statusLabels: Record<string, string> = {
   ready_for_classification: "Aguardando Classificação",
   discarded: "Descartado",
@@ -29,13 +29,13 @@ const statusLabels: Record<string, string> = {
 }
 
 const statusColors: Record<string, string> = {
-  ready_for_classification: "var(--color-chart-1)", // blue
-  discarded: "var(--color-chart-2)", // gray
-  ready_for_download: "var(--color-chart-3)", // yellow
-  failed_in_download: "var(--color-chart-4)", // red
-  ready_for_extraction: "var(--color-chart-5)", // orange
-  failed_in_extraction: "var(--destructive)", // destructive red
-  extracted: "var(--color-chart-6)", // green
+  ready_for_classification: "var(--color-chart-1)", // blue — not yet classified
+  discarded: "var(--color-chart-2)", // red — classified out
+  ready_for_download: "var(--color-chart-3)", // gold — passed classification
+  failed_in_download: "var(--color-chart-4)", // green — download failure
+  ready_for_extraction: "var(--color-chart-5)", // gray — awaiting extraction
+  failed_in_extraction: "var(--destructive)", // dark red — extraction failure
+  extracted: "var(--color-chart-6)", // green — fully processed
 }
 
 const statusOrder = [
@@ -177,7 +177,8 @@ export function SourcesPerHourChart() {
       <CardHeader>
         <CardTitle>Sources Fetched Per Hour</CardTitle>
         <CardDescription>
-          Showing {total.toLocaleString()} total sources for the last {hours} hours
+          Showing {total.toLocaleString()} total sources for the last {hours} hours.
+          Blue = awaiting classification; red = classified and discarded.
         </CardDescription>
       </CardHeader>
       <CardContent>


### PR DESCRIPTION
## Summary
- Enqueue `classify_pending_task` immediately after hourly ingest so sources are not left in `ready_for_classification` until the :35 backlog cron
- Clarify admin Sources-per-hour chart legend (blue = awaiting classification)

## Staging verification
- [x] Deploy Backend (develop) green
- [x] Deploy Frontend (develop) green
- [x] Staging health endpoint OK

## Production test plan
- [ ] Deploy Backend (master) green
- [ ] Deploy Frontend (master) green
- [ ] Production health endpoints OK
- [ ] `ready_for_classification` backlog stays near zero after hourly ingest

Made with [Cursor](https://cursor.com)