### PR TITLE
fix(pipeline): remediate missing ingest when backlog is active

### DIFF
--- a/.github/workflows/pipeline-health.yml
+++ b/.github/workflows/pipeline-health.yml
@@ -56,9 +56,18 @@ jobs:
             git checkout -f "$BRANCH"
             git reset --hard "origin/$BRANCH"
             export PIPELINE_HEALTH_WEBHOOK_AUTH="${{ secrets.CURSOR_AUTOMATION_TOKEN }}"
-            ARGS="--notify --json"
+            ARGS="--json"
             EVENT="${{ github.event_name }}"
             DISPATCH_ACTION="${{ github.event.action }}"
+            # Notify on schedule/remediate/manual checks — not on diagnose-only runs.
+            # Diagnose + --notify re-fires the Cursor webhook and can spawn agent storms.
+            if [ "$EVENT" = "schedule" ] \
+              || { [ "$EVENT" = "repository_dispatch" ] && [ "$DISPATCH_ACTION" = "pipeline-remediate" ]; } \
+              || [ "$EVENT" = "workflow_dispatch" ]; then
+              if ! { [ "$EVENT" = "workflow_dispatch" ] && [ "${{ inputs.diagnose }}" = "true" ] && [ "${{ inputs.remediate }}" != "true" ]; }; then
+                ARGS="$ARGS --notify"
+              fi
+            fi
             # Tier-A auto-remediation: safe for scheduled checks and on-demand dispatch.
             if [ "$EVENT" = "schedule" ] \
               || { [ "$EVENT" = "repository_dispatch" ] && [ "$DISPATCH_ACTION" = "pipeline-remediate" ]; } \

--- a/.github/workflows/pipeline-health.yml
+++ b/.github/workflows/pipeline-health.yml
@@ -33,6 +33,12 @@ on:
         default: false
         type: boolean
 
+# Only one VPS health/remediate run at a time. Concurrent remediates restart the
+# worker repeatedly and amplify Cursor webhook storms.
+concurrency:
+  group: pipeline-health-prod
+  cancel-in-progress: true
+
 jobs:
   check-production:
     name: Check prod pipeline on VPS

--- a/docs/cursor-automation-vps-ssh.md
+++ b/docs/cursor-automation-vps-ssh.md
@@ -81,6 +81,9 @@ the playbook below. Payload may include `"source": "prometheus-alertmanager"`.
 3. Tier A (no code) — map alert/failure to action:
    - stuck_sources / StuckSourcesCritical / StuckSourcesWarning:
      bash scripts/check-pipeline-health.sh --remediate
+   - backlog_active_but_no_recent_ingest / no_recent_pipeline_run:
+     bash scripts/check-pipeline-health.sh --remediate
+     (enqueues ingest_cities_hourly or ingest_cities_full_pipeline)
    - worker_heartbeat_missing / WorkerDown / HeartbeatMissesWarning:
      docker compose -p prod restart worker
    - arq_queue_jammed / QueueDepthCritical:
@@ -89,6 +92,7 @@ the playbook below. Payload may include `"source": "prometheus-alertmanager"`.
      df -h; docker system df; prune logs/images if safe
    - ApiScrapeDown / WorkerScrapeDown / ObservabilityScrapeDown:
      docker compose -p prod ps; check UFW and container health
+   Do not spam repository_dispatch while other agents are remediating.
 
 4. Tier B (code): branch fix/pipeline-<issue> from develop, minimal fix, PR to develop.
    Never push master directly. Follow AGENTS.md: develop → staging → master.

--- a/docs/pipeline-auto-remediation.md
+++ b/docs/pipeline-auto-remediation.md
@@ -85,7 +85,8 @@ full alert rule reference.
 | `curl localhost:8000/health` | API down |
 | `arquivo-worker` Docker health | Worker container unhealthy |
 | Redis key `arq:queue:health-check` | Worker process not heartbeating |
