### PR TITLE
Release: pipeline inventory Grafana dashboard

### DIFF
--- a/backend/app/metrics.py
+++ b/backend/app/metrics.py
@@ -92,6 +92,51 @@ pipeline_open_failure_issues = Gauge(
     registry=REGISTRY,
 )
 
+pipeline_inventory_total = Gauge(
+    "pipeline_inventory_total",
+    "Total Google News sources in the database.",
+    registry=REGISTRY,
+)
+
+pipeline_inventory_violent_death = Gauge(
+    "pipeline_inventory_violent_death",
+    "Sources classified as violent death (any status).",
+    registry=REGISTRY,
+)
+
+pipeline_inventory_raw_events = Gauge(
+    "pipeline_inventory_raw_events",
+    "Total extracted raw events.",
+    registry=REGISTRY,
+)
+
+pipeline_inventory_unique_events = Gauge(
+    "pipeline_inventory_unique_events",
+    "Total deduplicated unique events.",
+    registry=REGISTRY,
+)
+
+pipeline_inventory_sources = Gauge(
+    "pipeline_inventory_sources",
+    "Google News sources currently in each pipeline status.",
+    labelnames=["status"],
+    registry=REGISTRY,
+)
+
+pipeline_stuck_sources = Gauge(
+    "pipeline_stuck_sources",
+    "Sources stuck in a transient status longer than the stuck threshold.",
+    labelnames=["status"],
+    registry=REGISTRY,
+)
+
+pipeline_attempt_failures_24h = Gauge(
+    "pipeline_attempt_failures_24h",
+    "Failed download/extraction attempts in the last 24 hours, by stage and reason.",
+    labelnames=["stage", "failure_reason"],
+    registry=REGISTRY,
+)
+
 pipeline_cron_last_success_timestamp = Gauge(
     "pipeline_cron_last_success_timestamp",
     "Unix timestamp of the last successful cron run, by cron name.",
@@ -121,6 +166,54 @@ pipeline_failure_issue_recurrences_total = Counter(
 )
 
 CRON_TASKS = frozenset({"ingest_cities_hourly", "process_cities_backlog"})
+
+_STUCK_STATUSES = ("classifying", "downloading", "extracting")
+_seen_failure_labels: set[tuple[str, str]] = set()
+_seen_inventory_statuses: set[str] = set()
+
+
+def set_pipeline_inventory_metrics(
+    *,
+    status_counts: dict[str, int],
+    stuck_counts: dict[str, int],
+    failure_counts: dict[tuple[str, str], int],
+    sources_total: int,
+    violent_death: int,
+    raw_events_total: int,
+    unique_events_total: int,
+) -> None:
+    try:
+        pipeline_inventory_total.set(sources_total)
+        pipeline_inventory_violent_death.set(violent_death)
+        pipeline_inventory_raw_events.set(raw_events_total)
+        pipeline_inventory_unique_events.set(unique_events_total)
+
+        current_statuses: set[str] = set()
+        for status, count in status_counts.items():
+            pipeline_inventory_sources.labels(status=status).set(count)
+            current_statuses.add(status)
+        for status in _seen_inventory_statuses - current_statuses:
+            pipeline_inventory_sources.labels(status=status).set(0)
+        _seen_inventory_statuses.clear()
+        _seen_inventory_statuses.update(current_statuses)
+
+        for status in _STUCK_STATUSES:
+            pipeline_stuck_sources.labels(status=status).set(stuck_counts.get(status, 0))
+
+        current_failures: set[tuple[str, str]] = set()
+        for (stage, reason), count in failure_counts.items():
+            pipeline_attempt_failures_24h.labels(
+                stage=stage, failure_reason=reason
+            ).set(count)
+            current_failures.add((stage, reason))
+        for stage, reason in _seen_failure_labels - current_failures:
+            pipeline_attempt_failures_24h.labels(
+                stage=stage, failure_reason=reason
+            ).set(0)
+        _seen_failure_labels.clear()
+        _seen_failure_labels.update(current_failures)
+    except Exception as e:  # pragma: no cover
+        logger.warning(f"[metrics] set_pipeline_inventory_metrics failed: {e}")
 
 
 def generate_worker_metrics() -> bytes:

--- a/backend/app/services/pipeline_inventory_metrics.py
+++ b/backend/app/services/pipeline_inventory_metrics.py
@@ -1,0 +1,92 @@
+"""Poll Postgres and expose pipeline inventory gauges for Grafana."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+from loguru import logger
+from sqlalchemy import func, select, text
+
+from app.database import async_session_maker
+from app.metrics import set_pipeline_inventory_metrics
+from app.models.pipeline_attempt import PipelineAttempt
+from app.models.raw_event import RawEvent
+from app.models.source_google_news import SourceGoogleNews
+from app.models.unique_event import UniqueEvent
+
+STUCK_STATUSES = ("classifying", "downloading", "extracting")
+STUCK_MINUTES = 15
+FAILURE_WINDOW_HOURS = 24
+
+
+async def refresh_pipeline_inventory_metrics() -> None:
+    """Load source counts, stuck items, and recent failures from Postgres."""
+    try:
+        async with async_session_maker() as session:
+            status_rows = (
+                await session.execute(
+                    select(SourceGoogleNews.status, func.count(SourceGoogleNews.id)).group_by(
+                        SourceGoogleNews.status
+                    )
+                )
+            ).all()
+            status_counts = {str(status): int(count) for status, count in status_rows}
+
+            stuck_cutoff = datetime.utcnow() - timedelta(minutes=STUCK_MINUTES)
+            stuck_rows = (
+                await session.execute(
+                    text(
+                        """
+                        SELECT status, COUNT(*)
+                        FROM source_google_news
+                        WHERE status IN ('classifying', 'downloading', 'extracting')
+                          AND updated_at < :cutoff
+                        GROUP BY status
+                        """
+                    ),
+                    {"cutoff": stuck_cutoff},
+                )
+            ).all()
+            stuck_counts = {str(status): int(count) for status, count in stuck_rows}
+
+            failure_cutoff = datetime.utcnow() - timedelta(hours=FAILURE_WINDOW_HOURS)
+            failure_rows = (
+                await session.execute(
+                    select(
+                        PipelineAttempt.stage,
+                        PipelineAttempt.failure_reason,
+                        func.count(PipelineAttempt.id),
+                    )
+                    .where(
+                        PipelineAttempt.outcome == "failure",
+                        PipelineAttempt.created_at >= failure_cutoff,
+                        PipelineAttempt.failure_reason.is_not(None),
+                    )
+                    .group_by(PipelineAttempt.stage, PipelineAttempt.failure_reason)
+                )
+            ).all()
+            failure_counts = {
+                (str(stage), str(reason)): int(count)
+                for stage, reason, count in failure_rows
+            }
+
+            sources_total = await session.scalar(select(func.count(SourceGoogleNews.id)))
+            violent_death = await session.scalar(
+                select(func.count(SourceGoogleNews.id)).where(
+                    SourceGoogleNews.is_violent_death.is_(True)
+                )
+            )
+            raw_events_total = await session.scalar(select(func.count(RawEvent.id)))
+            unique_events_total = await session.scalar(select(func.count(UniqueEvent.id)))
+
+        set_pipeline_inventory_metrics(
+            status_counts=status_counts,
+            stuck_counts={status: stuck_counts.get(status, 0) for status in STUCK_STATUSES},
+            failure_counts=failure_counts,
+            sources_total=int(sources_total or 0),
+            violent_death=int(violent_death or 0),
+            raw_events_total=int(raw_events_total or 0),
+            unique_events_total=int(unique_events_total or 0),
+        )
+    except Exception as e:
+        logger.error(f"[PipelineInventory] Failed to refresh metrics: {e}")

--- a/backend/app/services/worker_monitor.py
+++ b/backend/app/services/worker_monitor.py
@@ -25,13 +25,14 @@ from app.metrics import (
 )
 from app.routers.pipeline import collect_pipeline_status
 from app.services.github import get_github_creator
+from app.services.pipeline_inventory_metrics import refresh_pipeline_inventory_metrics
 from app.services.telegram import notify_worker_down, notify_worker_recovered
 
 # How often to poll the heartbeat key.
 CHECK_INTERVAL_SECONDS = 60
 
-# How often to refresh the open GitHub failure-issue gauge.
-GITHUB_POLL_INTERVAL_SECONDS = 300
+# How often to refresh DB-backed inventory and GitHub failure-issue gauges.
+INVENTORY_POLL_INTERVAL_SECONDS = 300
 
 # Consecutive missed heartbeats before declaring the worker down. Kept high
 # enough to ride out a normal deploy (graceful worker shutdown can take ~120s)
@@ -60,6 +61,8 @@ async def monitor_worker_health(stop_event: asyncio.Event) -> None:
         f"threshold={MISS_THRESHOLD})"
     )
 
+    await refresh_pipeline_inventory_metrics()
+
     while not stop_event.is_set():
         try:
             status = await collect_pipeline_status()
@@ -67,11 +70,12 @@ async def monitor_worker_health(stop_event: asyncio.Event) -> None:
             alive = bool(status.get("worker_alive")) if redis_ok else False
 
             github_poll_counter += CHECK_INTERVAL_SECONDS
-            if github_poll_counter >= GITHUB_POLL_INTERVAL_SECONDS:
+            if github_poll_counter >= INVENTORY_POLL_INTERVAL_SECONDS:
                 github_poll_counter = 0
                 open_issues = await get_github_creator().count_open_failure_issues()
                 if open_issues is not None:
                     set_open_failure_issues(open_issues)
+                await refresh_pipeline_inventory_metrics()
 
             if not redis_ok:
                 logger.warning(

--- a/docs/observability-self-hosted.md
+++ b/docs/observability-self-hosted.md
@@ -52,22 +52,21 @@ operational questions:
 
 | Section | Answers |
 |---------|---------|
-| **Infrastructure** | Worker heartbeat, Redis, queue depth, scrape health |
-| **Pipeline Steps** | Per-step success rate and throughput (ingest → geocode), attempt failures |
-| **Crons** | Minutes since last successful `ingest_cities_hourly` / `process_cities_backlog` |
-| **Bugs** | Open GitHub `pipeline-failure` issues, new bugs and recurrences in range |
+| **Pipeline map** | Item counts at each step (same data as `/admin`) |
+| **Where is it stuck?** | Stuck in-flight items, backlog queues, worker/cron health |
+| **Failures (24h)** | Count, share %, and cause from `pipeline_attempt` |
 
-Default time range is **6 hours** (hourly crons). Performance panels (duration,
-content size) are in a collapsed row at the bottom.
+Inventory gauges refresh every **5 minutes** from Postgres via the API monitor.
 
 ### Metrics reference
 
 | Metric | Registry | Source |
 |--------|----------|--------|
+| `pipeline_inventory_sources{status}` | API | Live source counts by pipeline status |
+| `pipeline_inventory_total` / `_violent_death` / `_raw_events` / `_unique_events` | API | Summary totals matching `/admin` |
+| `pipeline_stuck_sources{status}` | API | Items in classifying/downloading/extracting > 15 min |
+| `pipeline_attempt_failures_24h{stage,failure_reason}` | API | Failed attempts in last 24h with cause |
 | `pipeline_cron_last_success_timestamp{cron}` | Worker | Set when cron task succeeds |
-| `pipeline_cron_runs_total{cron,outcome}` | Worker | Every cron execution |
-| `pipeline_failure_issues_created_total{task}` | Worker | New GitHub issue created |
-| `pipeline_failure_issue_recurrences_total{task}` | Worker | Comment on existing issue |
 | `pipeline_open_failure_issues` | API | Polled from GitHub every 5 min |
 
 ### GitHub Actions secrets

--- a/infra/observability/grafana/dashboards/pipeline-overview.json
+++ b/infra/observability/grafana/dashboards/pipeline-overview.json
@@ -1,16 +1,23 @@
 {
-  "title": "Arquivo da Viol\u00eancia - Pipeline",
+  "title": "Arquivo da Violência - Pipeline",
   "uid": "arquivo-pipeline",
   "schemaVersion": 39,
-  "version": 3,
+  "version": 4,
   "timezone": "browser",
-  "refresh": "30s",
+  "refresh": "1m",
   "tags": ["arquivo", "pipeline"],
   "time": {
-    "from": "now-6h",
+    "from": "now-24h",
     "to": "now"
   },
   "links": [
+    {
+      "title": "Admin dashboard",
+      "url": "https://arquivodaviolencia.com.br/admin",
+      "type": "link",
+      "icon": "dashboard",
+      "targetBlank": true
+    },
     {
       "title": "Open pipeline bugs on GitHub",
       "url": "https://github.com/JoaoCarabetta/arquivo-da-violencia/issues?q=is%3Aissue+is%3Aopen+label%3Apipeline-failure",
@@ -20,37 +27,554 @@
     }
   ],
   "templating": {
-    "list": [
-      {
-        "name": "stage",
-        "type": "query",
-        "datasource": { "type": "prometheus", "uid": "prometheus" },
-        "query": "label_values(pipeline_attempts_total{service=\"worker\"}, stage)",
-        "refresh": 2,
-        "includeAll": true,
-        "multi": true
-      }
-    ]
+    "list": []
   },
   "panels": [
     {
       "id": 100,
       "type": "row",
-      "title": "Infrastructure",
+      "title": "Pipeline map — items at each step",
       "gridPos": { "x": 0, "y": 0, "w": 24, "h": 1 },
       "collapsed": false
     },
     {
       "id": 1,
-      "title": "Worker Alive",
+      "title": "Total sources",
+      "description": "All Google News sources in the database (matches /admin).",
       "type": "stat",
-      "gridPos": { "x": 0, "y": 1, "w": 4, "h": 4 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "x": 0, "y": 1, "w": 5, "h": 4 },
       "options": {
         "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
         "colorMode": "value",
-        "textMode": "auto"
+        "textMode": "auto",
+        "graphMode": "none"
       },
-      "targets": [{ "expr": "pipeline_worker_alive{service=\"api\"}", "refId": "A" }],
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "pipeline_inventory_total{service=\"api\"}",
+          "refId": "A",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "noValue": "0",
+          "color": { "mode": "fixed", "fixedColor": "blue" }
+        }
+      }
+    },
+    {
+      "id": 2,
+      "title": "Violent death",
+      "description": "Sources classified as violent death (any status).",
+      "type": "stat",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "x": 5, "y": 1, "w": 5, "h": 4 },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "value",
+        "textMode": "auto",
+        "graphMode": "none"
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "pipeline_inventory_violent_death{service=\"api\"}",
+          "refId": "A",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "noValue": "0",
+          "color": { "mode": "fixed", "fixedColor": "purple" }
+        }
+      }
+    },
+    {
+      "id": 3,
+      "title": "Raw events",
+      "description": "Total extracted raw events.",
+      "type": "stat",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "x": 10, "y": 1, "w": 5, "h": 4 },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "value",
+        "textMode": "auto",
+        "graphMode": "none"
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "pipeline_inventory_raw_events{service=\"api\"}",
+          "refId": "A",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "noValue": "0",
+          "color": { "mode": "fixed", "fixedColor": "green" }
+        }
+      }
+    },
+    {
+      "id": 4,
+      "title": "Unique events",
+      "description": "Total deduplicated unique events.",
+      "type": "stat",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "x": 15, "y": 1, "w": 4, "h": 4 },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "value",
+        "textMode": "auto",
+        "graphMode": "none"
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "pipeline_inventory_unique_events{service=\"api\"}",
+          "refId": "A",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "noValue": "0",
+          "color": { "mode": "fixed", "fixedColor": "semi-dark-green" }
+        }
+      }
+    },
+    {
+      "id": 5,
+      "title": "Failed (terminal)",
+      "description": "Sources in failed_in_download or failed_in_extraction.",
+      "type": "stat",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "x": 19, "y": 1, "w": 5, "h": 4 },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "value",
+        "textMode": "auto",
+        "graphMode": "none"
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum(pipeline_inventory_sources{service=\"api\",status=~\"failed_in_.*\"})",
+          "refId": "A",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 10 },
+              { "color": "red", "value": 50 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": 6,
+      "title": "Sources by status",
+      "description": "Live count of sources at each pipeline step.",
+      "type": "table",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "x": 0, "y": 5, "w": 12, "h": 10 },
+      "options": {
+        "showHeader": true,
+        "sortBy": [{ "displayName": "Count", "desc": true }]
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "pipeline_inventory_sources{service=\"api\"}",
+          "format": "table",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true,
+              "instance": true,
+              "job": true,
+              "service": true
+            },
+            "renameByName": {
+              "status": "Status",
+              "Value": "Count"
+            }
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [{ "field": "Count", "desc": true }]
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": { "align": "auto", "cellOptions": { "type": "auto" } }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "Count" },
+            "properties": [
+              { "id": "custom.cellOptions", "value": { "type": "color-background", "mode": "gradient" } },
+              { "id": "color", "value": { "mode": "continuous-BlYlRd" } }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": 7,
+      "title": "Pipeline funnel",
+      "description": "Horizontal view of item counts at each step (left = early, right = terminal).",
+      "type": "bargauge",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "x": 12, "y": 5, "w": 12, "h": 10 },
+      "options": {
+        "displayMode": "gradient",
+        "orientation": "horizontal",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "showUnfilled": true,
+        "valueMode": "color"
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "pipeline_inventory_sources{service=\"api\",status=\"ready_for_classification\"}",
+          "refId": "A",
+          "legendFormat": "ready_for_classification",
+          "instant": true
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "pipeline_inventory_sources{service=\"api\",status=\"classifying\"}",
+          "refId": "B",
+          "legendFormat": "classifying",
+          "instant": true
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "pipeline_inventory_sources{service=\"api\",status=\"ready_for_download\"}",
+          "refId": "C",
+          "legendFormat": "ready_for_download",
+          "instant": true
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "pipeline_inventory_sources{service=\"api\",status=\"downloading\"}",
+          "refId": "D",
+          "legendFormat": "downloading",
+          "instant": true
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "pipeline_inventory_sources{service=\"api\",status=\"ready_for_extraction\"}",
+          "refId": "E",
+          "legendFormat": "ready_for_extraction",
+          "instant": true
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "pipeline_inventory_sources{service=\"api\",status=\"extracting\"}",
+          "refId": "F",
+          "legendFormat": "extracting",
+          "instant": true
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "pipeline_inventory_sources{service=\"api\",status=\"extracted\"}",
+          "refId": "G",
+          "legendFormat": "extracted",
+          "instant": true
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "pipeline_inventory_sources{service=\"api\",status=\"discarded\"}",
+          "refId": "H",
+          "legendFormat": "discarded",
+          "instant": true
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "pipeline_inventory_sources{service=\"api\",status=\"failed_in_download\"}",
+          "refId": "I",
+          "legendFormat": "failed_in_download",
+          "instant": true
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "pipeline_inventory_sources{service=\"api\",status=\"failed_in_extraction\"}",
+          "refId": "J",
+          "legendFormat": "failed_in_extraction",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "noValue": "0",
+          "min": 0,
+          "color": { "mode": "continuous-BlPu" }
+        }
+      }
+    },
+    {
+      "id": 200,
+      "type": "row",
+      "title": "Where is it stuck?",
+      "gridPos": { "x": 0, "y": 15, "w": 24, "h": 1 },
+      "collapsed": false
+    },
+    {
+      "id": 11,
+      "title": "Stuck classifying",
+      "description": "In classifying > 15 min without progress.",
+      "type": "stat",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "x": 0, "y": 16, "w": 8, "h": 4 },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "value",
+        "textMode": "auto",
+        "graphMode": "none"
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "pipeline_stuck_sources{service=\"api\",status=\"classifying\"}",
+          "refId": "A",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1 },
+              { "color": "red", "value": 5 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": 12,
+      "title": "Stuck downloading",
+      "description": "In downloading > 15 min without progress.",
+      "type": "stat",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "x": 8, "y": 16, "w": 8, "h": 4 },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "value",
+        "textMode": "auto",
+        "graphMode": "none"
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "pipeline_stuck_sources{service=\"api\",status=\"downloading\"}",
+          "refId": "A",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1 },
+              { "color": "red", "value": 5 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": 13,
+      "title": "Stuck extracting",
+      "description": "In extracting > 15 min without progress.",
+      "type": "stat",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "x": 16, "y": 16, "w": 8, "h": 4 },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "value",
+        "textMode": "auto",
+        "graphMode": "none"
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "pipeline_stuck_sources{service=\"api\",status=\"extracting\"}",
+          "refId": "A",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1 },
+              { "color": "red", "value": 5 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": 14,
+      "title": "Backlog: classification",
+      "description": "Sources waiting to be classified.",
+      "type": "stat",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "x": 0, "y": 20, "w": 8, "h": 4 },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "value",
+        "textMode": "auto",
+        "graphMode": "none"
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "pipeline_inventory_sources{service=\"api\",status=\"ready_for_classification\"}",
+          "refId": "A",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 100 },
+              { "color": "red", "value": 500 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": 15,
+      "title": "Backlog: download",
+      "description": "Sources waiting to be downloaded.",
+      "type": "stat",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "x": 8, "y": 20, "w": 8, "h": 4 },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "value",
+        "textMode": "auto",
+        "graphMode": "none"
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "pipeline_inventory_sources{service=\"api\",status=\"ready_for_download\"}",
+          "refId": "A",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 50 },
+              { "color": "red", "value": 200 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": 16,
+      "title": "Backlog: extraction",
+      "description": "Sources waiting to be extracted.",
+      "type": "stat",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "x": 16, "y": 20, "w": 8, "h": 4 },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "value",
+        "textMode": "auto",
+        "graphMode": "none"
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "pipeline_inventory_sources{service=\"api\",status=\"ready_for_extraction\"}",
+          "refId": "A",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 50 },
+              { "color": "red", "value": 200 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": 17,
+      "title": "Worker alive",
+      "type": "stat",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "x": 0, "y": 24, "w": 4, "h": 4 },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "value",
+        "textMode": "auto",
+        "graphMode": "none"
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "pipeline_worker_alive{service=\"api\"}",
+          "refId": "A",
+          "instant": true
+        }
+      ],
       "fieldConfig": {
         "defaults": {
           "mappings": [
@@ -66,16 +590,25 @@
       }
     },
     {
-      "id": 4,
-      "title": "Redis Connected",
+      "id": 18,
+      "title": "Redis",
       "type": "stat",
-      "gridPos": { "x": 4, "y": 1, "w": 4, "h": 4 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "x": 4, "y": 24, "w": 4, "h": 4 },
       "options": {
         "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
         "colorMode": "value",
-        "textMode": "auto"
+        "textMode": "auto",
+        "graphMode": "none"
       },
-      "targets": [{ "expr": "pipeline_redis_connected{service=\"api\"}", "refId": "A" }],
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "pipeline_redis_connected{service=\"api\"}",
+          "refId": "A",
+          "instant": true
+        }
+      ],
       "fieldConfig": {
         "defaults": {
           "mappings": [
@@ -91,16 +624,25 @@
       }
     },
     {
-      "id": 3,
-      "title": "Queue Depth",
+      "id": 19,
+      "title": "Queue depth",
       "type": "stat",
-      "gridPos": { "x": 8, "y": 1, "w": 4, "h": 4 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "x": 8, "y": 24, "w": 4, "h": 4 },
       "options": {
         "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
         "colorMode": "value",
-        "textMode": "auto"
+        "textMode": "auto",
+        "graphMode": "none"
       },
-      "targets": [{ "expr": "pipeline_queue_depth{service=\"api\"}", "refId": "A" }],
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "pipeline_queue_depth{service=\"api\"}",
+          "refId": "A",
+          "instant": true
+        }
+      ],
       "fieldConfig": {
         "defaults": {
           "noValue": "0",
@@ -116,41 +658,25 @@
       }
     },
     {
-      "id": 5,
-      "title": "Scrape Targets",
+      "id": 20,
+      "title": "Heartbeat misses",
       "type": "stat",
-      "gridPos": { "x": 12, "y": 1, "w": 4, "h": 4 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "x": 12, "y": 24, "w": 4, "h": 4 },
       "options": {
         "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
         "colorMode": "value",
-        "textMode": "auto"
+        "textMode": "auto",
+        "graphMode": "none"
       },
-      "targets": [{ "expr": "min(up{job=~\"arquivo-prod.*\"})", "refId": "A" }],
-      "fieldConfig": {
-        "defaults": {
-          "mappings": [
-            {
-              "type": "value",
-              "options": {
-                "0": { "text": "DOWN", "color": "red" },
-                "1": { "text": "UP", "color": "green" }
-              }
-            }
-          ]
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "pipeline_worker_heartbeat_misses{service=\"api\"}",
+          "refId": "A",
+          "instant": true
         }
-      }
-    },
-    {
-      "id": 6,
-      "title": "Heartbeat Misses",
-      "type": "stat",
-      "gridPos": { "x": 16, "y": 1, "w": 4, "h": 4 },
-      "options": {
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
-        "colorMode": "value",
-        "textMode": "auto"
-      },
-      "targets": [{ "expr": "pipeline_worker_heartbeat_misses{service=\"api\"}", "refId": "A" }],
+      ],
       "fieldConfig": {
         "defaults": {
           "noValue": "0",
@@ -166,17 +692,26 @@
       }
     },
     {
-      "id": 2,
-      "title": "Cron Scheduling",
-      "description": "Whether the worker has cron jobs enabled (config flag, not proof of execution).",
+      "id": 21,
+      "title": "Cron enabled",
+      "description": "Whether the worker has cron jobs enabled (config flag).",
       "type": "stat",
-      "gridPos": { "x": 20, "y": 1, "w": 4, "h": 4 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "x": 16, "y": 24, "w": 4, "h": 4 },
       "options": {
         "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
         "colorMode": "value",
-        "textMode": "auto"
+        "textMode": "auto",
+        "graphMode": "none"
       },
-      "targets": [{ "expr": "pipeline_cron_enabled{service=\"api\"}", "refId": "A" }],
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "pipeline_cron_enabled{service=\"api\"}",
+          "refId": "A",
+          "instant": true
+        }
+      ],
       "fieldConfig": {
         "defaults": {
           "mappings": [
@@ -192,191 +727,24 @@
       }
     },
     {
-      "id": 101,
-      "type": "row",
-      "title": "Pipeline Steps",
-      "gridPos": { "x": 0, "y": 5, "w": 24, "h": 1 },
-      "collapsed": false
-    },
-    {
-      "id": 11,
-      "title": "Step Success Rate",
-      "description": "Share of successful task runs per pipeline step in the selected range. Grey when no runs occurred.",
-      "type": "stat",
-      "gridPos": { "x": 0, "y": 6, "w": 24, "h": 5 },
-      "options": {
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
-        "colorMode": "value",
-        "textMode": "value_and_name",
-        "orientation": "horizontal"
-      },
-      "targets": [
-        {
-          "expr": "sum(increase(pipeline_task_total{service=\"worker\",task=\"ingest_cities_hourly\",outcome=\"success\"}[$__range])) / clamp_min(sum(increase(pipeline_task_total{service=\"worker\",task=\"ingest_cities_hourly\"}[$__range])), 1)",
-          "refId": "ingest",
-          "legendFormat": "ingest"
-        },
-        {
-          "expr": "sum(increase(pipeline_task_total{service=\"worker\",task=\"classify_batch\",outcome=\"success\"}[$__range])) / clamp_min(sum(increase(pipeline_task_total{service=\"worker\",task=\"classify_batch\"}[$__range])), 1)",
-          "refId": "classify",
-          "legendFormat": "classify"
-        },
-        {
-          "expr": "sum(increase(pipeline_task_total{service=\"worker\",task=\"download_batch\",outcome=\"success\"}[$__range])) / clamp_min(sum(increase(pipeline_task_total{service=\"worker\",task=\"download_batch\"}[$__range])), 1)",
-          "refId": "download",
-          "legendFormat": "download"
-        },
-        {
-          "expr": "sum(increase(pipeline_task_total{service=\"worker\",task=\"extract_batch\",outcome=\"success\"}[$__range])) / clamp_min(sum(increase(pipeline_task_total{service=\"worker\",task=\"extract_batch\"}[$__range])), 1)",
-          "refId": "extract",
-          "legendFormat": "extract"
-        },
-        {
-          "expr": "sum(increase(pipeline_task_total{service=\"worker\",task=\"batch_dedup\",outcome=\"success\"}[$__range])) / clamp_min(sum(increase(pipeline_task_total{service=\"worker\",task=\"batch_dedup\"}[$__range])), 1)",
-          "refId": "dedup",
-          "legendFormat": "dedup"
-        },
-        {
-          "expr": "sum(increase(pipeline_task_total{service=\"worker\",task=\"batch_enrich\",outcome=\"success\"}[$__range])) / clamp_min(sum(increase(pipeline_task_total{service=\"worker\",task=\"batch_enrich\"}[$__range])), 1)",
-          "refId": "enrich",
-          "legendFormat": "enrich"
-        },
-        {
-          "expr": "sum(increase(pipeline_task_total{service=\"worker\",task=\"batch_geocode\",outcome=\"success\"}[$__range])) / clamp_min(sum(increase(pipeline_task_total{service=\"worker\",task=\"batch_geocode\"}[$__range])), 1)",
-          "refId": "geocode",
-          "legendFormat": "geocode"
-        }
-      ],
-      "fieldConfig": {
-        "defaults": {
-          "unit": "percentunit",
-          "noValue": "no activity",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              { "color": "text", "value": null },
-              { "color": "red", "value": 0.01 },
-              { "color": "yellow", "value": 0.8 },
-              { "color": "green", "value": 0.95 }
-            ]
-          }
-        }
-      }
-    },
-    {
-      "id": 12,
-      "title": "Step Throughput",
-      "description": "Successful task runs per second by pipeline step.",
-      "type": "timeseries",
-      "gridPos": { "x": 0, "y": 11, "w": 12, "h": 8 },
-      "targets": [
-        {
-          "expr": "sum(rate(pipeline_task_total{service=\"worker\",outcome=\"success\",task=~\"ingest_cities_hourly|classify_batch|download_batch|extract_batch|batch_dedup|batch_enrich|batch_geocode\"}[15m])) by (task)",
-          "refId": "A",
-          "legendFormat": "{{task}}"
-        }
-      ],
-      "fieldConfig": {
-        "defaults": { "unit": "ops", "noValue": "0" }
-      }
-    },
-    {
-      "id": 13,
-      "title": "Task Failures (selected range)",
-      "type": "bargauge",
-      "gridPos": { "x": 12, "y": 11, "w": 12, "h": 8 },
-      "options": {
-        "displayMode": "gradient",
-        "orientation": "horizontal",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
-        "showUnfilled": true
-      },
-      "targets": [
-        {
-          "expr": "sum(increase(pipeline_task_total{service=\"worker\",outcome=\"failure\"}[$__range])) by (task)",
-          "refId": "A",
-          "legendFormat": "{{task}}"
-        }
-      ],
-      "fieldConfig": {
-        "defaults": {
-          "noValue": "none",
-          "min": 0,
-          "color": { "mode": "continuous-GrYlRd" }
-        }
-      }
-    },
-    {
-      "id": 30,
-      "title": "Attempt Success Rate",
-      "description": "Download/extraction attempt success by stage. Filter with the stage variable.",
-      "type": "stat",
-      "gridPos": { "x": 0, "y": 19, "w": 12, "h": 6 },
-      "options": {
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
-        "colorMode": "value",
-        "textMode": "value_and_name"
-      },
-      "targets": [
-        {
-          "expr": "sum(increase(pipeline_attempts_total{service=\"worker\",outcome=\"success\",stage=~\"$stage\"}[$__range])) by (stage) / clamp_min(sum(increase(pipeline_attempts_total{service=\"worker\",stage=~\"$stage\"}[$__range])) by (stage), 1)",
-          "refId": "A",
-          "legendFormat": "{{stage}}"
-        }
-      ],
-      "fieldConfig": {
-        "defaults": {
-          "unit": "percentunit",
-          "noValue": "no activity",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              { "color": "text", "value": null },
-              { "color": "red", "value": 0.01 },
-              { "color": "yellow", "value": 0.8 },
-              { "color": "green", "value": 0.95 }
-            ]
-          }
-        }
-      }
-    },
-    {
-      "id": 40,
-      "title": "Failures by Reason",
-      "type": "piechart",
-      "gridPos": { "x": 12, "y": 19, "w": 12, "h": 6 },
-      "targets": [
-        {
-          "expr": "sum(increase(pipeline_attempts_total{service=\"worker\",outcome=\"failure\",stage=~\"$stage\"}[$__range])) by (failure_reason)",
-          "refId": "A"
-        }
-      ],
-      "fieldConfig": {
-        "defaults": { "noValue": "none" }
-      }
-    },
-    {
-      "id": 102,
-      "type": "row",
-      "title": "Crons",
-      "gridPos": { "x": 0, "y": 25, "w": 24, "h": 1 },
-      "collapsed": false
-    },
-    {
-      "id": 21,
-      "title": "Last Hourly Ingest",
+      "id": 22,
+      "title": "Last hourly ingest",
       "description": "Minutes since ingest_cities_hourly last succeeded (:05 UTC).",
       "type": "stat",
-      "gridPos": { "x": 0, "y": 26, "w": 6, "h": 4 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "x": 20, "y": 24, "w": 4, "h": 4 },
       "options": {
         "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
         "colorMode": "value",
-        "textMode": "auto"
+        "textMode": "auto",
+        "graphMode": "none"
       },
       "targets": [
         {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
           "expr": "(time() - pipeline_cron_last_success_timestamp{service=\"worker\",cron=\"ingest_cities_hourly\"}) / 60",
-          "refId": "A"
+          "refId": "A",
+          "instant": true
         }
       ],
       "fieldConfig": {
@@ -396,20 +764,24 @@
       }
     },
     {
-      "id": 22,
-      "title": "Last Backlog Run",
-      "description": "Minutes since process_cities_backlog last succeeded (:35 UTC, may run up to 2h).",
+      "id": 23,
+      "title": "Last backlog run",
+      "description": "Minutes since process_cities_backlog last succeeded (:35 UTC).",
       "type": "stat",
-      "gridPos": { "x": 6, "y": 26, "w": 6, "h": 4 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "x": 0, "y": 28, "w": 6, "h": 4 },
       "options": {
         "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
         "colorMode": "value",
-        "textMode": "auto"
+        "textMode": "auto",
+        "graphMode": "none"
       },
       "targets": [
         {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
           "expr": "(time() - pipeline_cron_last_success_timestamp{service=\"worker\",cron=\"process_cities_backlog\"}) / 60",
-          "refId": "A"
+          "refId": "A",
+          "instant": true
         }
       ],
       "fieldConfig": {
@@ -429,10 +801,11 @@
       }
     },
     {
-      "id": 23,
-      "title": "Cron Runs (selected range)",
+      "id": 24,
+      "title": "Cron runs (24h)",
       "type": "bargauge",
-      "gridPos": { "x": 12, "y": 26, "w": 12, "h": 4 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "x": 6, "y": 28, "w": 18, "h": 4 },
       "options": {
         "displayMode": "gradient",
         "orientation": "horizontal",
@@ -441,34 +814,198 @@
       },
       "targets": [
         {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
           "expr": "sum(increase(pipeline_cron_runs_total{service=\"worker\"}[$__range])) by (cron, outcome)",
           "refId": "A",
           "legendFormat": "{{cron}} / {{outcome}}"
         }
       ],
       "fieldConfig": {
-        "defaults": { "noValue": "0", "min": 0 }
+        "defaults": {
+          "noValue": "0",
+          "min": 0
+        }
       }
     },
     {
-      "id": 103,
+      "id": 300,
       "type": "row",
-      "title": "Bugs",
-      "gridPos": { "x": 0, "y": 30, "w": 24, "h": 1 },
+      "title": "Failures (last 24h)",
+      "gridPos": { "x": 0, "y": 32, "w": 24, "h": 1 },
       "collapsed": false
     },
     {
       "id": 31,
-      "title": "Open Pipeline Bugs",
+      "title": "Attempt failures by stage and reason",
+      "description": "Failed download/extraction attempts in the last 24 hours.",
+      "type": "table",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "x": 0, "y": 33, "w": 14, "h": 10 },
+      "options": {
+        "showHeader": true,
+        "sortBy": [{ "displayName": "Count", "desc": true }]
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "pipeline_attempt_failures_24h{service=\"api\"}",
+          "format": "table",
+          "instant": true,
+          "refId": "count"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "pipeline_attempt_failures_24h{service=\"api\"} / clamp_min(sum(pipeline_attempt_failures_24h{service=\"api\"}), 1) * 100",
+          "format": "table",
+          "instant": true,
+          "refId": "pct"
+        }
+      ],
+      "transformations": [
+        { "id": "merge", "options": {} },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Time 1": true,
+              "Time 2": true,
+              "__name__": true,
+              "__name__ 1": true,
+              "__name__ 2": true,
+              "environment": true,
+              "instance": true,
+              "instance 1": true,
+              "instance 2": true,
+              "job": true,
+              "job 1": true,
+              "job 2": true,
+              "service": true,
+              "service 1": true,
+              "service 2": true
+            },
+            "renameByName": {
+              "stage": "Stage",
+              "failure_reason": "Reason",
+              "Value #count": "Count",
+              "Value #pct": "Share %"
+            }
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [{ "field": "Count", "desc": true }]
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": { "align": "auto", "cellOptions": { "type": "auto" } }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "Share %" },
+            "properties": [
+              { "id": "unit", "value": "percent" },
+              { "id": "decimals", "value": 1 }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "Count" },
+            "properties": [
+              { "id": "custom.cellOptions", "value": { "type": "color-background", "mode": "gradient" } },
+              { "id": "color", "value": { "mode": "continuous-GrYlRd" } }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": 32,
+      "title": "Failures by reason",
+      "type": "piechart",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "x": 14, "y": 33, "w": 10, "h": 10 },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "right", "values": ["value", "percent"] },
+        "pieType": "donut",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum(pipeline_attempt_failures_24h{service=\"api\"}) by (failure_reason)",
+          "refId": "A",
+          "legendFormat": "{{failure_reason}}",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "noValue": "none"
+        }
+      }
+    },
+    {
+      "id": 33,
+      "title": "Terminal failed statuses",
+      "description": "Sources stuck in failed_in_download or failed_in_extraction.",
+      "type": "bargauge",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "x": 0, "y": 43, "w": 12, "h": 6 },
+      "options": {
+        "displayMode": "gradient",
+        "orientation": "horizontal",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "showUnfilled": true
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "pipeline_inventory_sources{service=\"api\",status=\"failed_in_download\"}",
+          "refId": "A",
+          "legendFormat": "failed_in_download",
+          "instant": true
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "pipeline_inventory_sources{service=\"api\",status=\"failed_in_extraction\"}",
+          "refId": "B",
+          "legendFormat": "failed_in_extraction",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "noValue": "0",
+          "min": 0,
+          "color": { "mode": "continuous-GrYlRd" }
+        }
+      }
+    },
+    {
+      "id": 34,
+      "title": "Open pipeline bugs",
       "description": "Open GitHub issues with label pipeline-failure (polled every 5 min).",
       "type": "stat",
-      "gridPos": { "x": 0, "y": 31, "w": 6, "h": 4 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "x": 12, "y": 43, "w": 6, "h": 6 },
       "options": {
         "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
         "colorMode": "value",
-        "textMode": "auto"
+        "textMode": "auto",
+        "graphMode": "none"
       },
-      "targets": [{ "expr": "pipeline_open_failure_issues{service=\"api\"}", "refId": "A" }],
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "pipeline_open_failure_issues{service=\"api\"}",
+          "refId": "A",
+          "instant": true
+        }
+      ],
       "fieldConfig": {
         "defaults": {
           "noValue": "unknown",
@@ -484,141 +1021,41 @@
       }
     },
     {
-      "id": 32,
-      "title": "New Bugs (selected range)",
-      "type": "stat",
-      "gridPos": { "x": 6, "y": 31, "w": 6, "h": 4 },
+      "id": 35,
+      "title": "Failed / violent death",
+      "description": "Share of violent-death sources that ended in a terminal failed status.",
+      "type": "gauge",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "x": 18, "y": 43, "w": 6, "h": 6 },
       "options": {
         "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
-        "colorMode": "value",
-        "textMode": "auto"
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
       },
       "targets": [
         {
-          "expr": "sum(increase(pipeline_failure_issues_created_total{service=\"worker\"}[$__range]))",
-          "refId": "A"
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum(pipeline_inventory_sources{service=\"api\",status=~\"failed_in_.*\"}) / clamp_min(pipeline_inventory_violent_death{service=\"api\"}, 1)",
+          "refId": "A",
+          "instant": true
         }
       ],
       "fieldConfig": {
         "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
           "noValue": "0",
           "thresholds": {
             "mode": "absolute",
             "steps": [
               { "color": "green", "value": null },
-              { "color": "yellow", "value": 1 },
-              { "color": "red", "value": 3 }
+              { "color": "yellow", "value": 0.05 },
+              { "color": "orange", "value": 0.15 },
+              { "color": "red", "value": 0.3 }
             ]
           }
         }
-      }
-    },
-    {
-      "id": 33,
-      "title": "Bug Recurrences (selected range)",
-      "description": "Comments added to existing pipeline-failure issues.",
-      "type": "stat",
-      "gridPos": { "x": 12, "y": 31, "w": 6, "h": 4 },
-      "options": {
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
-        "colorMode": "value",
-        "textMode": "auto"
-      },
-      "targets": [
-        {
-          "expr": "sum(increase(pipeline_failure_issue_recurrences_total{service=\"worker\"}[$__range]))",
-          "refId": "A"
-        }
-      ],
-      "fieldConfig": {
-        "defaults": { "noValue": "0" }
-      }
-    },
-    {
-      "id": 34,
-      "title": "New Bugs by Task",
-      "type": "bargauge",
-      "gridPos": { "x": 18, "y": 31, "w": 6, "h": 4 },
-      "options": {
-        "displayMode": "gradient",
-        "orientation": "horizontal",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
-        "showUnfilled": true
-      },
-      "targets": [
-        {
-          "expr": "sum(increase(pipeline_failure_issues_created_total{service=\"worker\"}[$__range])) by (task)",
-          "refId": "A",
-          "legendFormat": "{{task}}"
-        }
-      ],
-      "fieldConfig": {
-        "defaults": { "noValue": "none", "min": 0 }
-      }
-    },
-    {
-      "id": 104,
-      "type": "row",
-      "title": "Performance Details",
-      "gridPos": { "x": 0, "y": 35, "w": 24, "h": 1 },
-      "collapsed": true
-    },
-    {
-      "id": 20,
-      "title": "Task Duration p50 / p95 by task",
-      "type": "timeseries",
-      "gridPos": { "x": 0, "y": 36, "w": 12, "h": 8 },
-      "targets": [
-        {
-          "expr": "histogram_quantile(0.5, sum(rate(pipeline_task_duration_seconds_bucket{service=\"worker\"}[10m])) by (task, le))",
-          "refId": "p50",
-          "legendFormat": "p50 {{task}}"
-        },
-        {
-          "expr": "histogram_quantile(0.95, sum(rate(pipeline_task_duration_seconds_bucket{service=\"worker\"}[10m])) by (task, le))",
-          "refId": "p95",
-          "legendFormat": "p95 {{task}}"
-        }
-      ],
-      "fieldConfig": {
-        "defaults": { "unit": "s", "noValue": "0" }
-      }
-    },
-    {
-      "id": 50,
-      "title": "Attempt Duration p95 by Stage",
-      "type": "timeseries",
-      "gridPos": { "x": 12, "y": 36, "w": 12, "h": 8 },
-      "targets": [
-        {
-          "expr": "histogram_quantile(0.95, sum(rate(pipeline_attempt_duration_seconds_bucket{service=\"worker\",stage=~\"$stage\"}[10m])) by (stage, le))",
-          "refId": "A",
-          "legendFormat": "p95 {{stage}}"
-        }
-      ],
-      "fieldConfig": {
-        "defaults": { "unit": "s", "noValue": "0" }
-      }
-    },
-    {
-      "id": 60,
-      "title": "Downloaded Content Size",
-      "type": "timeseries",
-      "gridPos": { "x": 0, "y": 44, "w": 24, "h": 8 },
-      "targets": [
-        {
-          "expr": "histogram_quantile(0.5, sum(rate(pipeline_attempt_content_length_bytes_bucket{service=\"worker\",stage=\"download\"}[15m])) by (le))",
-          "refId": "p50",
-          "legendFormat": "p50 bytes"
-        },
-        {
-          "expr": "histogram_quantile(0.95, sum(rate(pipeline_attempt_content_length_bytes_bucket{service=\"worker\",stage=\"download\"}[15m])) by (le))",
-          "refId": "p95",
-          "legendFormat": "p95 bytes"
-        }
-      ],
-      "fieldConfig": {
-        "defaults": { "unit": "bytes", "noValue": "0" }
       }
     }
   ]


### PR DESCRIPTION
## Summary
- Poll Postgres for per-step source counts, stuck items, and 24h failure breakdown
- Redesign Grafana dashboard around pipeline map, stuck detection, and failure rates

## Staging verification
- [x] Deploy Backend (develop) green — run 28945636970
- [x] Staging `/api/health` OK

## Production test plan
- [ ] Deploy Backend + Observability (master) green
- [ ] `/metrics` exposes `pipeline_inventory_*` gauges
- [ ] Grafana shows pipeline map at https://observability.carabetta.xyz/d/arquivo-pipeline

Made with [Cursor](https://cursor.com)