### PR TITLE
fix(pipeline): port #85 health remediate fixes to develop

### DIFF
--- a/.github/workflows/pipeline-health.yml
+++ b/.github/workflows/pipeline-health.yml
@@ -33,28 +33,45 @@ on:
         default: false
         type: boolean
 
+concurrency:
+  # Prevent parallel remediates from restart-thrashing the worker.
+  group: pipeline-health-prod
+  cancel-in-progress: true
+
 jobs:
   check-production:
     name: Check prod pipeline on VPS
     runs-on: ubuntu-latest
     steps:
-      - name: Sync check script and run health check
+      - name: Checkout health script
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            scripts/check-pipeline-health.sh
+          sparse-checkout-cone-mode: false
+
+      - name: Sync check script to VPS
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.VPS_HOST }}
+          username: ${{ secrets.VPS_USER }}
+          key: ${{ secrets.VPS_SSH_KEY }}
+          source: "scripts/check-pipeline-health.sh"
+          target: "/root/arquivo-da-violencia"
+          overwrite: true
+
+      - name: Run health check
         uses: appleboy/ssh-action@v1.0.3
         with:
           host: ${{ secrets.VPS_HOST }}
           username: ${{ secrets.VPS_USER }}
           key: ${{ secrets.VPS_SSH_KEY }}
-          script_stop: true
+          # Keep going after health exit 1 so diagnose logs still print.
+          script_stop: false
+          command_timeout: 15m
           script: |
-            set -euo pipefail
+            set -uo pipefail
             cd /root/arquivo-da-violencia
-            BRANCH="master"
-            if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-              BRANCH="${{ github.ref_name }}"
-            fi
-            git fetch origin "$BRANCH"
-            git checkout -f "$BRANCH"
-            git reset --hard "origin/$BRANCH"
             export PIPELINE_HEALTH_WEBHOOK_AUTH="${{ secrets.CURSOR_AUTOMATION_TOKEN }}"
             ARGS="--notify --json"
             EVENT="${{ github.event_name }}"

--- a/docs/pipeline-auto-remediation.md
+++ b/docs/pipeline-auto-remediation.md
@@ -98,26 +98,23 @@ full alert rule reference.
 Allowed without a PR:
 
 ```bash
-# Reset stranded transient statuses
+# Reset stranded transient statuses, clear ARQ locks, re-enqueue as needed
 bash scripts/check-pipeline-health.sh --remediate
 
-# Re-enqueue classification / full pipeline
-docker compose -p prod exec -T api python - <<'PY'
-import asyncio
-from arq import create_pool
-from arq.connections import RedisSettings
-
-async def main():
-    redis = await create_pool(RedisSettings(host="redis", port=6379))
-    await redis.enqueue_job("classify_pending_task", 200, 10)
-    await redis.enqueue_job("ingest_cities_full_pipeline", None, "1h")
-
-asyncio.run(main())
-PY
-
-# Restart worker if heartbeat missing (after deploy)
+# Restart worker ONLY if Redis heartbeat key is missing
 docker compose -p prod restart worker
 ```
+
+`--remediate` mapping:
+
+| Failure | Action |
+|---------|--------|
+| `worker_heartbeat_missing` | Restart worker, wait for heartbeat, clear ARQ locks |
+| `arq_queue_jammed` | Clear ARQ locks + enqueue `classify_pending_task` (no restart) |
+| `no_recent_pipeline_run` / `backlog_active_but_no_recent_ingest` | Enqueue `ingest_cities_full_pipeline` |
+| `stuck_sources` | Reset transient statuses |
+
+Do **not** restart the worker for queue jam alone — that clears the heartbeat and can cascade into WorkerDown / remediates thrashing.
 
 ### Tier B — Code fix → PR to `develop`
 

--- a/scripts/check-pipeline-health.sh
+++ b/scripts/check-pipeline-health.sh
@@ -308,6 +308,7 @@ PY
     filtered=()
     for f in "${FAILURES[@]}"; do
         [[ "$f" == no_recent_pipeline_run* ]] && continue
+        [[ "$f" == backlog_active_but_no_recent_ingest* ]] && continue
         filtered+=("$f")
     done
     FAILURES=("${filtered[@]}")
