### PR TITLE
fix(pipeline-health): keep remediates from being cancelled by diagnose

### DIFF
--- a/.github/workflows/pipeline-health.yml
+++ b/.github/workflows/pipeline-health.yml
@@ -34,9 +34,10 @@ on:
         type: boolean
 
 concurrency:
-  # Prevent parallel remediates from restart-thrashing the worker.
+  # Serialize remediates so they cannot restart-thrash the worker in parallel.
+  # Do not cancel-in-progress: diagnose dispatches must not abort an active remediate.
   group: pipeline-health-prod
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   check-production:


### PR DESCRIPTION
Follow-up to #85: concurrency group with cancel-in-progress aborted remediates when diagnose was dispatched. Set cancel-in-progress=false.