### PR TITLE
ci: disable one-shot staging backfill job

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -141,7 +141,7 @@ jobs:
     name: Backfill Staging Data
     needs: deploy-staging
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/develop'
+    if: false  # one-shot staging backfill completed 2026-07-08; use scripts/run_prod_backfill.sh
 
     steps:
       - name: Run staging backfill + enqueue


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Disables the `backfill-staging` job after the one-shot run completed successfully (0 near-dup merges — staging DB already synced from prod; 2 sources reclassified and pipeline enqueued).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8445a593-801a-40ac-a1c8-77d47ec57d29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8445a593-801a-40ac-a1c8-77d47ec57d29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