@@ -321,6 +322,17 @@ tier_a_restart_worker() {
         return 1
     fi
     DETAILS+=("REMEDIATE: worker_restarted")
+    # Wait for Redis heartbeat so follow-up checks / concurrent remediates
+    # do not treat a graceful restart as another WorkerDown.
+    local i hb
+    for i in 1 2 3 4 5 6 7 8 9 10; do
+        sleep 3
+        hb="$(docker compose $COMPOSE_PROD exec -T redis redis-cli GET "$REDIS_HEALTH_KEY" 2>/dev/null | tr -d '\r' || true)"
+        if [ -n "$hb" ] && [ "$hb" != "(nil)" ]; then
+            DETAILS+=("OK: worker_heartbeat_after_restart")
+            break
+        fi
+    done
     filtered=()
     for f in "${FAILURES[@]}"; do
         [[ "$f" == worker_heartbeat_missing* ]] && continue
@@ -333,6 +345,7 @@ tier_a_restart_worker() {
 if [ "$REMEDIATE" = true ]; then
     had_stuck=false
     had_no_pipeline=false
+    had_stale_ingest=false
     had_no_heartbeat=false
     had_queue_jam=false
     had_recent_ingest=false
@@ -341,6 +354,8 @@ if [ "$REMEDIATE" = true ]; then
             had_stuck=true
         elif [[ "$f" == no_recent_pipeline_run* ]]; then
             had_no_pipeline=true
+        elif [[ "$f" == backlog_active_but_no_recent_ingest* ]]; then
+            had_stale_ingest=true
         elif [[ "$f" == worker_heartbeat_missing* ]]; then
             had_no_heartbeat=true
         elif [[ "$f" == arq_queue_jammed* ]]; then
@@ -352,13 +367,21 @@ if [ "$REMEDIATE" = true ]; then
             had_recent_ingest=true
         fi
     done
-    if [ "$had_no_heartbeat" = true ] || [ "$had_queue_jam" = true ]; then
+    # Restart ONLY when the Redis heartbeat is missing. Queue jam alone used to
+    # restart a healthy worker, which cleared the heartbeat and cascaded into
+    # WorkerDown / webhook remediates thrashing the container.
+    if [ "$had_no_heartbeat" = true ]; then
         tier_a_restart_worker || true
         tier_a_clear_arq_queue || true
+    elif [ "$had_queue_jam" = true ]; then
+        tier_a_clear_arq_queue || true
     fi
+    # Prefer classify when ingest recently started (or queue was jammed with
+    # ready backlog). Otherwise kick a full cities pipeline when cron/ingest
+    # has gone quiet — including backlog_active_but_no_recent_ingest.
     if [ "$had_queue_jam" = true ] || { [ "$had_no_pipeline" = true ] && [ "$had_recent_ingest" = true ]; }; then
         tier_a_enqueue_classify || true
-    elif [ "$had_no_pipeline" = true ]; then
+    elif [ "$had_no_pipeline" = true ] || [ "$had_stale_ingest" = true ]; then
         tier_a_enqueue_pipeline || true
     fi
     if [ "$had_stuck" = true ]; then


### PR DESCRIPTION
## 📝 Descrição

Ports production hotfix **#85** (already on `master`) onto `develop` so the next develop→master merge does not reintroduce the restart-thrash / missing-ingest remediate bugs.

Triggered by on-call alert `backlog_active_but_no_recent_ingest` (2026-07-09T01:13Z).

**Prod status (resolved):** `pipeline_worker_alive=1`, queue empty, diagnose `status=healthy` with `OK: recent_ingest`.

**This PR:**
- Enqueue `ingest_cities_full_pipeline` for `backlog_active_but_no_recent_ingest`
- Restart worker only when heartbeat missing (not on queue jam alone)
- Wait for heartbeat after restart
- Workflow concurrency + SCP script + `script_stop: false`
- Docs Tier-A mapping updated

**Overlap:** Prefer **#94** if it lands first (same core + notify-guard). Close this as duplicate in that case.

## 🏷️ Tipo de Mudança

- [x] 🐛 Bug fix
- [x] 📚 Documentação
- [x] 🔧 Chore (CI)

## 🧪 Como Foi Testado?

- [x] `bash -n scripts/check-pipeline-health.sh`
- Diff matches `origin/master` for the three files (post-#85)
- Live prod healthy after Tier-A