### PR TITLE
Release: separate content-filter discards from pipeline failures

### DIFF
--- a/backend/app/metrics.py
+++ b/backend/app/metrics.py
@@ -137,6 +137,13 @@ pipeline_attempt_failures_24h = Gauge(
     registry=REGISTRY,
 )
 
+pipeline_attempt_discards_24h = Gauge(
+    "pipeline_attempt_discards_24h",
+    "Content-filter discards in the last 24 hours, by stage and reason.",
+    labelnames=["stage", "failure_reason"],
+    registry=REGISTRY,
+)
+
 pipeline_cron_last_success_timestamp = Gauge(
     "pipeline_cron_last_success_timestamp",
     "Unix timestamp of the last successful cron run, by cron name.",
@@ -169,6 +176,7 @@ CRON_TASKS = frozenset({"ingest_cities_hourly", "process_cities_backlog"})
 
 _STUCK_STATUSES = ("classifying", "downloading", "extracting")
 _seen_failure_labels: set[tuple[str, str]] = set()
+_seen_discard_labels: set[tuple[str, str]] = set()
 _seen_inventory_statuses: set[str] = set()
 
 
@@ -177,6 +185,7 @@ def set_pipeline_inventory_metrics(
     status_counts: dict[str, int],
     stuck_counts: dict[str, int],
     failure_counts: dict[tuple[str, str], int],
+    discard_counts: dict[tuple[str, str], int],
     sources_total: int,
     violent_death: int,
     raw_events_total: int,
@@ -212,6 +221,19 @@ def set_pipeline_inventory_metrics(
             ).set(0)
         _seen_failure_labels.clear()
         _seen_failure_labels.update(current_failures)
+
+        current_discards: set[tuple[str, str]] = set()
+        for (stage, reason), count in discard_counts.items():
+            pipeline_attempt_discards_24h.labels(
+                stage=stage, failure_reason=reason
+            ).set(count)
+            current_discards.add((stage, reason))
+        for stage, reason in _seen_discard_labels - current_discards:
+            pipeline_attempt_discards_24h.labels(
+                stage=stage, failure_reason=reason
+            ).set(0)
+        _seen_discard_labels.clear()
+        _seen_discard_labels.update(current_discards)
     except Exception as e:  # pragma: no cover
         logger.warning(f"[metrics] set_pipeline_inventory_metrics failed: {e}")
 

--- a/backend/app/models/pipeline_attempt.py
+++ b/backend/app/models/pipeline_attempt.py
@@ -22,8 +22,8 @@ class PipelineAttemptBase(SQLModel):
     )
     raw_event_id: int | None = Field(default=None, index=True)
 
-    stage: str = Field(max_length=20, index=True)  # download | extraction
-    outcome: str = Field(max_length=20, index=True)  # success | failure
+    stage: str = Field(max_length=20, index=True)  # download | content_gate | extraction
+    outcome: str = Field(max_length=20, index=True)  # success | failure | discarded
 
     # Failure classification (null on success)
     failure_reason: str | None = Field(default=None, max_length=40, index=True)

--- a/backend/app/services/diagnostics.py
+++ b/backend/app/services/diagnostics.py
@@ -26,6 +26,7 @@ STAGE_EXTRACTION = "extraction"
 # === Outcomes ===
 OUTCOME_SUCCESS = "success"
 OUTCOME_FAILURE = "failure"
+OUTCOME_DISCARDED = "discarded"  # intentional content-filter reject (not a bug)
 
 # === Download failure reasons ===
 FETCH_TIMEOUT = "fetch_timeout"
@@ -41,6 +42,15 @@ AGGREGATE_CONTENT = "aggregate_content"
 FOREIGN_CONTENT = "foreign_content"
 NON_INCIDENT_CONTENT = "non_incident_content"
 LLM_CONTENT_REJECT = "llm_content_reject"
+
+CONTENT_FILTER_REASONS = frozenset(
+    {
+        AGGREGATE_CONTENT,
+        FOREIGN_CONTENT,
+        NON_INCIDENT_CONTENT,
+        LLM_CONTENT_REJECT,
+    }
+)
 
 # === Extraction failure reasons ===
 LLM_RATE_LIMIT = "llm_rate_limit"  # 429 / RESOURCE_EXHAUSTED (short-term)
@@ -70,6 +80,11 @@ TRANSIENT_REASONS = frozenset(
 def is_transient(reason: str | None) -> bool:
     """Whether a failure reason is worth retrying."""
     return reason in TRANSIENT_REASONS
+
+
+def is_content_filter_reason(reason: str | None) -> bool:
+    """Whether a reason is an expected content-filter discard, not a pipeline bug."""
+    return reason in CONTENT_FILTER_REASONS
 
 
 def domain_of(url: str | None) -> str | None:

--- a/backend/app/services/download.py
+++ b/backend/app/services/download.py
@@ -130,7 +130,7 @@ async def _discard_after_content_gate(
 
     await diagnostics.record_attempt(
         stage=diagnostics.STAGE_CONTENT_GATE,
-        outcome=diagnostics.OUTCOME_FAILURE,
+        outcome=diagnostics.OUTCOME_DISCARDED,
         source_google_news_id=source_id,
         failure_reason=failure_reason,
         failure_detail=failure_detail,

--- a/backend/app/services/extraction.py
+++ b/backend/app/services/extraction.py
@@ -431,7 +431,7 @@ async def extract_source(source_id: int) -> RawEvent | None:
                 await session.commit()
             await diagnostics.record_attempt(
                 stage=diagnostics.STAGE_EXTRACTION,
-                outcome=diagnostics.OUTCOME_FAILURE,
+                outcome=diagnostics.OUTCOME_DISCARDED,
                 source_google_news_id=source_id,
                 failure_reason=reason,
                 failure_detail=str(e),
@@ -466,7 +466,7 @@ async def extract_source(source_id: int) -> RawEvent | None:
             await session.commit()
         await diagnostics.record_attempt(
             stage=diagnostics.STAGE_EXTRACTION,
-            outcome=diagnostics.OUTCOME_FAILURE,
+            outcome=diagnostics.OUTCOME_DISCARDED,
             source_google_news_id=source_id,
             failure_reason=failure_reason,
             failure_detail=reasoning,

--- a/backend/app/services/pipeline_inventory_metrics.py
+++ b/backend/app/services/pipeline_inventory_metrics.py
@@ -70,6 +70,26 @@ async def refresh_pipeline_inventory_metrics() -> None:
                 for stage, reason, count in failure_rows
             }
 
+            discard_rows = (
+                await session.execute(
+                    select(
+                        PipelineAttempt.stage,
+                        PipelineAttempt.failure_reason,
+                        func.count(PipelineAttempt.id),
+                    )
+                    .where(
+                        PipelineAttempt.outcome == "discarded",
+                        PipelineAttempt.created_at >= failure_cutoff,
+                        PipelineAttempt.failure_reason.is_not(None),
+                    )
+                    .group_by(PipelineAttempt.stage, PipelineAttempt.failure_reason)
+                )
+            ).all()
+            discard_counts = {
+                (str(stage), str(reason)): int(count)
+                for stage, reason, count in discard_rows
+            }
+
             sources_total = await session.scalar(select(func.count(SourceGoogleNews.id)))
             violent_death = await session.scalar(
                 select(func.count(SourceGoogleNews.id)).where(
@@ -83,6 +103,7 @@ async def refresh_pipeline_inventory_metrics() -> None:
             status_counts=status_counts,
             stuck_counts={status: stuck_counts.get(status, 0) for status in STUCK_STATUSES},
             failure_counts=failure_counts,
+            discard_counts=discard_counts,
             sources_total=int(sources_total or 0),
             violent_death=int(violent_death or 0),
             raw_events_total=int(raw_events_total or 0),

--- a/backend/tests/test_discard_metrics.py
+++ b/backend/tests/test_discard_metrics.py
@@ -1,0 +1,65 @@
+"""Tests for content-filter discard taxonomy and metrics gauges."""
+
+from app.metrics import pipeline_attempt_discards_24h, pipeline_attempt_failures_24h, set_pipeline_inventory_metrics
+from app.services import diagnostics
+
+
+def test_content_filter_reasons_include_llm_reject():
+    assert diagnostics.LLM_CONTENT_REJECT in diagnostics.CONTENT_FILTER_REASONS
+    assert diagnostics.is_content_filter_reason(diagnostics.LLM_CONTENT_REJECT)
+    assert diagnostics.is_content_filter_reason(diagnostics.AGGREGATE_CONTENT)
+    assert not diagnostics.is_content_filter_reason(diagnostics.FETCH_BLOCKED)
+    assert not diagnostics.is_content_filter_reason(None)
+
+
+def test_set_pipeline_inventory_metrics_splits_failures_and_discards():
+    set_pipeline_inventory_metrics(
+        status_counts={},
+        stuck_counts={},
+        failure_counts={("download", "fetch_timeout"): 3},
+        discard_counts={
+            ("content_gate", "llm_content_reject"): 5,
+            ("content_gate", "aggregate_content"): 2,
+        },
+        sources_total=0,
+        violent_death=0,
+        raw_events_total=0,
+        unique_events_total=0,
+    )
+
+    assert (
+        pipeline_attempt_failures_24h.labels(
+            stage="download", failure_reason="fetch_timeout"
+        )._value.get()
+        == 3.0
+    )
+    assert (
+        pipeline_attempt_discards_24h.labels(
+            stage="content_gate", failure_reason="llm_content_reject"
+        )._value.get()
+        == 5.0
+    )
+    assert (
+        pipeline_attempt_discards_24h.labels(
+            stage="content_gate", failure_reason="aggregate_content"
+        )._value.get()
+        == 2.0
+    )
+
+    # Stale discard labels are zeroed when absent from the next refresh.
+    set_pipeline_inventory_metrics(
+        status_counts={},
+        stuck_counts={},
+        failure_counts={("download", "fetch_timeout"): 3},
+        discard_counts={("content_gate", "llm_content_reject"): 1},
+        sources_total=0,
+        violent_death=0,
+        raw_events_total=0,
+        unique_events_total=0,
+    )
+    assert (
+        pipeline_attempt_discards_24h.labels(
+            stage="content_gate", failure_reason="aggregate_content"
+        )._value.get()
+        == 0.0
+    )

--- a/backend/tests/test_download_content_gate.py
+++ b/backend/tests/test_download_content_gate.py
@@ -6,6 +6,7 @@ import pytest
 
 from app.services.classification import ViolentDeathClassification
 from app.services.download import DownloadOutcome, download_source_content
+from app.services import diagnostics
 
 
 class _TestSessionMaker:
@@ -81,7 +82,10 @@ async def test_download_discards_heuristic_aggregate(download_db):
         return_value=(aggregate_content, None),
     ), patch(
         "app.services.download.classify_article_content",
-    ) as mock_llm:
+    ) as mock_llm, patch(
+        "app.services.download.diagnostics.record_attempt",
+        new=AsyncMock(),
+    ) as mock_record:
         outcome = await download_source_content(source.id)
 
     assert outcome == DownloadOutcome.discarded
@@ -89,6 +93,8 @@ async def test_download_discards_heuristic_aggregate(download_db):
     await download_db.refresh(source)
     assert source.status == SourceStatus.discarded
     assert "content_gate=heuristic" in source.classification_reasoning
+    mock_record.assert_called_once()
+    assert mock_record.call_args.kwargs["outcome"] == diagnostics.OUTCOME_DISCARDED
 
 
 @pytest.mark.asyncio
@@ -155,10 +161,16 @@ async def test_download_discards_llm_rejection(download_db):
             content_class_hint="aggregate_statistics",
             reasoning="Article is a statistics roundup",
         ),
-    ):
+    ), patch(
+        "app.services.download.diagnostics.record_attempt",
+        new=AsyncMock(),
+    ) as mock_record:
         outcome = await download_source_content(source.id)
 
     assert outcome == DownloadOutcome.discarded
     await download_db.refresh(source)
     assert source.status == SourceStatus.discarded
     assert "content_gate=llm" in source.classification_reasoning
+    mock_record.assert_called_once()
+    assert mock_record.call_args.kwargs["outcome"] == diagnostics.OUTCOME_DISCARDED
+    assert mock_record.call_args.kwargs["failure_reason"] == diagnostics.LLM_CONTENT_REJECT

--- a/backend/tests/test_extraction_content_class.py
+++ b/backend/tests/test_extraction_content_class.py
@@ -139,6 +139,7 @@ async def test_extract_source_discards_non_incident_content_class(extraction_db)
     assert source.status == SourceStatus.discarded
     assert "content_class=foreign" in source.classification_reasoning
     mock_record.assert_called_once()
+    assert mock_record.call_args.kwargs["outcome"] == diagnostics.OUTCOME_DISCARDED
     assert mock_record.call_args.kwargs["failure_reason"] == diagnostics.FOREIGN_CONTENT
 
 

--- a/infra/observability/grafana/dashboards/pipeline-overview.json
+++ b/infra/observability/grafana/dashboards/pipeline-overview.json
@@ -830,14 +830,14 @@
     {
       "id": 300,
       "type": "row",
-      "title": "Failures (last 24h)",
+      "title": "Pipeline failures (last 24h)",
       "gridPos": { "x": 0, "y": 32, "w": 24, "h": 1 },
       "collapsed": false
     },
     {
       "id": 31,
-      "title": "Attempt failures by stage and reason",
-      "description": "Failed download/extraction attempts in the last 24 hours.",
+      "title": "Pipeline failures by stage and reason",
+      "description": "Download/extraction errors worth investigating (excludes content-filter discards).",
       "type": "table",
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "gridPos": { "x": 0, "y": 33, "w": 14, "h": 10 },
@@ -924,7 +924,7 @@
     },
     {
       "id": 32,
-      "title": "Failures by reason",
+      "title": "Pipeline failures by reason",
       "type": "piechart",
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "gridPos": { "x": 14, "y": 33, "w": 10, "h": 10 },
@@ -949,12 +949,134 @@
       }
     },
     {
+      "id": 301,
+      "type": "row",
+      "title": "Content filter discards (last 24h)",
+      "gridPos": { "x": 0, "y": 43, "w": 24, "h": 1 },
+      "collapsed": false
+    },
+    {
+      "id": 41,
+      "title": "Content filter discards by stage and reason",
+      "description": "Expected filtering — articles rejected by content gate or extraction classifier.",
+      "type": "table",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "x": 0, "y": 44, "w": 14, "h": 10 },
+      "options": {
+        "showHeader": true,
+        "sortBy": [{ "displayName": "Count", "desc": true }]
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "pipeline_attempt_discards_24h{service=\"api\"}",
+          "format": "table",
+          "instant": true,
+          "refId": "count"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "pipeline_attempt_discards_24h{service=\"api\"} / clamp_min(sum(pipeline_attempt_discards_24h{service=\"api\"}), 1) * 100",
+          "format": "table",
+          "instant": true,
+          "refId": "pct"
+        }
+      ],
+      "transformations": [
+        { "id": "merge", "options": {} },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Time 1": true,
+              "Time 2": true,
+              "__name__": true,
+              "__name__ 1": true,
+              "__name__ 2": true,
+              "environment": true,
+              "instance": true,
+              "instance 1": true,
+              "instance 2": true,
+              "job": true,
+              "job 1": true,
+              "job 2": true,
+              "service": true,
+              "service 1": true,
+              "service 2": true
+            },
+            "renameByName": {
+              "stage": "Stage",
+              "failure_reason": "Reason",
+              "Value #count": "Count",
+              "Value #pct": "Share %"
+            }
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [{ "field": "Count", "desc": true }]
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": { "align": "auto", "cellOptions": { "type": "auto" } }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "Share %" },
+            "properties": [
+              { "id": "unit", "value": "percent" },
+              { "id": "decimals", "value": 1 }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "Count" },
+            "properties": [
+              { "id": "custom.cellOptions", "value": { "type": "color-background", "mode": "gradient" } },
+              { "id": "color", "value": { "mode": "continuous-BlPu" } }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": 42,
+      "title": "Content filter discards by reason",
+      "description": "Expected filtering — articles rejected by content gate or extraction classifier.",
+      "type": "piechart",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "x": 14, "y": 44, "w": 10, "h": 10 },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "right", "values": ["value", "percent"] },
+        "pieType": "donut",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum(pipeline_attempt_discards_24h{service=\"api\"}) by (failure_reason)",
+          "refId": "A",
+          "legendFormat": "{{failure_reason}}",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "noValue": "none"
+        }
+      }
+    },
+    {
       "id": 33,
       "title": "Terminal failed statuses",
       "description": "Sources stuck in failed_in_download or failed_in_extraction.",
       "type": "bargauge",
       "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "gridPos": { "x": 0, "y": 43, "w": 12, "h": 6 },
+      "gridPos": { "x": 0, "y": 54, "w": 12, "h": 6 },
       "options": {
         "displayMode": "gradient",
         "orientation": "horizontal",
@@ -991,7 +1113,7 @@
       "description": "Open GitHub issues with label pipeline-failure (polled every 5 min).",
       "type": "stat",
       "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "gridPos": { "x": 12, "y": 43, "w": 6, "h": 6 },
+      "gridPos": { "x": 12, "y": 54, "w": 6, "h": 6 },
       "options": {
         "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
         "colorMode": "value",
@@ -1026,7 +1148,7 @@
       "description": "Share of violent-death sources that ended in a terminal failed status.",
       "type": "gauge",
       "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "gridPos": { "x": 18, "y": 43, "w": 6, "h": 6 },
+      "gridPos": { "x": 18, "y": 54, "w": 6, "h": 6 },
       "options": {
         "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
         "showThresholdLabels": false,


### PR DESCRIPTION
## Summary
- Record content-gate and extraction discards with `outcome=discarded` instead of `failure`
- Add `pipeline_attempt_discards_24h` Prometheus gauge
- Split Grafana dashboard: pipeline failures vs content filter discards

## Staging verification
- [x] Deploy Backend (develop) green — run 28976268421
- [x] Staging health endpoints OK

## Production test plan
- [ ] Deploy Backend (master) green
- [ ] Deploy Observability (master) green — Grafana dashboard update
- [ ] Production health endpoints OK
- [ ] Pipeline status OK

Made with [Cursor](https://cursor.com)