### PR TITLE
Add extend-extraction-schema Cursor skill

### DIFF
--- a/.cursor/skills/extend-extraction-schema/SKILL.md
+++ b/.cursor/skills/extend-extraction-schema/SKILL.md
@@ -1,0 +1,253 @@
+---
+name: extend-extraction-schema
+description: >-
+  Extends the Arquivo da Violência extraction JSON schema for homicide incidents:
+  decide if information already exists, add a new field built from existing
+  extraction, or add a new LLM-extracted field with correct JSON placement,
+  prompts, tests, and eval fixtures. Use when recording new facts about an
+  incident in ViolentDeathEvent / extraction_data. Not for portal UI or tasks
+  unrelated to recording homicide incidents in extraction.
+---
+
+# Extend Extraction Schema
+
+## Scope
+
+This skill covers **recording new information about homicide incidents** in the extraction JSON (`ViolentDeathEvent` → `raw_event.extraction_data`).
+
+**In scope:** JSON shape in `extraction_schemas.py`, LLM prompt rules, population rules, unit tests, eval fixtures.
+
+**Wrong skill — tell the user and stop** if the request is not about recording homicide incidents in extraction (e.g. portal UI, map filters, dedup, classification pipeline, infrastructure, non-homicide content).
+
+**Portal:** ask at the end whether the field should appear on the portal; do **not** change frontend files in this skill.
+
+---
+
+## Workflow — run in order
+
+Copy this checklist and work through it **with the user** before writing code.
+
+```
+Task progress:
+- [ ] 1. About recording homicide incidents in extraction? (if no → wrong skill)
+- [ ] 2. Already captured in extraction JSON?
+- [ ] 3. Can add a NEW field built from existing extraction? (preferred)
+- [ ] 4. Or needs new LLM extraction → new field + placement
+- [ ] 5. Prompt / population rule / eval / tests
+- [ ] 6. Ask: should this appear on the portal later? (no frontend work here)
+```
+
+### Step 1 — Right skill?
+
+Is the request about **recording new information about homicide incidents** in the extraction schema?
+
+→ **If no:** tell the user this is the **wrong skill** and stop. Common mismatches: portal or admin UI, map filters, export columns, dedup/enrichment, headline classification, database migrations unrelated to extraction JSON, or content outside violent-death homicide incidents.
+
+→ **If yes:** continue. The incident is usually a single case (`content_class = incident`); ask the user if unclear.
+
+### Step 2 — Already captured?
+
+Search the current extraction schema and prompt. Does the information already have a **typed** home?
+
+| Outcome | Action |
+|---------|--------|
+| Field exists and semantics match | **Done.** Tell the user where it lives (JSON path). Tune prompt/eval only if extraction quality is poor. |
+| Only mentioned in `chronological_description` or prose | **Not captured.** Continue — structured storage is still needed. |
+| Overlaps an existing field but semantics differ | Clarify with user; avoid duplicating columns/fields with different meanings. |
+
+Key existing areas: `event_subtype`, `victims.*`, `perpetrators.*`, `homicide_dynamic.*`, `location_info.*`, `date_time.*`, root flags on `ViolentDeathEvent`.
+
+### Step 3 — New field built from existing extraction (preferred)
+
+Can the value be determined **after** the LLM runs, from fields already extracted?
+
+→ Add a **new field** to the JSON shape, populated by a **rule** (e.g. `derive_*()` in `extraction.py`, or a Pydantic validator). **Do not** ask the LLM to extract this field directly.
+
+**Prefer this over Step 4** when the fact is logically computable from existing output.
+
+Example pattern: `security_force_involved` — new denormalized flag derived from victim/perp `is_security_force` lists.
+
+Steps:
+1. Add field to the correct model in `extraction_schemas.py`
+2. Implement population rule; call before persist
+3. Unit-test the rule
+4. Eval case asserting the field value (dotted path or indirect via full extraction)
+
+### Step 4 — New field needs LLM extraction
+
+The text must be read and interpreted; it cannot be reliably built from existing fields alone.
+
+1. **Place** the field (see [JSON placement](#json-placement) below)
+2. Add to `extraction_schemas.py` with a clear `Field(description=...)` — the description guides the LLM
+3. Add prompt rules in `extraction.py` (when to set true/false/null; disambiguation)
+4. For victim/perp fields: complete [identifiable vs unidentified](#identifiable-vs-unidentified) checklist with the user
+5. Always ask: should this live in `homicide_dynamic`? (default **no** for person attributes)
+
+Nested fields appear in `extraction_data` automatically via `model_dump()`. SQL columns are **not** part of this skill unless the user explicitly asks later.
+
+### Step 5 — Eval and tests
+
+| Action | Command / file |
+|--------|----------------|
+| Unit tests | `pytest tests/test_extraction_*.py tests/test_taxonomy.py -v` (as relevant) |
+| Validate fixture | `python -m eval extraction validate --fixture tests/fixtures/eval/<fixture>.json` |
+| Run case(s) | `python -m eval extraction run --fixture ... --ids <case-id> --output eval/results/<name>.json` |
+| Report | `python -m eval extraction report --run eval/results/<name>.json` |
+
+Export env before LLM eval runs:
+
+```bash
+cd backend && export $(grep -v '^#' ../.env | xargs)
+```
+
+Add eval cases with `scoring.required_fields` using dotted paths (e.g. `victims.identifiable_victims.0.<field>`, `homicide_dynamic.<field>`).
+
+→ Path examples: [reference.md](reference.md#eval-scoring-paths)
+
+### Step 6 — Portal (ask only)
+
+After schema and eval are settled, ask:
+
+> "Should this new field appear on the public portal (detail, export, filters)?"
+
+Note the answer for a **follow-up workflow**. Do **not** edit frontend or portal API files in this skill.
+
+---
+
+## Architecture (brief)
+
+```
+LLM prompt (extraction.py)
+    → ViolentDeathEvent (extraction_schemas.py)
+    → population rules (optional — Step 3)
+    → raw_event.extraction_data (JSON, always)
+```
+
+Full layer table → [reference.md](reference.md#data-layers)
+
+---
+
+## JSON placement
+
+```
+ViolentDeathEvent
+├── event_family / event_subtype     ← incident classification (existing)
+├── content_class
+├── location_info                    ← where
+├── date_time                        ← when
+├── victims
+│   ├── identifiable_victims[]
+│   ├── unidentified_groups[]
+│   └── number_of_* / number_of_victims
+├── perpetrators (optional)
+│   ├── identifiable_perpetrators[]
+│   ├── unidentified_groups[]
+│   └── number_of_* / number_of_perpetrators
+├── homicide_dynamic
+│   ├── title
+│   ├── method
+│   └── chronological_description    ← narrative only — not sole storage for typed facts
+└── additional_context               ← last resort prose
+```
+
+| Question | Place field |
+|----------|-------------|
+| Who (identity, role, employer, on-duty)? | `IdentifiableVictim` / `IdentifiablePerpetrator` or group models — **not** `homicide_dynamic` |
+| Event-level how (means, commission context, one value per incident)? | `homicide_dynamic` |
+| Where / when? | `location_info` / `date_time` |
+| Whole-event flag not covered above? | `ViolentDeathEvent` root |
+
+→ `homicide_dynamic` detail: [reference.md](reference.md#homicide_dynamic--ask-on-every-placement-review)
+
+### Placement checklist
+
+Copy with the user when adding any field:
+
+```
+- [ ] Already exists? (Step 2)
+- [ ] Built from existing extraction? (Step 3) vs LLM extraction? (Step 4)
+- [ ] IdentifiableVictim
+- [ ] UnidentifiedVictimGroup
+- [ ] IdentifiablePerpetrator
+- [ ] UnidentifiedPerpetratorGroup
+- [ ] homicide_dynamic — event-level HOW (not who)?
+- [ ] location_info / date_time
+- [ ] ViolentDeathEvent root
+- [ ] additional_context only (reject if a typed home exists above)
+- [ ] Prompt and/or population rule
+- [ ] Eval path(s) for each slot marked yes
+```
+
+---
+
+## Identifiable vs unidentified
+
+When the field is on **victims or perpetrators**, walk through all four slots with the user:
+
+| Model | When |
+|-------|------|
+| `IdentifiableVictim` | Each individually described victim |
+| `UnidentifiedVictimGroup` | Count + collective description only |
+| `IdentifiablePerpetrator` | Each individually described author |
+| `UnidentifiedPerpetratorGroup` | Unnamed author group |
+
+| Field kind | Identifiable* | Unidentified*Group |
+|------------|---------------|---------------------|
+| Name, age, gender, occupation | Yes | No — use `description` |
+| Booleans (`is_security_force`, `is_civilian`) | Yes | Yes |
+| Enums / detailed status | Yes, per person | Usually **no** — unless text describes whole group |
+
+Mirror across victim and perpetrator sides when the attribute applies to both.
+
+Population rules and eval must scan **identifiable lists and unidentified groups** on both sides.
+
+→ Worked examples: [examples.md](examples.md)
+
+---
+
+## Implementation checklist (Steps 3–5)
+
+### Path A — Built field (Step 3)
+
+- [ ] `extraction_schemas.py` — new field on correct model
+- [ ] `extraction.py` — `derive_*()` or post-extraction population; **no** LLM prompt for this field
+- [ ] Unit test for the rule
+- [ ] Eval fixture — assert field value
+
+### Path B — LLM-extracted field (Step 4)
+
+- [ ] `extraction_schemas.py` — `Field(description=...)`
+- [ ] `extraction.py` — prompt section (identifiable vs group wording for victim/perp fields)
+- [ ] Eval fixture — `scoring.required_fields` with dotted path(s)
+- [ ] Optional: smoke test on a real article
+
+### Common files
+
+| File | Path A | Path B |
+|------|--------|--------|
+| `backend/app/services/extraction_schemas.py` | ✓ | ✓ |
+| `backend/app/services/extraction.py` | population rule | prompt + rule if also derived |
+| `backend/tests/fixtures/eval/*.json` | ✓ | ✓ |
+| `backend/tests/test_extraction_*.py` | ✓ rule tests | as needed |
+
+**Do not change:** `frontend/**`, DB models/alembic (unless user explicitly requests SQL promotion outside this skill).
+
+---
+
+## What NOT to do
+
+| Mistake | Instead |
+|---------|---------|
+| New subtype for a person attribute | Victim/perp field (Step 4) or built field (Step 3) |
+| LLM extracts a field computable from existing data | Step 3 — new field + population rule |
+| Store typed facts only in `chronological_description` | Typed field in correct JSON slot |
+| Edit portal/frontend in this skill | Ask in Step 6; separate workflow |
+| Task not about recording homicide incidents | Tell user — wrong skill (Step 1) |
+
+---
+
+## Additional resources
+
+- File checklist, eval paths, model map → [reference.md](reference.md)
+- Worked examples → [examples.md](examples.md)
+- Eval CLI details → `backend/eval/README.md`

--- a/.cursor/skills/extend-extraction-schema/examples.md
+++ b/.cursor/skills/extend-extraction-schema/examples.md
@@ -1,0 +1,94 @@
+# Worked Examples
+
+Illustrative scenarios — see [SKILL.md](SKILL.md) for the main workflow (Steps 1–6).
+
+## Example 1: LLM-extracted victim field (Step 4)
+
+**Scenario:** capture that an individually described victim is a civil police officer killed off duty.
+
+**Step 1:** recording homicide incident information — in scope.
+
+**Step 2:** `is_security_force` exists; `security_agent_type` and `security_agent_on_duty` do not.
+
+**Step 3:** cannot build type/on-duty reliably from `is_security_force` alone — needs LLM (Step 4).
+
+### Placement
+
+| Slot | Decision |
+|------|----------|
+| `IdentifiableVictim` | Yes — `security_agent_type`, `security_agent_on_duty` |
+| `UnidentifiedVictimGroup` | N/A (victim individually described) |
+| `IdentifiablePerpetrator` | N/A (author unknown) |
+| `UnidentifiedPerpetratorGroup` | Optional if text only says "autores fugiram" |
+| `homicide_dynamic` | **No** — job/on-duty is not event dynamics |
+
+Use victim fields — not a new `event_subtype` for "police victim."
+
+### Eval snippet
+
+```json
+"scoring": {
+  "required_fields": [
+    "victims.identifiable_victims.0.is_security_force",
+    "victims.identifiable_victims.0.security_agent_type",
+    "victims.identifiable_victims.0.security_agent_on_duty"
+  ]
+}
+```
+
+**Step 6:** ask if portal should show "policial vitimado" — do not implement here.
+
+---
+
+## Example 1b: Unidentified victim group (Step 4)
+
+**Scenario:** "Dois policiais foram mortos em emboscada" — group only, no names.
+
+Use `unidentified_groups` with `is_security_force: true`. Do not put `security_agent_type` / `security_agent_on_duty` on the group unless the text describes the whole group that way.
+
+---
+
+## Example 2: Built field from existing extraction (Step 3)
+
+**Scenario:** expose `any_security_force_party: bool` on `ViolentDeathEvent` root — true if **any** victim or perpetrator (identifiable or group) has `is_security_force=true`.
+
+**Step 2:** `is_security_force` already extracted per party.
+
+**Step 3:** preferred — new JSON field + population rule; **no** LLM prompt for `any_security_force_party`.
+
+Similar existing pattern: `derive_security_force_involved()` at persist time.
+
+---
+
+## Example 3: Already captured (Step 2 — done)
+
+**User ask:** "Record that the victim was killed by firearm."
+
+**Answer:** `homicide_dynamic.method` = `"Arma de fogo"`. No new field. Improve prompt/eval only if extraction misses it.
+
+---
+
+## Example 4: Wrong skill (Step 1)
+
+**User ask:** "Add a filter on the map for off-duty police victims."
+
+→ **Wrong skill.** That is portal UI, not extraction JSON. Tell the user and stop (or note for a frontend workflow after a field exists).
+
+---
+
+## Example 5: `intervencao_policial` vs police victim
+
+| Article | `event_subtype` (existing field) | Victim fields (this skill) |
+|---------|----------------------------------|----------------------------|
+| "Suspeito neutralizado em operação da PM" | `intervencao_policial` | victim usually not police |
+| "Policial civil morto em Copacabana" | `simples` (or other) | `is_security_force`, `security_agent_type`, … |
+
+Direction matters: police as author vs police as victim.
+
+---
+
+## Anti-pattern: person attribute as subtype ✗
+
+> "Add subtype `police_victim` for homicides where the victim is a police officer"
+
+Use victim fields from Example 1 instead.

--- a/.cursor/skills/extend-extraction-schema/reference.md
+++ b/.cursor/skills/extend-extraction-schema/reference.md
@@ -1,0 +1,156 @@
+# Extend Extraction Schema — Reference
+
+Main workflow → [SKILL.md](SKILL.md). This file is lookup detail for JSON placement, eval paths, and file touchpoints.
+
+## Decision summary
+
+| Step | Question | Outcome |
+|------|----------|---------|
+| 1 | Recording homicide incidents in extraction? | If no → **wrong skill**, stop |
+| 2 | Already in JSON schema? | If yes → done (document path) |
+| 3 | New field **built** from existing extraction? | **Preferred** — new field + population rule, no LLM prompt for it |
+| 4 | Needs **LLM extraction**? | New field + prompt + placement |
+| 5 | Tests + eval fixtures | Required |
+| 6 | Portal exposure? | Ask only — separate workflow |
+
+**Built field vs LLM field:** both add a new campo to the JSON shape. A built field is filled by a rule after extraction; an LLM field is read from the article text.
+
+## Identifiable vs unidentified (victim / perpetrator)
+
+When adding or changing **any** victim or perpetrator field, prompt the user through **all four model slots**:
+
+| Model | When to use |
+|-------|-------------|
+| `IdentifiableVictim` | Each individually described victim |
+| `UnidentifiedVictimGroup` | Count + collective description only |
+| `IdentifiablePerpetrator` | Each individually described author |
+| `UnidentifiedPerpetratorGroup` | Unnamed author group |
+
+**Mirror** across victim and perpetrator sides when the attribute applies to both. **Group models** usually carry booleans (`is_security_force`, `is_civilian`) and `description`/`context` — not full per-person enums unless the text describes the whole group.
+
+**Eval:** at least one identifiable case; add an unidentified-group case if group fields changed.
+
+**Population rules:** scan `identifiable_*` lists **and** `unidentified_groups` on both victims and perpetrators.
+
+### `homicide_dynamic` — ask on every placement review
+
+| Field | Role |
+|-------|------|
+| `title` | Formatted technical headline — not for arbitrary new attributes |
+| `method` | `MethodOfDeath` enum — means of killing |
+| `chronological_description` | Required narrative — may repeat facts; **not** sole storage for typed data |
+| *new fields* | Event-level **how** (commission mode, context) — one value per incident |
+
+**Not for:** victim/perp identity, occupation, on-duty (use victim/perp models).
+
+**Ask:** "Should this live in `homicide_dynamic`?" — default **no** for person attributes; **yes** for incident-level dynamics.
+
+### Victim security-agent fields (example — proposed standard)
+
+On `IdentifiableVictim` and `IdentifiablePerpetrator` (when party is security force):
+
+| Field | Type | When to set |
+|-------|------|-------------|
+| `is_security_force` | `bool \| null` | **Exists.** True if PM/PC/PF/PRF/penal/guarda |
+| `security_agent_type` | `Literal["PM","PC","PF","PRF","penal","outro"] \| null` | Only when `is_security_force=true` |
+| `security_agent_on_duty` | `bool \| null` | Only when `is_security_force=true`; `true`=em serviço, `false`=folga, `null`=texto não diz |
+
+Mirror `is_security_force` on group models; type/on_duty only when individuals are identifiable.
+
+## Wrong skill (Step 1)
+
+Tell the user and stop if the request is **not** about recording homicide incidents in the extraction JSON — e.g. portal UI, dedup, enrichment, classification-only work, or non-homicide scope.
+
+Person attributes belong on victim/perp models, not as a substitute for unrelated tasks.
+
+## Portal / frontend — deferred
+
+Do not edit frontend in the extraction-schema skill. After Step 6, portal work may include (separate workflow):
+
+| Concern | Typical files |
+|---------|---------------|
+| Event detail | `EventDetailView.tsx`, `eventDetail.ts`, `public.py` |
+| Export | `exportColumns.ts` |
+| Map + filter + stats | `types.ts`, `RightPanel.tsx`, `public.py` `/map-points`, denormalized SQL columns |
+
+See git history or a future portal skill for tier patterns. SQL denormalization is only needed when the portal must filter or aggregate in SQL.
+
+## Data layers
+
+| Layer | Location | When to change |
+|-------|----------|----------------|
+| JSON shape | `extraction_schemas.py` | Any new field (built or LLM) |
+| LLM instructions | `extraction.py` system prompt | LLM-extracted fields only (Step 4) |
+| Population rules | `extraction.py` | Built fields (Step 3) |
+| Full extraction JSON | `raw_event.extraction_data` | Automatic via `model_dump()` |
+| Queryable SQL columns | `raw_event`, `unique_event` | **Out of scope** unless user requests separately |
+| Eval spec | `tests/fixtures/eval/*.json` | Regression cases |
+
+## Nested models in `extraction_schemas.py`
+
+| Model | Use for |
+|-------|---------|
+| `IdentifiableVictim` | name, age, gender, occupation, `is_security_force`, proposed `security_agent_*`, relationship |
+| `UnidentifiedVictimGroup` | count, description, `is_security_force`, `is_civilian`, context |
+| `IdentifiablePerpetrator` | same pattern as identifiable victim |
+| `UnidentifiedPerpetratorGroup` | same pattern as unidentified victim group |
+| `Location` | neighborhood, street, city, state, establishment |
+| `DateTime` / `DateVerification` | date extraction with verification |
+| `HomicideDynamic` | `title`, `method`, `chronological_description`; event-level **how** |
+| `ViolentDeathEvent` | root: `event_family`, `event_subtype`, victims, perpetrators, content_class |
+
+## File checklist — built field (Step 3)
+
+| File | Changes |
+|------|---------|
+| `backend/app/services/extraction_schemas.py` | New field on correct nested model |
+| `backend/app/services/extraction.py` | `derive_*()` or post-extraction population — **no** LLM prompt for this field |
+| `backend/tests/test_extraction_*.py` | Unit tests for rule |
+| `backend/tests/fixtures/eval/*.json` | Case asserting field value |
+
+## File checklist — LLM field (Step 4)
+
+| File | Changes |
+|------|---------|
+| `backend/app/services/extraction_schemas.py` | New `Field` with LLM-facing description |
+| `backend/app/services/extraction.py` | Prompt rules (identifiable vs group for victim/perp) |
+| `backend/tests/fixtures/eval/*.json` | `scoring.required_fields` with dotted paths |
+
+## Eval scoring paths
+
+Dotted paths used by `eval/stages/extraction/score.py`:
+
+```
+event_family
+event_subtype
+content_class
+date_time.date
+location_info.city
+location_info.state
+victims.number_of_victims
+victims.identifiable_victims.0.is_security_force
+victims.identifiable_victims.0.<new_field>
+victims.unidentified_groups.0.is_security_force
+homicide_dynamic.method
+homicide_dynamic.<new_field>
+```
+
+Update `eval/schemas_extraction.py` `DEFAULT_REQUIRED_FIELDS` only if the field should be scored on **all** cases by default.
+
+## Eval fixtures
+
+| Fixture | When |
+|---------|------|
+| `extraction_hard.json` | Full extraction with custom `required_fields` |
+| `extraction_seed.json` | Bootstrap from DB (hand-review labels) |
+
+## Validation commands
+
+```bash
+cd backend && export $(grep -v '^#' ../.env | xargs)
+
+pytest tests/test_extraction_*.py tests/test_eval_extraction.py -v
+python -m eval extraction validate --fixture tests/fixtures/eval/extraction_hard.json
+python -m eval extraction run --fixture tests/fixtures/eval/extraction_hard.json --ids <case-id> --output eval/results/test.json
+python -m eval extraction report --run eval/results/test.json
+```


### PR DESCRIPTION
## Summary
- Adds the `extend-extraction-schema` Cursor skill for recording new homicide incident facts in extraction JSON (`ViolentDeathEvent` / `extraction_data`).
- Documents the workflow: scope gate, check existing fields, prefer built fields from existing extraction, LLM-extracted fields with JSON placement, eval, and a portal follow-up question (no frontend changes in this skill).

## Test plan
- [x] Skill files present under `.cursor/skills/extend-extraction-schema/`
- [ ] Dry-run the skill on a sample extraction request


Made with [Cursor](https://cursor.com)