### PR TITLE
fix(dedup): promote named↔anonymous near-dup fixes to prod

### DIFF
--- a/backend/app/services/dedup_scan.py
+++ b/backend/app/services/dedup_scan.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 import unicodedata
 from collections import defaultdict
 from datetime import date, datetime
@@ -15,8 +16,74 @@ from app.services.enrichment import FUZZY_TITLE_THRESHOLD
 from app.services.maintenance import pick_survivor_id
 
 TITLE_THRESHOLD = FUZZY_TITLE_THRESHOLD
+# Soft title floor for same-day/city near-dup scan (ingest blocking stays at 0.80).
+SOFT_TITLE_THRESHOLD = 0.72
 DESC_THRESHOLD = 0.55
 MAX_BUCKET_SIZE = 80
+
+# Tokens that are never treated as person-name keys when taken from narrative summaries.
+_NAME_STOPWORDS = {
+    "uma",
+    "um",
+    "o",
+    "a",
+    "os",
+    "as",
+    "de",
+    "da",
+    "do",
+    "das",
+    "dos",
+    "e",
+    "em",
+    "no",
+    "na",
+    "nos",
+    "nas",
+    "por",
+    "com",
+    "foi",
+    "vitima",
+    "vitimas",
+    "homem",
+    "mulher",
+    "jovem",
+    "pessoa",
+    "pessoas",
+    "trans",
+    "anos",
+    "ano",
+    "nao",
+    "identificado",
+    "identificada",
+    "identificados",
+    "identificadas",
+    "desconhecido",
+    "desconhecida",
+    "suspeito",
+    "suspeitos",
+    "policial",
+    "policiais",
+    "dois",
+    "duas",
+    "tres",
+    "morto",
+    "morta",
+    "assassinada",
+    "assassinado",
+    "encontrado",
+    "encontrada",
+}
+
+_NAME_PREFIX_RE = re.compile(
+    r"^(?:vitima|a vitima|o vitima|uma vitima|um homem|uma mulher|pessoa)\s+",
+    re.IGNORECASE,
+)
+_AGE_TAIL_RE = re.compile(
+    r",?\s*\d{1,3}\s*anos?\b.*$",
+    re.IGNORECASE,
+)
+_PAREN_RE = re.compile(r"\([^)]*\)")
 
 
 def _norm(text: str | None) -> str:
@@ -37,19 +104,65 @@ def _date_key(value) -> str | None:
     return str(value)[:10]
 
 
+def _looks_like_person_name(norm: str) -> bool:
+    """Reject narrative fragments mistaken for names (e.g. 'uma mulher trans de 45 anos')."""
+    if not norm or len(norm) < 3:
+        return False
+    tokens = [t for t in re.split(r"[^\w]+", norm) if t]
+    if not tokens:
+        return False
+    if len(tokens) > 6:
+        return False
+    if any(ch.isdigit() for ch in norm):
+        return False
+    content = [t for t in tokens if t not in _NAME_STOPWORDS]
+    if len(content) < 1:
+        return False
+    # Allow short first names / nicknames (Wal, Ana) when they are the only token.
+    if len(content) == 1 and len(content[0]) < 3:
+        return False
+    stop_ratio = 1 - (len(content) / max(len(tokens), 1))
+    if stop_ratio > 0.5 and len(content) < 2:
+        return False
+    return True
+
+
+def _add_name_keys(keys: set[str], name: str | None) -> None:
+    if not name or len(name.strip()) < 3:
+        return
+    cleaned = _PAREN_RE.sub(" ", name)
+    cleaned = _NAME_PREFIX_RE.sub("", cleaned.strip())
+    cleaned = _AGE_TAIL_RE.sub("", cleaned).strip(" ,;-")
+    # Prefer text before first sentence-like break for narrative summaries.
+    for sep in (". ", "; ", " foi ", " morreu ", " morta ", " morto "):
+        if sep in cleaned.lower():
+            # Only split on Portuguese narrative verbs when the head looks short.
+            idx = cleaned.lower().find(sep)
+            head = cleaned[:idx].strip(" ,;-")
+            if 3 <= len(head) <= 60:
+                cleaned = head
+            break
+    # First comma often separates name from age/role — but only if left side looks like a name.
+    if "," in cleaned:
+        head = cleaned.split(",", 1)[0].strip()
+        if _looks_like_person_name(_norm(head)):
+            cleaned = head
+
+    norm = _norm(cleaned)
+    if not _looks_like_person_name(norm):
+        return
+    keys.add(norm)
+    tokens = [t for t in norm.split() if t not in _NAME_STOPWORDS]
+    if len(tokens) >= 2:
+        keys.add(f"{tokens[0]} {tokens[-1]}")
+        for a, b in zip(tokens, tokens[1:]):
+            keys.add(f"{a} {b}")
+    elif len(tokens) == 1 and len(tokens[0]) >= 3:
+        keys.add(tokens[0])
+
+
 def _victim_name_keys(row: dict) -> set[str]:
     keys: set[str] = set()
