### PR TITLE
ci: one-shot staging backfill cleanup

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -137,6 +137,33 @@ jobs:
             docker compose -p staging exec -T api \
               python scripts/enqueue_backfill_pipeline.py
 
+  backfill-staging:
+    name: Backfill Staging Data
+    needs: deploy-staging
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/develop'
+
+    steps:
+      - name: Run staging backfill + enqueue
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.VPS_HOST }}
+          username: ${{ secrets.VPS_USER }}
+          key: ${{ secrets.VPS_SSH_KEY }}
+          script_stop: true
+          script: |
+            set -euo pipefail
+            cd /root/arquivo-da-violencia
+            echo "==> staging backfill dry-run"
+            docker compose -p staging exec -T api \
+              python scripts/backfill_prod_cleanup.py --dry-run --since 2026-01-01
+            echo "==> staging backfill execute"
+            docker compose -p staging exec -T api \
+              python scripts/backfill_prod_cleanup.py --execute --since 2026-01-01
+            echo "==> enqueue pipeline jobs"
+            docker compose -p staging exec -T api \
+              python scripts/enqueue_backfill_pipeline.py
+
   deploy-production:
     name: Deploy to Production
     needs: build


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Runs the staging near-dup merge + reclassify backfill that failed during earlier deploy attempts (before asyncio/Postgres fixes landed).

After this one-shot job completes, a follow-up commit will disable `backfill-staging` so it does not run on every develop deploy.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8445a593-801a-40ac-a1c8-77d47ec57d29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8445a593-801a-40ac-a1c8-77d47ec57d29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