-| Recent `CITIES_PIPELINE` in worker logs (100 min) | Hourly cron did not run (when cron enabled) |
+| Recent ingest start logs within 100 min | Hourly ingest cron did not run (when cron enabled) |
+| Backlog activity without recent ingest start | `process_cities_backlog` (or classify) running, but `ingest_cities_hourly` missed |
 | Stuck `classifying` / `downloading` / `extracting` > 15 min | Worker crashed mid-batch |
 | Classification `errors > 0` in last 2 h logs | Usually Postgres dialect / boolean bug |
 | `Maintenance step failed` / `ProgrammingError` in logs | SQL not portable to Postgres |
@@ -98,10 +99,13 @@ full alert rule reference.
 Allowed without a PR:
 
 ```bash
-# Reset stranded transient statuses
+# Reset stranded transient statuses / re-enqueue missing ingest / restart worker
 bash scripts/check-pipeline-health.sh --remediate
 
-# Re-enqueue classification / full pipeline
+# Manual equivalents (script already does these when --remediate):
+# - backlog_active_but_no_recent_ingest → enqueue ingest_cities_hourly
+# - no_recent_pipeline_run → enqueue ingest_cities_full_pipeline
+# - worker_heartbeat_missing / arq_queue_jammed → restart worker + clear locks
 docker compose -p prod exec -T api python - <<'PY'
 import asyncio
 from arq import create_pool
@@ -109,8 +113,7 @@ from arq.connections import RedisSettings
 
 async def main():
     redis = await create_pool(RedisSettings(host="redis", port=6379))
-    await redis.enqueue_job("classify_pending_task", 200, 10)
-    await redis.enqueue_job("ingest_cities_full_pipeline", None, "1h")
+    await redis.enqueue_job("ingest_cities_hourly", None, "1h")
 
 asyncio.run(main())
 PY

--- a/scripts/check-pipeline-health.sh
+++ b/scripts/check-pipeline-health.sh
@@ -285,6 +285,41 @@ PY
     return 0
 }
 
+_clear_missing_ingest_failures() {
+    filtered=()
+    for f in "${FAILURES[@]}"; do
+        [[ "$f" == no_recent_pipeline_run* ]] && continue
+        [[ "$f" == backlog_active_but_no_recent_ingest* ]] && continue
+        filtered+=("$f")
+    done
+    FAILURES=("${filtered[@]}")
+}
+
+tier_a_enqueue_ingest_hourly() {
+    # Prefer the short hourly ingest when backlog processing is already active.
+    echo_step "🔧 Tier-A: re-enqueueing ingest_cities_hourly..."
+    local job_id
+    if ! job_id="$(docker compose $COMPOSE_PROD exec -T api python - <<'PY'
+import asyncio
+from app.tasks.worker import create_arq_pool
+
+async def main():
+    redis = await create_arq_pool()
+    job = await redis.enqueue_job("ingest_cities_hourly", None, "1h")
+    print(job.job_id)
+    await redis.aclose()
+
+asyncio.run(main())
+PY
+)"; then
+        record_failure "remediate_enqueue_ingest_hourly_failed"
+        return 1
+    fi
+    DETAILS+=("REMEDIATE: enqueued_ingest_cities_hourly(job_id=${job_id})")
+    _clear_missing_ingest_failures
+    return 0
+}
+
 tier_a_enqueue_pipeline() {
     echo_step "🔧 Tier-A: re-enqueueing ingest_cities_full_pipeline..."
     local job_id
@@ -305,12 +340,7 @@ PY
         return 1
     fi
     DETAILS+=("REMEDIATE: enqueued_ingest_cities_full_pipeline(job_id=${job_id})")
-    filtered=()
-    for f in "${FAILURES[@]}"; do
-        [[ "$f" == no_recent_pipeline_run* ]] && continue
-        filtered+=("$f")
-    done
-    FAILURES=("${filtered[@]}")
+    _clear_missing_ingest_failures
     return 0
 }
 
@@ -332,34 +362,39 @@ tier_a_restart_worker() {
 
 if [ "$REMEDIATE" = true ]; then
     had_stuck=false
-    had_no_pipeline=false
+    had_missing_ingest=false
+    had_backlog_no_ingest=false
     had_no_heartbeat=false
     had_queue_jam=false
-    had_recent_ingest=false
     for f in "${FAILURES[@]:-}"; do
         if [[ "$f" == stuck_sources* ]]; then
             had_stuck=true
         elif [[ "$f" == no_recent_pipeline_run* ]]; then
-            had_no_pipeline=true
+            had_missing_ingest=true
+        elif [[ "$f" == backlog_active_but_no_recent_ingest* ]]; then
+            # Backlog/classify activity without a recent ingest start — still need ingest.
+            had_missing_ingest=true
+            had_backlog_no_ingest=true
         elif [[ "$f" == worker_heartbeat_missing* ]]; then
             had_no_heartbeat=true
         elif [[ "$f" == arq_queue_jammed* ]]; then
             had_queue_jam=true
         fi
     done
-    for d in "${DETAILS[@]:-}"; do
-        if [[ "$d" == OK:\ recent_ingest ]]; then
-            had_recent_ingest=true
-        fi
-    done
     if [ "$had_no_heartbeat" = true ] || [ "$had_queue_jam" = true ]; then
         tier_a_restart_worker || true
         tier_a_clear_arq_queue || true
     fi
-    if [ "$had_queue_jam" = true ] || { [ "$had_no_pipeline" = true ] && [ "$had_recent_ingest" = true ]; }; then
+    # Missing ingest always re-enqueues ingest (even when queue was also jammed).
+    # Previously queue-jam short-circuited to classify-only and left ingest stalled.
+    if [ "$had_missing_ingest" = true ]; then
+        if [ "$had_backlog_no_ingest" = true ]; then
+            tier_a_enqueue_ingest_hourly || true
+        else
+            tier_a_enqueue_pipeline || true
+        fi
+    elif [ "$had_queue_jam" = true ]; then
         tier_a_enqueue_classify || true
-    elif [ "$had_no_pipeline" = true ]; then
-        tier_a_enqueue_pipeline || true
     fi
     if [ "$had_stuck" = true ]; then
         echo_step "🔧 Tier-A: resetting stuck transient source statuses..."


### PR DESCRIPTION
## 📝 Descrição

On-call response to prod alert `backlog_active_but_no_recent_ingest(within_100m)` (2026-07-09T01:13Z).

**Root cause:** Tier-A `--remediate` ignored `backlog_active_but_no_recent_ingest`, so ingest was never re-enqueued while backlog/classify activity kept the check unhealthy. Diagnose runs with `--notify` re-fired the Cursor webhook and spawned concurrent agents that thrashed the worker.

**Note:** Related emergency fix [#85](https://github.com/JoaoCarabetta/arquivo-da-violencia/pull/85) already landed on `master` (restart thrash + backlog remediate). This PR brings the develop-path fix + diagnose `--notify` skip + workflow concurrency per AGENTS.md (`develop` → staging → `master`).

## 🏷️ Tipo de Mudança

- [x] 🐛 Bug fix
- [x] 🔧 Chore (CI)

## 🧪 Como Foi Testado?

- [x] `bash -n scripts/check-pipeline-health.sh`
- [x] Prod interim: master remediate run `28987375816` enqueued ingest; diagnose `28987556556` → `status=healthy`, `OK: recent_ingest`
- [x] Live metrics: `pipeline_worker_alive=1`, `queue_depth=0`

## ✅ Checklist

- [x] Minimal change
- [x] Docs updated (`docs/pipeline-auto-remediation.md`, `docs/cursor-automation-vps-ssh.md`)
- [ ] Staging verify after merge to develop

## 💬 Notas Adicionais

Prod is currently healthy. Merge this to develop to keep staging/master script parity and stop diagnose webhook storms. Prefer consolidating other duplicate on-call PRs (#87/#90/#94/…) into this path.