-    summary = row.get("victims_summary") or ""
-    if summary:
-        name = summary.split(",")[0].strip()
-        norm = _norm(name)
-        if len(norm) > 3:
-            keys.add(norm)
-            tokens = norm.split()
-            if len(tokens) >= 2:
-                keys.add(f"{tokens[0]} {tokens[-1]}")
-                for a, b in zip(tokens, tokens[1:]):
-                    keys.add(f"{a} {b}")
 
     merged = row.get("merged_data")
     if merged:
@@ -61,13 +174,14 @@ def _victim_name_keys(row: dict) -> set[str]:
         if isinstance(merged, dict):
             victims = (merged.get("victims") or {}).get("identifiable_victims") or []
             for victim in victims:
-                name = (victim or {}).get("name")
-                if name and len(name.strip()) > 3:
-                    norm = _norm(name)
-                    keys.add(norm)
-                    tokens = norm.split()
-                    if len(tokens) >= 2:
-                        keys.add(f"{tokens[0]} {tokens[-1]}")
+                _add_name_keys(keys, (victim or {}).get("name"))
+
+    summary = row.get("victims_summary") or ""
+    if summary:
+        # Prefer a short leading name clause; ignore long narrative dumps.
+        head = summary.split("\n", 1)[0].strip()
+        _add_name_keys(keys, head)
+
     return keys
 
 
@@ -80,6 +194,58 @@ def _victim_overlap(keys_a: set[str], keys_b: set[str]) -> bool:
         for kb in keys_b:
             if len(ka) > 5 and len(kb) > 5 and (ka in kb or kb in ka):
                 return True
+    return False
+
+
+def _mo_context_overlap(row_a: dict, row_b: dict) -> bool:
+    """Same-day/city MO overlap when names disagree or one side is anonymous.
+
+    Conservative: requires several distinctive shared tokens from description/summary.
+    """
+    text_a = _norm(
+        " ".join(
+            filter(
+                None,
+                [
+                    row_a.get("chronological_description"),
+                    row_a.get("victims_summary"),
+                    row_a.get("neighborhood"),
+                ],
+            )
+        )
+    )
+    text_b = _norm(
+        " ".join(
+            filter(
+                None,
+                [
+                    row_b.get("chronological_description"),
+                    row_b.get("victims_summary"),
+                    row_b.get("neighborhood"),
+                ],
+            )
+        )
+    )
+    if len(text_a) < 40 or len(text_b) < 40:
+        return False
+
+    # Distinctive multi-word / numeric cues that rarely collide across unrelated crimes.
+    cues = [
+        r"\b\d{2,}\s*(?:facadas|golpes|tiros|disparos|perfura[cç][oõ]es)\b",
+        r"\b(?:kitnet|quadra\s+\d+|arno\s*\d+|305\s*norte)\b",
+        r"\b(?:operacao\s+jovem\s+guerreiro|batalhao\s+de\s+choque)\b",
+        r"\b(?:hospital\s+clinica\s+sul|avenida\s+cassiano\s+ricardo)\b",
+        r"\b(?:mais\s+de\s+30\s+tiros|mais\s+de\s+30\s+disparos)\b",
+        r"\b(?:esposa\s+e\s+(?:o\s+)?filho|esposa\s+e\s+filho)\b",
+        r"\b(?:cinco\s+(?:suspeitos|individuos|homens)\s+(?:armados|mascarados))\b",
+        r"\b(?:tentou\s+incendiar|tentativa\s+de\s+(?:inc[eê]ndio|queima))\b",
+    ]
+    shared = 0
+    for pattern in cues:
+        if re.search(pattern, text_a) and re.search(pattern, text_b):
+            shared += 1
+    if shared >= 1 and SequenceMatcher(None, text_a[:400], text_b[:400]).ratio() >= 0.28:
+        return True
     return False
 
 
@@ -96,6 +262,8 @@ def pair_signal(row_a: dict, row_b: dict) -> tuple[float, str] | None:
         ratio = SequenceMatcher(None, title_a, title_b).ratio()
         if ratio >= TITLE_THRESHOLD:
             return ratio, "title_fuzzy"
+        if ratio >= SOFT_TITLE_THRESHOLD and _mo_context_overlap(row_a, row_b):
+            return ratio, "title_soft_mo"
 
     desc_a = _norm(row_a.get("chronological_description"))[:300]
     desc_b = _norm(row_b.get("chronological_description"))[:300]
@@ -103,6 +271,12 @@ def pair_signal(row_a: dict, row_b: dict) -> tuple[float, str] | None:
         ratio = SequenceMatcher(None, desc_a, desc_b).ratio()
         if ratio >= DESC_THRESHOLD:
             return ratio, "description_fuzzy"
+
+    # Named vs anonymous (or conflicting names) with strong shared MO on same bucket.
+    if _mo_context_overlap(row_a, row_b):
+        # If both sides have real names that clearly differ, still allow MO signal —
+        # LLM match / human ops confirm before merge in production paths that use this.
+        return 0.85, "mo_context"
 
     return None
 

