### PR TITLE
ci: disable one-shot prod enqueue job after backfill ship

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -201,7 +201,7 @@ jobs:
     name: Enqueue Pipeline Jobs (prod)
     needs: sync-staging-db
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master'
+    if: false  # one-shot enqueue after 2026-07-08 backfill; use enqueue_backfill_pipeline.py manually
 
     steps:
       - name: Enqueue requeued sources


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Disables the `enqueue-pipeline-prod` GitHub Actions job now that the one-shot prod backfill enqueue completed successfully on 2026-07-08.

Future backfills should use `scripts/run_prod_backfill.sh` or the manual `Prod Backfill Cleanup` workflow instead of running on every deploy.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8445a593-801a-40ac-a1c8-77d47ec57d29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8445a593-801a-40ac-a1c8-77d47ec57d29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

