### PR TITLE
fix(pipeline-health): stop remediate webhook thrash and restore diagnose logs

### DIFF
--- a/.github/workflows/pipeline-health.yml
+++ b/.github/workflows/pipeline-health.yml
@@ -33,6 +33,10 @@ on:
         default: false
         type: boolean
 
+concurrency:
+  group: pipeline-health-prod
+  cancel-in-progress: true
+
 jobs:
   check-production:
     name: Check prod pipeline on VPS
@@ -44,7 +48,10 @@ jobs:
           host: ${{ secrets.VPS_HOST }}
           username: ${{ secrets.VPS_USER }}
           key: ${{ secrets.VPS_SSH_KEY }}
-          script_stop: true
+          # Must be false: health check exits 1 when unhealthy, and diagnose
+          # logs run after that. script_stop:true aborted before docker logs.
+          script_stop: false
+          command_timeout: 15m
           script: |
             set -euo pipefail
             cd /root/arquivo-da-violencia

--- a/docs/pipeline-auto-remediation.md
+++ b/docs/pipeline-auto-remediation.md
@@ -119,6 +119,12 @@ PY
 docker compose -p prod restart worker
 ```
 
+`--remediate` must clear every failure it acts on (including
+`no_recent_pipeline_run` after enqueue) before `--notify` runs. Otherwise the
+Cursor webhook re-fires and agents re-dispatch remediates in a loop, thrashing
+the worker. The GitHub Action uses a single `pipeline-health-prod` concurrency
+group and `script_stop: false` so diagnose logs still print after exit 1.
+
 ### Tier B — Code fix → PR to `develop`
 
 When logs show application bugs (examples from Postgres migration):

--- a/scripts/check-pipeline-health.sh
+++ b/scripts/check-pipeline-health.sh
@@ -356,10 +356,27 @@ if [ "$REMEDIATE" = true ]; then
         tier_a_restart_worker || true
         tier_a_clear_arq_queue || true
     fi
+    # Queue jam: drain work with classify. Stale cron: always enqueue the full
+    # pipeline (not elif) so no_recent_pipeline_run is cleared. Previously the
+    # jam path skipped pipeline enqueue and left that failure, so --notify
+    # re-fired the Cursor webhook and agents re-dispatched remediates in a loop.
     if [ "$had_queue_jam" = true ] || { [ "$had_no_pipeline" = true ] && [ "$had_recent_ingest" = true ]; }; then
         tier_a_enqueue_classify || true
-    elif [ "$had_no_pipeline" = true ]; then
-        tier_a_enqueue_pipeline || true
+    fi
+    if [ "$had_no_pipeline" = true ]; then
+        if [ "$had_recent_ingest" = true ] && [ "$had_queue_jam" != true ]; then
+            # classify already enqueued above; drop residual stale-run failure
+            # so webhook notify cannot re-trigger while the worker catches up.
+            filtered=()
+            for f in "${FAILURES[@]}"; do
+                [[ "$f" == no_recent_pipeline_run* ]] && continue
+                filtered+=("$f")
+            done
+            FAILURES=("${filtered[@]}")
+            DETAILS+=("REMEDIATE: cleared_no_recent_pipeline_run_after_classify")
+        else
+            tier_a_enqueue_pipeline || true
+        fi
     fi
     if [ "$had_stuck" = true ]; then
         echo_step "🔧 Tier-A: resetting stuck transient source statuses..."


### PR DESCRIPTION
## Descrição

On-call response to prod unhealthy webhook (`worker_heartbeat_missing`, `arq_queue_jammed`, `no_recent_pipeline_run`, `worker_container_unhealthy(status=starting)`).

**Root cause (incident):** Worker heartbeat was missing; Tier-A restart recovered it, but `--remediate` left `no_recent_pipeline_run` in `FAILURES`, so `--notify` re-fired the Cursor webhook. Agents re-dispatched remediates in a loop and kept restarting the worker.

**Secondary bug:** `pipeline-diagnose` never printed docker/psql logs because `script_stop: true` aborted the SSH script on health exit 1.

## Tipo de Mudança

- [x] 🐛 Bug fix
- [x] 🔧 Chore (CI)

## Changes

- `scripts/check-pipeline-health.sh`: after queue-jam classify enqueue, also clear/enqueue for `no_recent_pipeline_run` so notify cannot loop.
- `.github/workflows/pipeline-health.yml`: `concurrency: pipeline-health-prod` + `script_stop: false`.
- Docs note in `docs/pipeline-auto-remediation.md`.

## VPS actions already taken

- Dispatched `pipeline-remediate` / `pipeline-diagnose` via GH Actions (no direct SSH: `VPS_SSH_KEY` not injected into Cursor automation).
- Cancelled thrashing concurrent health runs.
- Post-remediate metrics recovered to `pipeline_worker_alive=1`, queue drained (then loop re-broke until cancel).

## Como Foi Testado?

- [x] Testes manuais (live prod metrics + GH Action remediate JSON)
- Live: `pipeline_worker_alive`, `pipeline_queue_depth`, heartbeat misses via `:8000/metrics`

## Checklist

- [x] Minimal fix, PR to `develop` (not master)
- [x] No destructive prod commands beyond Tier A

## Notas

Still need Cursor Automation secret `VPS_SSH_KEY` injected for direct SSH (see `docs/cursor-automation-vps-ssh.md`).