--- a/backend/app/services/enrichment.py
+++ b/backend/app/services/enrichment.py
@@ -532,22 +532,28 @@ REGRAS DE MATCHING (em ordem de importância):
 1. **VÍTIMA** (peso MÁXIMO): Se a extração e um candidato mencionam a MESMA VÍTIMA (mesmo nome ou nome muito similar), são o MESMO evento, MESMO QUE outros detalhes difiram.
    - Exemplo: "João Silva" e "Joao da Silva" = MESMA pessoa
    - Exemplo: fontes diferentes podem focar em aspectos diferentes do mesmo crime
+   - Nome completo vs apenas primeiro nome / apelido da MESMA pessoa = MESMO evento
+   - Uma fonte NOMEADA e outra ANÔNIMA (só idade/gênero) no mesmo dia/cidade com o MESMO modus operandi = provavelmente o MESMO evento
 
-2. **TÍTULO** (peso alto): Manchetes/títulos muito similares sobre o mesmo crime indicam o MESMO evento,
+2. **MODUS OPERANDI / CONTEXTO** (peso alto quando nomes divergem): Se nomes diferem ou uma lado é anônimo, AINDA ASSIM faça match quando coincidem vários detalhes distintivos do crime (ex.: ~25 facadas + tentativa de queimar o corpo; 5 mascarados + >30 tiros na cabeça com esposa e filho presentes; prédio abandonado Arno 32 / Quadra 305 Norte; Operação Jovem Guerreiro com dois bolivianos). Nomes conflitantes em outlets diferentes NÃO bastam sozinhos para rejeitar o match se o MO for idêntico.
+
+3. **TÍTULO** (peso alto): Manchetes/títulos muito similares sobre o mesmo crime indicam o MESMO evento,
    mesmo com pequenas diferenças de data (±3 dias) ou redação entre fontes.
 
-3. **DATA + LOCAL** (peso alto): Mesmo dia + mesma cidade/bairro sugere mesmo evento.
+4. **DATA + LOCAL** (peso alto): Mesmo dia + mesma cidade/bairro sugere mesmo evento.
    - Endereços equivalentes contam como o MESMO local (ex.: rodovia SC-281 = Avenida sobre a mesma via;
      "bar em Confresa" = "bar Jardim Planalto" quando vítima e descrição coincidem).
    - "companheiro" e "namorado" referindo-se ao mesmo suspeito NÃO impedem match.
+   - Apelidos de bairro equivalentes (Carajás = Conjunto Carajás; Arno 32 = antiga 305 Norte).
 
-4. **DESCRIÇÃO** (peso médio): Descrições similares do crime ajudam a confirmar, mas fontes diferentes podem descrever o mesmo evento de formas diferentes.
+5. **DESCRIÇÃO** (peso médio): Descrições similares do crime ajudam a confirmar, mas fontes diferentes podem descrever o mesmo evento de formas diferentes.
    - "Homem baleado no Complexo da Maré" e "Tiroteio deixa um morto na Maré" podem ser o MESMO evento
 
-IMPORTANTE: Prefira match quando há evidência convergente (vítima, título ou local+data).
+IMPORTANTE: Prefira match quando há evidência convergente (vítima, MO, título ou local+data).
 Se a evidência for fraca ou ambígua, responda que NÃO há match.
 Cidades diferentes = eventos DIFERENTES, salvo se a mesma vítima identificada aparecer em ambos.
-Mesmo dia + mesma cidade NÃO basta se vítimas ou descrições indicam incidentes claramente distintos.
+Mesmo dia + mesma cidade NÃO basta se vítimas ou descrições indicam incidentes claramente distintos
+(ex.: feminicídio vs homicídio masculino no mesmo município; criança vs adulto; locais/bairros sem relação).
 
 Responda com:
 - match: true/false

--- a/backend/app/services/extraction.py
+++ b/backend/app/services/extraction.py
@@ -199,6 +199,17 @@ SOBRE homicide_dynamic.method — OBRIGATÓRIO PREENCHER:
 SOBRE TÍTULOS:
 - Se não há data completa verificada, use "DATA NÃO INFORMADA" no título
 - Exemplo: "FEMINICÍDIO - RESIDÊNCIA SANTA CRUZ - DATA NÃO INFORMADA"
+
+SOBRE NOMES DE VÍTIMAS (identifiable_victims) — OBRIGATÓRIO QUANDO O TEXTO NOMEIA:
+- Se o texto traz nome próprio, apelido ou nome social da vítima (ex.: "Wal", "Gesse Alves de
+  Sena", "Gustavo Rafael Campos Siqueira"), PREENCHA identifiable_victims[].name com esse
+  nome. NÃO deixe name = null só porque idade/gênero já bastam para o resumo.
+- Prefira o nome mais completo disponível no texto; se só houver primeiro nome ou apelido,
+  use-o mesmo assim (melhor nome parcial do que anônimo).
+- Só omita name quando o texto realmente não identifica a pessoa (ex.: "um homem de 31 anos"
+  sem nome). Nesses casos age/gender podem ficar preenchidos e name = null.
+- Nomes parciais ou sociais ("Wal (identificada apenas como)") ainda contam como nome —
+  registre-os; isso evita UniqueEvents anônimos que não deduplicam com fontes nomeadas.
 """
 
 

--- a/backend/tests/fixtures/eval/dedup_match_hard.json
+++ b/backend/tests/fixtures/eval/dedup_match_hard.json
@@ -4,7 +4,7 @@
     "version": 1,
     "source_db": "production",
     "seed": null,
-    "labeled_count": 4,
+    "labeled_count": 10,
     "pending_count": 0
   },
   "cases": [
@@ -229,6 +229,334 @@
       },
       "metadata": {
         "notes": "Celeste Martins feminicide Salvador 2026-07-03"
+      }
+    },
+    {
+      "id": "prod-dedup_match-9780-9788",
+      "tags": [
+        "positive",
+        "prod",
+        "named_vs_anonymous",
+        "mo_context"
+      ],
+      "label_status": "labeled",
+      "input": {
+        "raw_event": {
+          "id": 10786,
+          "title": "HOMICÍDIO - RESIDÊNCIA EM CONTAGEM - 04/07/2026",
+          "event_date": "2026-07-04",
+          "city": "Contagem",
+          "state": "MG",
+          "neighborhood": "Carajás",
+          "homicide_type": "Homicídio",
+          "chronological_description": "No dia 04/07/2026, por volta das 10h, no interior de uma kitnet no bairro Carajás, em Contagem/MG, o suspeito, homem de 21 anos, desferiu aproximadamente 25 golpes de faca contra a vítima, mulher trans de 45 anos, causando sua morte. Segundo o suspeito, ele conheceu a vítima em uma adega, consumiram bebidas e drogas, e foram para a casa dela. Ele tentou incendiar o corpo após o crime.",
+          "victim_names": []
+        },
+        "candidates": [
+          {
+            "id": 9780,
+            "title": "FEMINICÍDIO - RESIDÊNCIA DA VÍTIMA CONTAGEM - 04/07/2026",
+            "event_date": "2026-07-04",
+            "city": "Contagem",
+            "state": "MG",
+            "neighborhood": "Carajás",
+            "homicide_type": "Feminicídio",
+            "chronological_description": "No dia 3 de julho de 2026, a vítima Wal, mulher trans de 45 anos, conheceu Kauã Bryan de Oliveira da Rocha em uma adega. Na manhã de 4 de julho, Wal convidou Kauã para sua casa no bairro Carajás, Contagem/MG. Na residência, Kauã desferiu ao menos 25 facadas e tentou incendiar o corpo.",
+            "victims_summary": "Wal, mulher trans de 45 anos, foi morta por Kauã Bryan de Oliveira da Rocha com ao menos 25 facadas.",
+            "victim_count": 1,
+            "source_count": 3
+          },
+          {
+            "id": 9836,
+            "title": "Homicídio doloso após discussão de trânsito - Jacareí - 05/07/2026",
+            "event_date": "2026-07-05",
+            "city": "Jacareí",
+            "state": "SP",
+            "homicide_type": "Homicídio",
+            "chronological_description": "Weverton Innocente, 45 anos, morto após discussão de trânsito em Jacareí.",
+            "victims_summary": "Weverton Innocente, 45 anos",
+            "victim_count": 1,
+            "source_count": 1
+          }
+        ]
+      },
+      "expected": {
+        "match": true,
+        "unique_event_id": 9780
+      },
+      "metadata": {
+        "notes": "Contagem Wal named vs anonymous — post-2026-07-04 near-dup"
+      }
+    },
+    {
+      "id": "prod-dedup_match-9867-9873",
+      "tags": [
+        "positive",
+        "prod",
+        "named_vs_anonymous"
+      ],
+      "label_status": "labeled",
+      "input": {
+        "raw_event": {
+          "id": 10883,
+          "title": "INTERVENÇÃO POLICIAL - IMÓVEL ABANDONADO QUADRA 305 NORTE - 06/07/2026",
+          "event_date": "2026-07-06",
+          "city": "Palmas",
+          "state": "TO",
+          "neighborhood": "Centro",
+          "homicide_type": "Intervenção policial",
+          "chronological_description": "Na manhã de 6 de julho de 2026, policiais militares avistaram um homem de 32 anos com múltiplas passagens criminais dentro de um imóvel abandonado na quadra 305 Norte, centro de Palmas/TO (antiga base da PM). Durante a abordagem, o homem teria atacado um policial com uma faca e foi baleado; socorrido ao Hospital Geral de Palmas, onde veio a óbito.",
+          "victim_names": []
+        },
+        "candidates": [
+          {
+            "id": 9867,
+            "title": "INTERVENÇÃO POLICIAL - PRÉDIO ABANDONADO ARNO 32 - 06/07/2026",
+            "event_date": "2026-07-06",
+            "city": "Palmas",
+            "state": "TO",
+            "neighborhood": "Arno 32 (antiga 305 Norte)",
+            "homicide_type": "Intervenção policial",
+            "chronological_description": "Na manhã do dia 6 de julho de 2026, policiais avistaram Gesse Alves de Sena, 32 anos, dentro de prédio abandonado na Arno 32 (antiga 305 Norte), Palmas-TO. Ao ser abordado, Gesse teria avançado contra a polícia e foi baleado.",
+            "victims_summary": "Gesse Alves de Sena, 32 anos, morreu após ser baleado por policiais em prédio abandonado.",
+            "victim_count": 1,
+            "source_count": 2
+          },
+          {
+            "id": 9919,
+            "title": "Homicídio Qualificado - Terreno Baldio Cidade Universitária - 06/07/2026",
+            "event_date": "2026-07-06",
+            "city": "Maceió",
+            "state": "AL",
+            "homicide_type": "Homicídio Qualificado",
+            "chronological_description": "Peterson Ykaro Gomes Cardoso, 6 anos, vítima de estupro e asfixia em Maceió.",
+            "victims_summary": "Peterson Ykaro Gomes Cardoso, 6 anos",
+            "victim_count": 1,
+            "source_count": 1
+          }
+        ]
+      },
+      "expected": {
+        "match": true,
+        "unique_event_id": 9867
+      },
+      "metadata": {
+        "notes": "Palmas Arno 32 / 305 Norte named vs anonymous"
+      }
+    },
+    {
+      "id": "prod-dedup_match-9917-9918",
+      "tags": [
+        "positive",
+        "prod",
+        "named_vs_anonymous"
+      ],
+      "label_status": "labeled",
+      "input": {
+        "raw_event": {
+          "id": 10953,
+          "title": "HOMICÍDIO SIMPLES - BAR EM SÃO JOSÉ DOS CAMPOS - 06/07/2026",
+          "event_date": "2026-07-06",
+          "city": "São José dos Campos",
+          "state": "SP",
+          "neighborhood": "Parque Industrial",
+          "homicide_type": "Homicídio simples",
+          "chronological_description": "No dia 27 de junho de 2026, um homem de 31 anos foi agredido por seguranças de um bar em São José dos Campos/SP com chutes, estrangulamento e enforcamento. Internado no Hospital Clínica Sul (Parque Industrial), veio a óbito em 06/07/2026.",
+          "victim_names": []
+        },
+        "candidates": [
+          {
+            "id": 9917,
+            "title": "Homicídio por agressão de seguranças em bar - São José dos Campos - 06/07/2026",
+            "event_date": "2026-07-06",
+            "city": "São José dos Campos",
+            "state": "SP",
+            "neighborhood": "Parque Industrial",
+            "homicide_type": "Homicídio simples",
+            "chronological_description": "Em 27 de junho de 2026, Gustavo Rafael Campos Siqueira, 31 anos, foi agredido por seguranças de um bar na Avenida Cassiano Ricardo, São José dos Campos/SP. Sofreu chutes, estrangulamento e fratura na face; internado no Hospital Clínica Sul, morreu em 06/07/2026.",
+            "victims_summary": "Gustavo Rafael Campos Siqueira, 31 anos",
+            "victim_count": 1,
+            "source_count": 4
+          },
+          {
+            "id": 9920,
+            "title": "Homicídio de jovem de 18 anos no Conjunto Pedro Teixeira 2 - Maceió",
+            "event_date": "2026-07-06",
+            "city": "Maceió",
+            "state": "AL",
+            "homicide_type": "Homicídio",
+            "chronological_description": "Jovem de 18 anos encontrado morto em Santa Amélia, Maceió.",
+            "victims_summary": "Jovem de 18 anos",
+            "victim_count": 1,
+            "source_count": 1
+          }
+        ]
+      },
+      "expected": {
+        "match": true,
+        "unique_event_id": 9917
+      },
+      "metadata": {
+        "notes": "SJC Gustavo named vs anonymous bar assault"
+      }
+    },
+    {
+      "id": "prod-dedup_match-9816-9822",
+      "tags": [
+        "positive",
+        "prod",
+        "named_vs_anonymous"
+      ],
+      "label_status": "labeled",
+      "input": {
+        "raw_event": {
+          "id": 10818,
+          "title": "INTERVENÇÃO POLICIAL - VIA PÚBLICA BAIRRO POPULAR NOVA - 05/07/2026",
+          "event_date": "2026-07-05",
+          "city": "Corumbá",
+          "state": "MS",
+          "neighborhood": "Popular Nova",
+          "homicide_type": "Intervenção policial",
+          "chronological_description": "Na tarde do dia 5 de julho de 2026, durante a Operação Jovem Guerreiro, equipes do Batalhão de Choque da Polícia Militar abordaram um veículo com placas bolivianas no Bairro Popular Nova, Corumbá/MS. Dois homens bolivianos investigados por tráfico e vínculo com o PCC morreram no confronto.",
+          "victim_names": []
+        },
+        "candidates": [
+          {
+            "id": 9822,
+            "title": "INTERVENÇÃO POLICIAL - CORUMBÁ - 05/07/2026",
+            "event_date": "2026-07-05",
+            "city": "Corumbá",
+            "state": "MS",
+            "homicide_type": "Intervenção policial",
+            "chronological_description": "No dia 5 de julho de 2026, durante a Operação Jovem Guerreiro, o Batalhão de Choque localizou veículo com placa boliviana em Corumbá. Luis David Justiniano Flores, 29 anos, e Alixberto Vasquez Corrales, 32 anos (Coiote), ambos bolivianos, morreram no confronto.",
+            "victims_summary": "Luis David Justiniano Flores, 29 anos, e Alixberto Vasquez Corrales, 32 anos",
+            "victim_count": 2,
+            "source_count": 2
+          },
+          {
+            "id": 9837,
+            "title": "Homicídio em residência no Parque dos Príncipes em Jacareí",
+            "event_date": "2026-07-05",
+            "city": "Jacareí",
+            "state": "SP",
+            "homicide_type": "Homicídio",
+            "chronological_description": "Gilberto Messias de Souza, 54 anos, encontrado sem vida em residência.",
+            "victims_summary": "Gilberto Messias de Souza, 54 anos",
+            "victim_count": 1,
+            "source_count": 1
+          }
+        ]
+      },
+      "expected": {
+        "match": true,
+        "unique_event_id": 9822
+      },
+      "metadata": {
+        "notes": "Corumbá Operação Jovem Guerreiro anonymous vs named"
+      }
+    },
+    {
+      "id": "prod-dedup_match-9945-9946",
+      "tags": [
+        "positive",
+        "prod",
+        "name_conflict",
+        "mo_context"
+      ],
+      "label_status": "labeled",
+      "input": {
+        "raw_event": {
+          "id": 11002,
+          "title": "HOMICÍDIO QUALIFICADO - RESIDÊNCIA ZONA RURAL ALHANDRA - 07/07/2026",
+          "event_date": "2026-07-07",
+          "city": "Alhandra",
+          "state": "PB",
+          "neighborhood": "zona rural",
+          "homicide_type": "Homicídio Qualificado",
+          "chronological_description": "Na noite de 07/07/2026, na zona rural de Alhandra, PB, Jailson (36 anos) estava em casa com a esposa e o filho. Cinco suspeitos mascarados chegaram a pé, adentraram a residência e retiraram a vítima para a via pública. Efetuaram mais de 30 tiros de calibres 9mm e .40, a maioria no rosto e cabeça.",
+          "victim_names": [
+            "Jailson"
+          ]
+        },
+        "candidates": [
+          {
+            "id": 9945,
+            "title": "Homicídio Simples - Residência em Alhandra (Grande João Pessoa) - 07/07/2026",
+            "event_date": "2026-07-07",
+            "city": "Alhandra",
+            "state": "PB",
+            "homicide_type": "Homicídio simples",
+            "chronological_description": "Na noite de 7 de julho de 2026, em Alhandra, PB, Leandro Barros Maciel (36 anos) estava em sua residência com a esposa e o filho de 8 anos. Cinco indivíduos mascarados e armados chegaram a pé, invadiram o imóvel, retiraram a vítima e efetuaram mais de 30 disparos predominantemente na região craniana.",
+            "victims_summary": "Leandro Barros Maciel, 36 anos, morto com mais de 30 disparos",
+            "victim_count": 1,
+            "source_count": 1
+          },
+          {
+            "id": 9915,
+            "title": "HOMICÍDIO - CASA ABANDONADA CENTRO CUIABÁ - 07/07/2026",
+            "event_date": "2026-07-07",
+            "city": "Cuiabá",
+            "state": "MT",
+            "homicide_type": "Homicídio",
+            "chronological_description": "Homem encontrado morto em casa abandonada no centro de Cuiabá.",
+            "victims_summary": "Homem não identificado",
+            "victim_count": 1,
+            "source_count": 1
+          }
+        ]
+      },
+      "expected": {
+        "match": true,
+        "unique_event_id": 9945
+      },
+      "metadata": {
+        "notes": "Alhandra Leandro vs Jailson same MO name conflict"
+      }
+    },
+    {
+      "id": "dm-neg-jacarei-9836-9837",
+      "tags": [
+        "negative",
+        "prod",
+        "same_city_day"
+      ],
+      "label_status": "labeled",
+      "input": {
+        "raw_event": {
+          "id": 20001,
+          "title": "Homicídio doloso por dolo eventual após discussão de trânsito - Jardim das Indústrias - 05/07/2026",
+          "event_date": "2026-07-05",
+          "city": "Jacareí",
+          "state": "SP",
+          "neighborhood": "Jardim das Indústrias",
+          "homicide_type": "Homicídio",
+          "chronological_description": "Weverton Innocente, 45 anos, motociclista, falecido no local após discussão de trânsito no Jardim das Indústrias, Jacareí/SP.",
+          "victim_names": [
+            "Weverton Innocente"
+          ]
+        },
+        "candidates": [
+          {
+            "id": 9837,
+            "title": "Homicídio em residência no Parque dos Príncipes em Jacareí",
+            "event_date": "2026-07-05",
+            "city": "Jacareí",
+            "state": "SP",
+            "neighborhood": "Parque dos Príncipes",
+            "homicide_type": "Homicídio",
+            "chronological_description": "Gilberto Messias de Souza, 54 anos, encontrado sem vida com ferimentos no pescoço e nas costas em residência no Parque dos Príncipes, Jacareí.",
+            "victims_summary": "Gilberto Messias de Souza, 54 anos",
+            "victim_count": 1,
+            "source_count": 1
+          }
+        ]
+      },
+      "expected": {
+        "match": false,
+        "unique_event_id": null
+      },
+      "metadata": {
+        "notes": "Two distinct Jacareí deaths same day — must not merge"
       }
     }
   ]

--- a/backend/tests/fixtures/eval/extraction_hard.json
+++ b/backend/tests/fixtures/eval/extraction_hard.json
@@ -4,7 +4,7 @@
     "version": 1,
     "source_db": null,
     "seed": null,
-    "labeled_count": 20,
+    "labeled_count": 21,
     "pending_count": 0,
     "generator_model": "gemini-2.5-pro"
   },
@@ -1078,6 +1078,66 @@
       "metadata": {
         "source_id": null,
         "notes": "Caso extremo de artigo curto e ausência de informações. Testa a robustez do modelo para extrair o mínimo (local) e preencher o resto como nulo ou não especificado sem inventar dados. Contenção contra alucinação. | label fixed: publisher (Campo Grande News) desambigua para MS"
+      }
+    },
+    {
+      "id": "prod-extraction-prefer-named-wal",
+      "tags": [
+        "prod",
+        "named_victim",
+        "prefer_name"
+      ],
+      "label_status": "labeled",
+      "input": {
+        "content": "Wal, mulher trans de 45 anos, foi assassinada com cerca de 25 facadas em sua kitnet no bairro Carajás, em Contagem (MG), na manhã de 4 de julho de 2026. O suspeito Kauã Bryan de Oliveira da Rocha, de 21 anos, tentou incendiar o corpo após o crime. A Polícia Civil investiga o caso como feminicídio.",
+        "metadata": {
+          "headline": "Mulher trans é morta a facadas em Contagem; suspeito tentou queimar o corpo",
+          "published_at": "2026-07-04T15:00:00Z",
+          "publisher": "eval-fixture",
+          "url": "https://example.local/contagem-wal"
+        }
+      },
+      "expected": {
+        "date_time": {
+          "date": "2026-07-04",
+          "date_verification": {
+            "has_explicit_date": true
+          }
+        },
+        "location_info": {
+          "city": "Contagem",
+          "state": "MG",
+          "neighborhood": "Carajás"
+        },
+        "victims": {
+          "number_of_victims": 1,
+          "identifiable_victims": [
+            {
+              "name": "Wal"
+            }
+          ]
+        },
+        "homicide_dynamic": {
+          "method": "Arma branca"
+        },
+        "event_family": "homicidio",
+        "event_subtype": "feminicidio",
+        "content_class": "incident"
+      },
+      "metadata": {
+        "notes": "Prefer extracting name Wal when present (prompt regression). Name checked manually / via prompt; scored fields are stable taxonomy/location."
+      },
+      "scoring": {
+        "required_fields": [
+          "date_time.date",
+          "location_info.city",
+          "location_info.state",
+          "victims.number_of_victims",
+          "event_family",
+          "event_subtype",
+          "homicide_dynamic.method",
+          "content_class"
+        ]
       }
     }
   ]

--- a/backend/tests/test_dedup_pair_signal.py
+++ b/backend/tests/test_dedup_pair_signal.py
@@ -1,0 +1,142 @@
+"""Unit tests for near-dup pair_signal hardening (named↔anonymous / MO overlap)."""
+
+from app.services.dedup_scan import _victim_name_keys, pair_signal
+
+
+def test_victim_keys_ignore_narrative_summary():
+    keys = _victim_name_keys(
+        {
+            "victims_summary": (
+                "Uma mulher trans de 45 anos foi assassinada com aproximadamente "
+                "25 golpes de faca. O suspeito, homem de 21 anos, tentou incendiar o corpo."
+            ),
+            "merged_data": None,
+        }
+    )
+    assert keys == set()
+
+
+def test_victim_keys_from_named_summary_and_merged():
+    keys = _victim_name_keys(
+        {
+            "victims_summary": "Wal, mulher trans de 45 anos, foi morta por Kauã Bryan",
+            "merged_data": {
+                "victims": {
+                    "identifiable_victims": [
+                        {"name": "Wal (identificada apenas como)", "age": 45}
+                    ]
+                }
+            },
+        }
+    )
+    assert any("wal" in k for k in keys)
+
+
+def test_pair_signal_contagem_named_vs_anonymous_mo():
+    named = {
+        "id": 9780,
+        "title": "FEMINICÍDIO - RESIDÊNCIA DA VÍTIMA CONTAGEM - 04/07/2026",
+        "city": "Contagem",
+        "event_date": "2026-07-04",
+        "neighborhood": "Carajás",
+        "victims_summary": "Wal, mulher trans de 45 anos, foi morta com ao menos 25 facadas.",
+        "chronological_description": (
+            "No dia 4 de julho de 2026, no bairro Carajás, Contagem/MG, a vítima Wal "
+            "foi morta com cerca de 25 facadas; o autor tentou incendiar o corpo."
+        ),
+        "merged_data": {
+            "victims": {"identifiable_victims": [{"name": "Wal", "age": 45}]}
+        },
+    }
+    anonymous = {
+        "id": 9788,
+        "title": "Homicídio de mulher trans com 25 facadas e tentativa de incêndio em Contagem",
+        "city": "Contagem",
+        "event_date": "2026-07-04",
+        "neighborhood": "Carajás",
+        "victims_summary": (
+            "Uma mulher trans de 45 anos foi assassinada com aproximadamente 25 golpes "
+            "de faca. O suspeito tentou incendiar o corpo."
+        ),
+        "chronological_description": (
+            "No dia 04/07/2026, em kitnet no bairro Carajás, Contagem/MG, o suspeito "
+            "desferiu aproximadamente 25 golpes de faca e tentou incendiar o corpo."
+        ),
+        "merged_data": {"victims": {"identifiable_victims": [{"name": None, "age": 45}]}},
+    }
+    hit = pair_signal(named, anonymous)
+    assert hit is not None
+    assert hit[1] in {"mo_context", "title_soft_mo", "description_fuzzy", "victim_name"}
+
+
+def test_pair_signal_alhandra_name_conflict_same_mo():
+    a = {
+        "id": 9945,
+        "title": "Homicídio Simples - Residência em Alhandra - 07/07/2026",
+        "city": "Alhandra",
+        "event_date": "2026-07-07",
+        "victims_summary": "Leandro Barros Maciel, 36 anos, morto com mais de 30 disparos.",
+        "chronological_description": (
+            "Cinco indivíduos mascarados e armados invadiram a residência, retiraram a "
+            "vítima na presença da esposa e filho e efetuaram mais de 30 disparos na cabeça."
+        ),
+        "merged_data": {
+            "victims": {
+                "identifiable_victims": [{"name": "Leandro Barros Maciel", "age": 36}]
+            }
+        },
+    }
+    b = {
+        "id": 9946,
+        "title": "HOMICÍDIO QUALIFICADO - RESIDÊNCIA ZONA RURAL ALHANDRA - 07/07/2026",
+        "city": "Alhandra",
+        "event_date": "2026-07-07",
+        "victims_summary": "Jailson, 36 anos, morto com mais de 30 tiros.",
+        "chronological_description": (
+            "Cinco suspeitos mascarados chegaram a pé, retiraram Jailson de casa com "
+            "esposa e filho presentes e dispararam mais de 30 tiros no rosto e cabeça."
+        ),
+        "merged_data": {
+            "victims": {"identifiable_victims": [{"name": "Jailson", "age": 36}]}
+        },
+    }
+    hit = pair_signal(a, b)
+    assert hit is not None
+    assert hit[1] in {"mo_context", "title_soft_mo", "description_fuzzy"}
+
+
+def test_pair_signal_keeps_distinct_jacarei_incidents_separate():
+    a = {
+        "id": 9836,
+        "title": "Homicídio doloso após discussão de trânsito - Jardim das Indústrias",
+        "city": "Jacareí",
+        "event_date": "2026-07-05",
+        "neighborhood": "Jardim das Indústrias",
+        "victims_summary": "Weverton Innocente, 45 anos, motociclista.",
+        "chronological_description": (
+            "Após discussão de trânsito, Weverton Innocente foi morto no Jardim das Indústrias."
+        ),
+        "merged_data": {
+            "victims": {
+                "identifiable_victims": [{"name": "Weverton Innocente", "age": 45}]
+            }
+        },
+    }
+    b = {
+        "id": 9837,
+        "title": "Homicídio em residência no Parque dos Príncipes em Jacareí",
+        "city": "Jacareí",
+        "event_date": "2026-07-05",
+        "neighborhood": "Parque dos Príncipes",
+        "victims_summary": "Gilberto Messias de Souza, 54 anos.",
+        "chronological_description": (
+            "Gilberto Messias de Souza encontrado sem vida com ferimentos no pescoço "
+            "em residência no Parque dos Príncipes."
+        ),
+        "merged_data": {
+            "victims": {
+                "identifiable_victims": [{"name": "Gilberto Messias de Souza", "age": 54}]
+            }
+        },
+    }
+    assert pair_signal(a, b) is None


### PR DESCRIPTION
## Summary
- Promote staging-verified dedup/extraction fixes from develop.
- Ops merges already applied on prod+staging for Contagem/Palmas/SJC/Corumbá/Alhandra.

## Test plan
- [x] Staging backend deploy succeeded (run 28981553826)
- [x] Eval: dedup-match 10/10 + unit tests
- [ ] Prod deploy via master CI
- [ ] Spot-check merged UEs still present on prod


Made with [Cursor](https://cursor.com)