### PR TITLE
Release: pipeline batch CLI for safe stage re-runs

### DIFF
--- a/backend/app/services/batch_jobs.py
+++ b/backend/app/services/batch_jobs.py
@@ -1,0 +1,641 @@
+"""Batch pipeline re-run helpers (re-extract, re-enrich, re-geocode, drain)."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import date, datetime
+from typing import Any, Iterable, Sequence
+
+from loguru import logger
+from sqlalchemy import text
+from sqlmodel import select
+
+from app.database import async_session_maker
+from app.models import RawEvent
+from app.services.backfill import (
+    ReclassifySignal,
+    find_discarded_reclassification_candidates,
+    requeue_discarded_sources,
+)
+
+
+def _parse_ids(ids: Sequence[int] | None) -> list[int]:
+    if not ids:
+        return []
+    return [int(i) for i in ids]
+
+
+def _date_clause(
+    column: str,
+    *,
+    since: date | None,
+    until: date | None,
+    params: dict[str, Any],
+) -> str:
+    parts: list[str] = []
+    if since is not None:
+        params["since"] = since
+        parts.append(f"CAST({column} AS DATE) >= :since")
+    if until is not None:
+        params["until"] = until
+        parts.append(f"CAST({column} AS DATE) <= :until")
+    return (" AND " + " AND ".join(parts)) if parts else ""
+
+
+def _location_clause(
+    *,
+    city: str | None,
+    state: str | None,
+    params: dict[str, Any],
+    city_col: str = "city",
+    state_col: str = "state",
+) -> str:
+    parts: list[str] = []
+    if city:
+        params["city"] = city.strip().lower()
+        parts.append(f"LOWER({city_col}) = :city")
+    if state:
+        params["state"] = state.strip().lower()
+        parts.append(f"LOWER({state_col}) = :state")
+    return (" AND " + " AND ".join(parts)) if parts else ""
+
+
+def _ids_clause(
+    column: str,
+    ids: Sequence[int],
+    params: dict[str, Any],
+) -> str:
+    if not ids:
+        return ""
+    # Named bind list for SQLAlchemy text()
+    placeholders = []
+    for i, value in enumerate(ids):
+        key = f"id_{i}"
+        params[key] = value
+        placeholders.append(f":{key}")
+    return f" AND {column} IN ({', '.join(placeholders)})"
+
+
+# ---------------------------------------------------------------------------
+# Candidate selection: re-extract
+# ---------------------------------------------------------------------------
+
+
+async def find_reextract_candidates(
+    *,
+    limit: int = 100,
+    since: date | None = None,
+    until: date | None = None,
+    city: str | None = None,
+    state: str | None = None,
+    source_ids: Sequence[int] | None = None,
+) -> list[dict[str, Any]]:
+    """Return extracted sources eligible for in-place re-extraction."""
+    ids = _parse_ids(source_ids)
+    params: dict[str, Any] = {"lim": limit}
+    date_sql = _date_clause("re.event_date", since=since, until=until, params=params)
+    loc_sql = _location_clause(city=city, state=state, params=params, city_col="re.city", state_col="re.state")
+    ids_sql = _ids_clause("s.id", ids, params)
+
+    # Prefer the raw_event linked to a unique_event; else latest by id.
+    query = f"""
+        SELECT
+            s.id AS source_id,
+            s.headline,
+            s.publisher_name,
+            s.resolved_url,
+            s.published_at,
+            LENGTH(s.content) AS content_len,
+            re.id AS raw_event_id,
+            re.unique_event_id,
+            re.event_date,
+            re.city,
+            re.state,
+            re.title AS raw_title
+        FROM source_google_news s
+        INNER JOIN raw_event re ON re.id = (
+            SELECT r.id
+            FROM raw_event r
+            WHERE r.source_google_news_id = s.id
+            ORDER BY
+                CASE WHEN r.unique_event_id IS NOT NULL THEN 0 ELSE 1 END,
+                r.id DESC
+            LIMIT 1
+        )
+        WHERE s.status = 'extracted'
+          AND s.content IS NOT NULL
+          AND LENGTH(TRIM(s.content)) > 200
+          {date_sql}
+          {loc_sql}
+          {ids_sql}
+        ORDER BY re.event_date DESC, s.id DESC
+        LIMIT :lim
+    """
+    async with async_session_maker() as session:
+        result = await session.execute(text(query), params)
+        return [dict(row._mapping) for row in result.fetchall()]
+
+
+def _as_date(value: Any) -> date | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, date):
+        return value
+    if isinstance(value, str):
+        return date.fromisoformat(value[:10])
+    return None
+
+
+def dedup_keys_changed(candidate: dict[str, Any], fields: dict[str, Any]) -> bool:
+    """True when re-extract changed city/state/event_date (stale unique link risk)."""
+    old_city = (candidate.get("city") or "").strip().lower()
+    new_city = (fields.get("city") or "").strip().lower()
+    old_state = (candidate.get("state") or "").strip().lower()
+    new_state = (fields.get("state") or "").strip().lower()
+    return (
+        old_city != new_city
+        or old_state != new_state
+        or _as_date(candidate.get("event_date")) != _as_date(fields.get("event_date"))
+    )
+
+
+async def update_raw_event_in_place(
+    raw_event_id: int,
+    fields: dict[str, Any],
+    *,
+    unlink_for_rededup: bool = False,
+) -> None:
+    """Overwrite denormalized + JSON extraction columns on an existing raw_event."""
+    async with async_session_maker() as session:
+        result = await session.execute(
+            select(RawEvent).where(RawEvent.id == raw_event_id)
+        )
+        raw_event = result.scalar_one_or_none()
+        if raw_event is None:
+            raise ValueError(f"raw_event {raw_event_id} not found")
+        for key, value in fields.items():
+            setattr(raw_event, key, value)
+        if unlink_for_rededup:
+            raw_event.unique_event_id = None
+            raw_event.deduplication_status = "pending"
+        raw_event.updated_at = datetime.utcnow()
+        session.add(raw_event)
+        await session.commit()
+
+
+async def flag_unique_needs_enrichment(unique_event_ids: Iterable[int]) -> int:
+    ids = sorted({int(i) for i in unique_event_ids if i is not None})
+    if not ids:
+        return 0
+    params: dict[str, Any] = {}
+    ids_sql = _ids_clause("id", ids, params).replace(" AND ", "", 1)
+    async with async_session_maker() as session:
+        result = await session.execute(
+            text(f"""
+                UPDATE unique_event
+                SET needs_enrichment = true,
+                    updated_at = CURRENT_TIMESTAMP
+                WHERE {ids_sql}
+            """),
+            params,
+        )
+        await session.commit()
+        return result.rowcount or 0
+
+
+async def refresh_unique_source_counts(unique_event_ids: Iterable[int]) -> int:
+    """Recompute source_count from currently linked raw_events and flag enrichment."""
+    ids = sorted({int(i) for i in unique_event_ids if i is not None})
+    if not ids:
+        return 0
+    params: dict[str, Any] = {}
+    ids_sql = _ids_clause("id", ids, params).replace(" AND ", "", 1)
+    async with async_session_maker() as session:
+        result = await session.execute(
+            text(f"""
+                UPDATE unique_event u
+                SET source_count = (
+                        SELECT COUNT(*) FROM raw_event r
+                        WHERE r.unique_event_id = u.id
+                    ),
+                    needs_enrichment = true,
+                    updated_at = CURRENT_TIMESTAMP
+                WHERE {ids_sql}
+            """),
+            params,
+        )
+        await session.commit()
+        return result.rowcount or 0
+
+
+async def reextract_sources(
+    *,
+    dry_run: bool = True,
+    limit: int = 100,
+    since: date | None = None,
+    until: date | None = None,
+    city: str | None = None,
+    state: str | None = None,
+    source_ids: Sequence[int] | None = None,
+    concurrency: int = 5,
+) -> dict[str, Any]:
+    """In-place re-extract for already-extracted sources (no new raw_event rows)."""
+    from app.config import get_settings
+    from app.services.extraction import (
+        extract_event_from_content,
+        raw_event_fields_from_event,
+    )
+
+    settings = get_settings()
+    candidates = await find_reextract_candidates(
+        limit=limit,
+        since=since,
+        until=until,
+        city=city,
+        state=state,
+        source_ids=source_ids,
+    )
+    audit: dict[str, Any] = {
+        "dry_run": dry_run,
+        "candidate_count": len(candidates),
+        "updated": 0,
+        "failed": 0,
+        "would_discard": 0,
+        "unlinked_for_rededup": 0,
+        "flagged_enrichment": 0,
+        "samples": [
+            {
+                "source_id": c["source_id"],
+                "raw_event_id": c["raw_event_id"],
+                "unique_event_id": c.get("unique_event_id"),
+                "city": c.get("city"),
+                "event_date": str(c["event_date"]) if c.get("event_date") else None,
+                "headline": (c.get("headline") or "")[:120],
+            }
+            for c in candidates[:50]
+        ],
+        "failures": [],
+        "would_discard_ids": [],
+    }
+    if dry_run or not candidates:
+        return audit
+
+    semaphore = asyncio.Semaphore(concurrency)
+    flagged: list[int] = []
+    unlinked_parent_ids: list[int] = []
+    unlinked = 0
+
+    async def _one(candidate: dict[str, Any]) -> str:
+        nonlocal unlinked
+        source_id = candidate["source_id"]
+        raw_event_id = candidate["raw_event_id"]
+        async with semaphore:
+            async with async_session_maker() as session:
+                row = (
+                    await session.execute(
+                        text("""
+                            SELECT content, headline, published_at, publisher_name, resolved_url
+                            FROM source_google_news
+                            WHERE id = :id
+                        """),
+                        {"id": source_id},
+                    )
+                ).fetchone()
+            if not row or not row[0]:
+                return "failed"
+
+            content, headline, published_at, publisher_name, resolved_url = row
+            original_length = len(content)
+            if original_length > settings.extraction_max_chars:
+                logger.info(
+                    f"[batch reextract] Truncating source {source_id} content from "
+                    f"{original_length} to {settings.extraction_max_chars} chars"
+                )
+                content = content[: settings.extraction_max_chars]
+            metadata = {
+                "headline": headline,
+                "publisher": publisher_name,
+                "url": resolved_url,
+            }
+            if published_at:
+                try:
+                    pub = published_at
+                    if isinstance(pub, str):
+                        pub = datetime.fromisoformat(pub.replace("Z", "+00:00"))
+                    metadata["published_at"] = pub.strftime("%d/%m/%Y às %H:%M")
+                except Exception:
+                    metadata["published_at"] = str(published_at)
+
+            try:
+                event = await asyncio.to_thread(
+                    extract_event_from_content, content, metadata
+                )
+            except Exception as exc:
+                logger.warning(f"[batch reextract] source {source_id} failed: {exc}")
+                audit["failures"].append(
+                    {"source_id": source_id, "error": str(exc)[:300]}
+                )
+                return "failed"
+
+            if str(event.content_class) != "incident":
+                audit["would_discard_ids"].append(source_id)
+                return "would_discard"
+
+            fields = raw_event_fields_from_event(event)
+            prior_unique_id = candidate.get("unique_event_id")
+            must_unlink = bool(prior_unique_id) and dedup_keys_changed(candidate, fields)
+            await update_raw_event_in_place(
+                raw_event_id, fields, unlink_for_rededup=must_unlink
+            )
+            if must_unlink and prior_unique_id:
+                unlinked += 1
+                unlinked_parent_ids.append(int(prior_unique_id))
+            elif prior_unique_id:
+                flagged.append(int(prior_unique_id))
+            return "updated"
+
+    results = await asyncio.gather(
+        *[_one(c) for c in candidates],
+        return_exceptions=True,
+    )
+    normalized: list[str] = []
+    for candidate, result in zip(candidates, results, strict=True):
+        if isinstance(result, Exception):
+            logger.warning(
+                f"[batch reextract] source {candidate['source_id']} "
+                f"raised: {result}"
+            )
+            audit["failures"].append(
+                {
+                    "source_id": candidate["source_id"],
+                    "error": str(result)[:300],
+                }
+            )
+            normalized.append("failed")
+        else:
+            normalized.append(result)
+
+    audit["updated"] = sum(1 for r in normalized if r == "updated")
+    audit["failed"] = sum(1 for r in normalized if r == "failed")
+    audit["would_discard"] = sum(1 for r in normalized if r == "would_discard")
+    audit["unlinked_for_rededup"] = unlinked
+    # Always reconcile parents after per-item commits (even if some tasks failed).
+    refreshed = await refresh_unique_source_counts(unlinked_parent_ids)
+    flagged_only = await flag_unique_needs_enrichment(flagged)
+    audit["flagged_enrichment"] = refreshed + flagged_only
+    return audit
+
+
+# ---------------------------------------------------------------------------
+# Re-enrich / re-geocode
+# ---------------------------------------------------------------------------
+
+
+async def find_unique_event_ids(
+    *,
+    limit: int = 500,
+    since: date | None = None,
+    until: date | None = None,
+    city: str | None = None,
+    state: str | None = None,
+    unique_event_ids: Sequence[int] | None = None,
+) -> list[int]:
+    ids = _parse_ids(unique_event_ids)
+    params: dict[str, Any] = {"lim": limit}
+    date_sql = _date_clause("event_date", since=since, until=until, params=params)
+    loc_sql = _location_clause(city=city, state=state, params=params)
+    ids_sql = _ids_clause("id", ids, params)
+    query = f"""
+        SELECT id FROM unique_event
+        WHERE 1=1
+          {date_sql}
+          {loc_sql}
+          {ids_sql}
+        ORDER BY event_date DESC, id DESC
+        LIMIT :lim
+    """
+    async with async_session_maker() as session:
+        result = await session.execute(text(query), params)
+        return [row[0] for row in result.fetchall()]
+
+
+async def flag_reenrich(
+    *,
+    dry_run: bool = True,
+    limit: int = 500,
+    since: date | None = None,
+    until: date | None = None,
+    city: str | None = None,
+    state: str | None = None,
+    unique_event_ids: Sequence[int] | None = None,
+) -> dict[str, Any]:
+    ids = await find_unique_event_ids(
+        limit=limit,
+        since=since,
+        until=until,
+        city=city,
+        state=state,
+        unique_event_ids=unique_event_ids,
+    )
+    audit: dict[str, Any] = {
+        "dry_run": dry_run,
+        "candidate_count": len(ids),
+        "flagged": 0,
+        "unique_event_ids": ids[:100],
+    }
+    if dry_run or not ids:
+        return audit
+    audit["flagged"] = await flag_unique_needs_enrichment(ids)
+    return audit
+
+
+async def clear_geocode_for_requeue(
+    unique_event_ids: Sequence[int],
+) -> int:
+    ids = _parse_ids(unique_event_ids)
+    if not ids:
+        return 0
+    params: dict[str, Any] = {}
+    ids_sql = _ids_clause("id", ids, params).replace(" AND ", "", 1)
+    async with async_session_maker() as session:
+        result = await session.execute(
+            text(f"""
+                UPDATE unique_event
+                SET geocoding_source = NULL,
+                    latitude = NULL,
+                    longitude = NULL,
+                    plus_code = NULL,
+                    place_id = NULL,
+                    formatted_address = NULL,
+                    location_precision = NULL,
+                    geocoding_confidence = NULL,
+                    updated_at = CURRENT_TIMESTAMP
+                WHERE {ids_sql}
+            """),
+            params,
+        )
+        await session.commit()
+        return result.rowcount or 0
+
+
+async def flag_regeocode(
+    *,
+    dry_run: bool = True,
+    limit: int = 500,
+    since: date | None = None,
+    until: date | None = None,
+    city: str | None = None,
+    state: str | None = None,
+    unique_event_ids: Sequence[int] | None = None,
+) -> dict[str, Any]:
+    ids = await find_unique_event_ids(
+        limit=limit,
+        since=since,
+        until=until,
+        city=city,
+        state=state,
+        unique_event_ids=unique_event_ids,
+    )
+    audit: dict[str, Any] = {
+        "dry_run": dry_run,
+        "candidate_count": len(ids),
+        "cleared": 0,
+        "unique_event_ids": ids[:100],
+    }
+    if dry_run or not ids:
+        return audit
+    audit["cleared"] = await clear_geocode_for_requeue(ids)
+    return audit
+
+
+# ---------------------------------------------------------------------------
+# Reclassify wrapper
+# ---------------------------------------------------------------------------
+
+
+async def run_reclassify(
+    *,
+    dry_run: bool = True,
+    limit: int = 500,
+    since: date | None = None,
+    signal: ReclassifySignal = "all",
+) -> dict[str, Any]:
+    candidates = await find_discarded_reclassification_candidates(
+        limit=limit,
+        since=since,
+        signal=signal,
+    )
+    source_ids = [row["id"] for row in candidates]
+    audit = await requeue_discarded_sources(source_ids, dry_run=dry_run)
+    audit["candidate_count"] = len(candidates)
+    audit["signal"] = signal
+    audit["samples"] = [
+        {
+            "id": row["id"],
+            "headline": (row.get("headline") or "")[:120],
+            "target_status": row["target_status"],
+        }
+        for row in candidates[:50]
+    ]
+    return audit
+
+
+# ---------------------------------------------------------------------------
+# Drain / recollect enqueue
+# ---------------------------------------------------------------------------
+
+DRAIN_DEFAULTS = {
+    "classify": {"limit": 300, "concurrency": 10},
+    "download": {"limit": 200},
+    "extract": {"limit": 100},
+    "dedup": {"limit": 200},
+    "enrich": {"limit": 50},
+    "geocode": {"limit": 200},
+}
+
+ALL_DRAIN_STAGES = ("classify", "download", "extract", "dedup", "enrich", "geocode")
+
+
+async def enqueue_drain(
+    stages: Sequence[str] | None = None,
+    *,
+    limits: dict[str, int] | None = None,
+) -> dict[str, Any]:
+    """Enqueue backlog drain jobs on the namespaced ARQ queue."""
+    from app.tasks.worker import create_arq_pool, get_arq_queue_name
+
+    selected = list(stages) if stages else list(ALL_DRAIN_STAGES)
+    unknown = [s for s in selected if s not in DRAIN_DEFAULTS]
+    if unknown:
+        raise ValueError(f"Unknown drain stages: {unknown}")
+
+    limits = limits or {}
+    redis = await create_arq_pool()
+    enqueued: list[str] = []
+    try:
+        for stage in selected:
+            defaults = DRAIN_DEFAULTS[stage]
+            limit = int(limits.get(stage, defaults["limit"]))
+            if stage == "classify":
+                await redis.enqueue_job(
+                    "classify_pending_task",
+                    limit=limit,
+                    chain_next=False,
+                    concurrency=int(defaults.get("concurrency", 10)),
+                )
+            elif stage == "download":
+                await redis.enqueue_job(
+                    "download_classified_task", limit=limit, chain_next=False
+                )
+            elif stage == "extract":
+                await redis.enqueue_job(
+                    "extract_ready_task", limit=limit, chain_next=False
+                )
+            elif stage == "dedup":
+                await redis.enqueue_job(
+                    "batch_dedup_task", limit=limit, chain_next=False
+                )
+            elif stage == "enrich":
+                await redis.enqueue_job(
+                    "batch_enrich_task", limit=limit, chain_next=False
+                )
+            elif stage == "geocode":
+                await redis.enqueue_job("batch_geocode_task", limit=limit)
+            enqueued.append(f"{stage}:{limit}")
+    finally:
+        await redis.close()
+
+    return {
+        "queue": get_arq_queue_name(),
+        "enqueued": enqueued,
+    }
+
+
+async def enqueue_recollect(
+    *,
+    when: str = "1d",
+    full_pipeline: bool = False,
+) -> dict[str, Any]:
+    from app.tasks.worker import create_arq_pool, get_arq_queue_name
+
+    redis = await create_arq_pool()
+    try:
+        if full_pipeline:
+            job = await redis.enqueue_job(
+                "ingest_cities_full_pipeline", when=when
+            )
+            task = "ingest_cities_full_pipeline"
+        else:
+            job = await redis.enqueue_job("ingest_cities_task", when=when)
+            task = "ingest_cities_task"
+    finally:
+        await redis.close()
+
+    return {
+        "queue": get_arq_queue_name(),
+        "task": task,
+        "when": when,
+        "job_id": getattr(job, "job_id", None),
+    }

--- a/backend/app/services/extraction.py
+++ b/backend/app/services/extraction.py
@@ -300,6 +300,49 @@ def extract_event_from_content(
     return apply_extraction_heuristics(event, content, metadata)
 
 
+def raw_event_fields_from_event(event: ViolentDeathEvent) -> dict:
+    """Map a ViolentDeathEvent to denormalized RawEvent column values.
+
+    Shared by forward insert (`extract_source`) and in-place re-extract
+    (`batch_jobs.reextract_sources`) so both paths stay aligned.
+    """
+    event_date = None
+    if event.date_time.date:
+        try:
+            event_date = datetime.strptime(event.date_time.date, "%Y-%m-%d")
+        except ValueError:
+            logger.warning(f"Could not parse date: {event.date_time.date}")
+
+    return {
+        "event_date": event_date,
+        "date_precision": event.date_time.date_precision,
+        "time_of_day": event.date_time.time_of_day,
+        "city": event.location_info.city,
+        "state": event.location_info.state,
+        "neighborhood": event.location_info.neighborhood,
+        "victim_count": event.victims.number_of_victims,
+        "identified_victim_count": event.victims.number_of_identifiable_victims,
+        "perpetrator_count": (
+            event.perpetrators.number_of_perpetrators if event.perpetrators else None
+        ),
+        "security_force_involved": derive_security_force_involved(event),
+        "security_force_victim": derive_security_force_victim(event),
+        "event_family": event.event_family,
+        "event_subtype": event.event_subtype,
+        "homicide_type": format_legacy_homicide_type(
+            event.event_family, event.event_subtype
+        ),
+        "method_of_death": event.homicide_dynamic.method,
+        "title": event.homicide_dynamic.title,
+        "chronological_description": event.homicide_dynamic.chronological_description,
+        "content_class": str(event.content_class),
+        "extraction_data": event.model_dump(),
+        "extraction_model": get_settings().extraction_model,
+        "extraction_success": True,
+        "extraction_error": None,
+    }
+
+
 def _build_extraction_prompt(content: str, metadata: dict | None = None) -> str:
     """
     Build the extraction prompt with metadata context.
@@ -507,47 +550,13 @@ async def extract_source(source_id: int) -> RawEvent | None:
         )
         return None
 
-    security_force_involved = derive_security_force_involved(event)
-    security_force_victim = derive_security_force_victim(event)
-
-    event_data = event.model_dump()
-
-    # Parse date string to datetime if present
-    event_date = None
-    if event.date_time.date:
-        try:
-            from datetime import datetime as dt
-            event_date = dt.strptime(event.date_time.date, "%Y-%m-%d")
-        except ValueError:
-            logger.warning(f"Could not parse date: {event.date_time.date}")
+    fields = raw_event_fields_from_event(event)
 
     # Step 3: persist the RawEvent in a fresh short-lived session.
     async with async_session_maker() as session:
         raw_event = RawEvent(
             source_google_news_id=source_id,
-            # Denormalized queryable fields
-            event_date=event_date,
-            date_precision=event.date_time.date_precision,
-            time_of_day=event.date_time.time_of_day,
-            city=event.location_info.city,
-            state=event.location_info.state,
-            neighborhood=event.location_info.neighborhood,
-            victim_count=event.victims.number_of_victims,
-            identified_victim_count=event.victims.number_of_identifiable_victims,
-            perpetrator_count=event.perpetrators.number_of_perpetrators if event.perpetrators else None,
-            security_force_involved=security_force_involved,
-            security_force_victim=security_force_victim,
-            event_family=event.event_family,
-            event_subtype=event.event_subtype,
-            homicide_type=format_legacy_homicide_type(event.event_family, event.event_subtype),
-            method_of_death=event.homicide_dynamic.method,
-            title=event.homicide_dynamic.title,
-            chronological_description=event.homicide_dynamic.chronological_description,
-            content_class=str(event.content_class),
-            # Full structured data as JSON
-            extraction_data=event_data,
-            extraction_model=get_settings().extraction_model,
-            extraction_success=True,
+            **fields,
         )
 
         session.add(raw_event)

--- a/backend/scripts/enqueue_backfill_pipeline.py
+++ b/backend/scripts/enqueue_backfill_pipeline.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Enqueue pipeline jobs after backfill requeue."""
+"""Enqueue pipeline jobs after backfill requeue (namespaced ARQ queue)."""
 
 from __future__ import annotations
 
@@ -11,15 +11,12 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 
 async def main() -> None:
-    from arq import create_pool
-    from arq.connections import RedisSettings
+    from app.services.batch_jobs import enqueue_drain
 
-    redis = await create_pool(RedisSettings(host="redis", port=6379))
-    await redis.enqueue_job("classify_pending_task", 300, 10)
-    await redis.enqueue_job("download_classified_task", 200)
-    await redis.enqueue_job("extract_ready_task", 100)
-    await redis.enqueue_job("batch_enrich_task", 50)
-    print("Pipeline jobs enqueued")
+    result = await enqueue_drain(
+        stages=["classify", "download", "extract", "enrich"],
+    )
+    print(f"Pipeline jobs enqueued on {result['queue']}: {result['enqueued']}")
 
 
 if __name__ == "__main__":

--- a/backend/scripts/pipeline_batch.py
+++ b/backend/scripts/pipeline_batch.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""Unified CLI for pipeline batch re-runs (reclassify, reextract, reenrich, …).
+
+Usage (inside api container):
+
+    python scripts/pipeline_batch.py reextract --since 2026-01-01 --dry-run
+    python scripts/pipeline_batch.py reextract --ids 12,34 --execute --enqueue
+    python scripts/pipeline_batch.py reenrich --city "Rio de Janeiro" --execute
+    python scripts/pipeline_batch.py drain --stages enrich,geocode
+    python scripts/pipeline_batch.py recollect --when 1d --full
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from datetime import date
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from app.services import batch_jobs
+
+
+def _parse_since(value: str | None) -> date | None:
+    if not value:
+        return None
+    return date.fromisoformat(value)
+
+
+def _parse_ids(value: str | None) -> list[int] | None:
+    if not value:
+        return None
+    parts = [p.strip() for p in value.split(",") if p.strip()]
+    return [int(p) for p in parts]
+
+
+def _add_mode(parser: argparse.ArgumentParser) -> None:
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--dry-run", action="store_true", help="Report only")
+    mode.add_argument("--execute", action="store_true", help="Apply changes")
+
+
+def _add_common_filters(parser: argparse.ArgumentParser, *, ids_help: str) -> None:
+    parser.add_argument("--since", default=None, help="YYYY-MM-DD lower bound")
+    parser.add_argument("--until", default=None, help="YYYY-MM-DD upper bound (inclusive)")
+    parser.add_argument("--city", default=None, help="Filter by city (exact, case-insensitive)")
+    parser.add_argument("--state", default=None, help="Filter by state (exact, case-insensitive)")
+    parser.add_argument("--ids", default=None, help=ids_help)
+    parser.add_argument("--limit", type=int, default=None, help="Max rows")
+    parser.add_argument(
+        "--enqueue",
+        action="store_true",
+        help="After execute, enqueue matching drain jobs",
+    )
+    parser.add_argument("--json", action="store_true", help="Print JSON audit")
+
+
+def _print_audit(audit: dict, *, json_mode: bool, label: str) -> None:
+    if json_mode:
+        print(json.dumps(audit, ensure_ascii=False, indent=2, default=str))
+        return
+    print(f"[{label}] {json.dumps(audit, ensure_ascii=False, default=str)}")
+
+
+async def _maybe_enqueue_after(
+    command: str,
+    *,
+    enqueue: bool,
+    execute: bool,
+) -> dict | None:
+    if not enqueue or not execute:
+        return None
+    if command == "reextract":
+        # Dedup first for any unlinked raws; enrich for still-linked uniques.
+        return await batch_jobs.enqueue_drain(stages=["dedup", "enrich"])
+    if command == "reenrich":
+        return await batch_jobs.enqueue_drain(stages=["enrich"])
+    if command == "regeocode":
+        return await batch_jobs.enqueue_drain(stages=["geocode"])
+    if command == "reclassify":
+        return await batch_jobs.enqueue_drain(
+            stages=["classify", "download", "extract", "dedup", "enrich"]
+        )
+    return None
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Pipeline batch re-run toolkit (Docker/API container)."
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    # reclassify
+    p = sub.add_parser("reclassify", help="Requeue discarded false-negative sources")
+    _add_mode(p)
+    p.add_argument(
+        "--signal",
+        choices=("all", "death_keywords", "heuristic_true", "false_negative"),
+        default="all",
+    )
+    p.add_argument("--since", default=None, help="Filter discarded by updated_at >= date")
+    p.add_argument("--limit", type=int, default=500)
+    p.add_argument("--enqueue", action="store_true")
+    p.add_argument("--json", action="store_true")
+
+    # reextract
+    p = sub.add_parser("reextract", help="In-place re-extract already-extracted sources")
+    _add_mode(p)
+    _add_common_filters(p, ids_help="Comma-separated source_google_news ids")
+    p.add_argument("--concurrency", type=int, default=5)
+
+    # reenrich
+    p = sub.add_parser("reenrich", help="Flag unique_events for batch enrichment")
+    _add_mode(p)
+    _add_common_filters(p, ids_help="Comma-separated unique_event ids")
+
+    # regeocode
+    p = sub.add_parser("regeocode", help="Clear geocode so backlog can retry")
+    _add_mode(p)
+    _add_common_filters(p, ids_help="Comma-separated unique_event ids")
+
+    # drain
+    p = sub.add_parser("drain", help="Enqueue backlog drain jobs on namespaced queue")
+    p.add_argument(
+        "--stages",
+        default=",".join(batch_jobs.ALL_DRAIN_STAGES),
+        help="Comma-separated: classify,download,extract,dedup,enrich,geocode",
+    )
+    p.add_argument("--json", action="store_true")
+
+    # recollect
+    p = sub.add_parser("recollect", help="Enqueue city RSS ingest (when= window)")
+    p.add_argument("--when", default="1d", help="Google News when window (e.g. 1h, 1d, 7d)")
+    p.add_argument(
+        "--full",
+        action="store_true",
+        help="Use ingest_cities_full_pipeline instead of ingest only",
+    )
+    p.add_argument("--json", action="store_true")
+
+    return parser
+
+
+async def _run(args: argparse.Namespace) -> dict:
+    command = args.command
+
+    if command == "drain":
+        stages = [s.strip() for s in args.stages.split(",") if s.strip()]
+        return await batch_jobs.enqueue_drain(stages=stages)
+
+    if command == "recollect":
+        return await batch_jobs.enqueue_recollect(
+            when=args.when,
+            full_pipeline=args.full,
+        )
+
+    dry_run = bool(args.dry_run)
+    since = _parse_since(getattr(args, "since", None))
+    until = _parse_since(getattr(args, "until", None))
+    ids = _parse_ids(getattr(args, "ids", None))
+
+    if command == "reclassify":
+        audit = await batch_jobs.run_reclassify(
+            dry_run=dry_run,
+            limit=args.limit,
+            since=since,
+            signal=args.signal,
+        )
+    elif command == "reextract":
+        audit = await batch_jobs.reextract_sources(
+            dry_run=dry_run,
+            limit=args.limit if args.limit is not None else 100,
+            since=since,
+            until=until,
+            city=args.city,
+            state=args.state,
+            source_ids=ids,
+            concurrency=args.concurrency,
+        )
+    elif command == "reenrich":
+        audit = await batch_jobs.flag_reenrich(
+            dry_run=dry_run,
+            limit=args.limit if args.limit is not None else 500,
+            since=since,
+            until=until,
+            city=args.city,
+            state=args.state,
+            unique_event_ids=ids,
+        )
+    elif command == "regeocode":
+        audit = await batch_jobs.flag_regeocode(
+            dry_run=dry_run,
+            limit=args.limit if args.limit is not None else 500,
+            since=since,
+            until=until,
+            city=args.city,
+            state=args.state,
+            unique_event_ids=ids,
+        )
+    else:
+        raise SystemExit(f"Unknown command: {command}")
+
+    enqueued = await _maybe_enqueue_after(
+        command, enqueue=bool(getattr(args, "enqueue", False)), execute=not dry_run
+    )
+    if enqueued is not None:
+        audit["enqueued"] = enqueued
+    return audit
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+    audit = asyncio.run(_run(args))
+    label = "DRY-RUN" if getattr(args, "dry_run", False) else "EXECUTE"
+    if args.command in ("drain", "recollect"):
+        label = "ENQUEUE"
+    _print_audit(audit, json_mode=bool(getattr(args, "json", False)), label=label)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/test_batch_jobs.py
+++ b/backend/tests/test_batch_jobs.py
@@ -1,0 +1,372 @@
+"""Tests for pipeline batch job helpers."""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.batch_jobs import (
+    ALL_DRAIN_STAGES,
+    _date_clause,
+    _ids_clause,
+    _location_clause,
+    _parse_ids,
+    clear_geocode_for_requeue,
+    dedup_keys_changed,
+    enqueue_drain,
+    flag_unique_needs_enrichment,
+    reextract_sources,
+    update_raw_event_in_place,
+)
+from app.services.extraction import raw_event_fields_from_event
+from app.services.extraction_schemas import (
+    DateTime,
+    DateVerification,
+    HomicideDynamic,
+    Location,
+    Victims,
+    ViolentDeathEvent,
+)
+
+
+def _minimal_event(
+    *,
+    content_class: str = "incident",
+    title: str = "Homem é morto a tiros",
+    event_date: str | None = "2026-03-15",
+) -> ViolentDeathEvent:
+    return ViolentDeathEvent(
+        event_family="homicidio",
+        event_subtype="simples",
+        content_class=content_class,  # type: ignore[arg-type]
+        location_info=Location(city="São Paulo", state="SP", neighborhood="Centro"),
+        date_time=DateTime(
+            date_verification=DateVerification(
+                has_explicit_date=bool(event_date),
+                date_source="explicit" if event_date else "none",
+                year_explicitly_mentioned=bool(event_date),
+                verification_reasoning="test",
+            ),
+            date=event_date,
+            date_precision="exata" if event_date else "não informada",
+        ),
+        victims=Victims(
+            identifiable_victims=[],
+            number_of_identifiable_victims=0,
+            number_of_victims=1,
+        ),
+        homicide_dynamic=HomicideDynamic(
+            title=title,
+            chronological_description="Vítima foi alvejada.",
+            method="Arma de fogo",
+        ),
+    )
+
+
+def test_parse_ids_empty():
+    assert _parse_ids(None) == []
+    assert _parse_ids([]) == []
+
+
+def test_parse_ids_values():
+    assert _parse_ids([1, "2", 3]) == [1, 2, 3]
+
+
+def test_date_clause_since_until():
+    params: dict = {}
+    clause = _date_clause(
+        "event_date", since=date(2026, 1, 1), until=date(2026, 6, 30), params=params
+    )
+    assert "CAST(event_date AS DATE) >= :since" in clause
+    assert "CAST(event_date AS DATE) <= :until" in clause
+    assert params["since"] == date(2026, 1, 1)
+    assert params["until"] == date(2026, 6, 30)
+
+
+def test_location_clause():
+    params: dict = {}
+    clause = _location_clause(city="Rio de Janeiro", state="RJ", params=params)
+    assert "LOWER(city) = :city" in clause
+    assert params["city"] == "rio de janeiro"
+    assert params["state"] == "rj"
+
+
+def test_ids_clause():
+    params: dict = {}
+    clause = _ids_clause("id", [10, 20], params)
+    assert "id IN (:id_0, :id_1)" in clause
+    assert params["id_0"] == 10
+    assert params["id_1"] == 20
+
+
+def test_dedup_keys_changed_detects_city_and_date():
+    candidate = {
+        "city": "São Paulo",
+        "state": "SP",
+        "event_date": datetime(2026, 3, 15),
+    }
+    assert not dedup_keys_changed(
+        candidate,
+        {"city": "São Paulo", "state": "SP", "event_date": datetime(2026, 3, 15)},
+    )
+    assert dedup_keys_changed(
+        candidate,
+        {"city": "Campinas", "state": "SP", "event_date": datetime(2026, 3, 15)},
+    )
+    assert dedup_keys_changed(
+        candidate,
+        {"city": "São Paulo", "state": "SP", "event_date": datetime(2026, 3, 16)},
+    )
+
+
+def test_raw_event_fields_from_event_maps_core_columns():
+    fields = raw_event_fields_from_event(_minimal_event())
+    assert fields["city"] == "São Paulo"
+    assert fields["state"] == "SP"
+    assert fields["content_class"] == "incident"
+    assert fields["extraction_success"] is True
+    assert fields["event_date"] == datetime(2026, 3, 15)
+    assert fields["extraction_data"]["homicide_dynamic"]["title"] == "Homem é morto a tiros"
+
+
+@pytest.mark.asyncio
+async def test_reextract_dry_run_does_not_call_llm():
+    candidates = [
+        {
+            "source_id": 1,
+            "raw_event_id": 10,
+            "unique_event_id": 100,
+            "city": "SP",
+            "event_date": datetime(2026, 1, 2),
+            "headline": "Test",
+        }
+    ]
+    with patch(
+        "app.services.batch_jobs.find_reextract_candidates",
+        new=AsyncMock(return_value=candidates),
+    ), patch(
+        "app.services.extraction.extract_event_from_content",
+    ) as extract_mock:
+        audit = await reextract_sources(dry_run=True, limit=5)
+        extract_mock.assert_not_called()
+    assert audit["candidate_count"] == 1
+    assert audit["updated"] == 0
+    assert audit["samples"][0]["source_id"] == 1
+
+
+@pytest.mark.asyncio
+async def test_reextract_execute_updates_in_place_and_flags_enrichment():
+    candidates = [
+        {
+            "source_id": 1,
+            "raw_event_id": 10,
+            "unique_event_id": 100,
+            "city": "São Paulo",
+            "state": "SP",
+            "event_date": datetime(2026, 1, 2),
+            "headline": "Test",
+        }
+    ]
+    event = _minimal_event(title="Updated title", event_date="2026-01-02")
+    source_row = ("body " * 50, "headline", datetime(2026, 1, 3), "Publisher", "http://x")
+
+    session = AsyncMock()
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=None)
+    execute_result = MagicMock()
+    execute_result.fetchone.return_value = source_row
+    session.execute = AsyncMock(return_value=execute_result)
+
+    with patch(
+        "app.services.batch_jobs.find_reextract_candidates",
+        new=AsyncMock(return_value=candidates),
+    ), patch(
+        "app.services.batch_jobs.async_session_maker",
+        return_value=session,
+    ), patch(
+        "app.services.extraction.extract_event_from_content",
+        return_value=event,
+    ), patch(
+        "app.services.batch_jobs.update_raw_event_in_place",
+        new=AsyncMock(),
+    ) as update_mock, patch(
+        "app.services.batch_jobs.flag_unique_needs_enrichment",
+        new=AsyncMock(return_value=1),
+    ) as flag_mock:
+        audit = await reextract_sources(dry_run=False, limit=5, concurrency=1)
+
+    assert audit["updated"] == 1
+    assert audit["failed"] == 0
+    assert audit["would_discard"] == 0
+    update_mock.assert_awaited_once()
+    assert update_mock.await_args.args[0] == 10
+    assert update_mock.await_args.kwargs.get("unlink_for_rededup") is False
+    flag_mock.assert_awaited_once()
+    assert 100 in list(flag_mock.await_args.args[0])
+
+
+@pytest.mark.asyncio
+async def test_reextract_unlinks_when_city_changes():
+    candidates = [
+        {
+            "source_id": 1,
+            "raw_event_id": 10,
+            "unique_event_id": 100,
+            "city": "Rio de Janeiro",
+            "state": "RJ",
+            "event_date": datetime(2026, 1, 2),
+            "headline": "Test",
+        }
+    ]
+    event = _minimal_event(title="Updated title", event_date="2026-01-02")
+    source_row = ("body " * 50, "headline", datetime(2026, 1, 3), "Publisher", "http://x")
+    session = AsyncMock()
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=None)
+    execute_result = MagicMock()
+    execute_result.fetchone.return_value = source_row
+    session.execute = AsyncMock(return_value=execute_result)
+
+    with patch(
+        "app.services.batch_jobs.find_reextract_candidates",
+        new=AsyncMock(return_value=candidates),
+    ), patch(
+        "app.services.batch_jobs.async_session_maker",
+        return_value=session,
+    ), patch(
+        "app.services.extraction.extract_event_from_content",
+        return_value=event,
+    ), patch(
+        "app.services.batch_jobs.update_raw_event_in_place",
+        new=AsyncMock(),
+    ) as update_mock, patch(
+        "app.services.batch_jobs.refresh_unique_source_counts",
+        new=AsyncMock(return_value=1),
+    ) as refresh_mock, patch(
+        "app.services.batch_jobs.flag_unique_needs_enrichment",
+        new=AsyncMock(return_value=0),
+    ) as flag_mock:
+        audit = await reextract_sources(dry_run=False, limit=5, concurrency=1)
+
+    assert audit["updated"] == 1
+    assert audit["unlinked_for_rededup"] == 1
+    assert update_mock.await_args.kwargs.get("unlink_for_rededup") is True
+    refresh_mock.assert_awaited_once()
+    assert 100 in list(refresh_mock.await_args.args[0])
+    flag_mock.assert_awaited_once()
+    assert list(flag_mock.await_args.args[0]) == []
+
+
+@pytest.mark.asyncio
+async def test_reextract_would_discard_keeps_history():
+    candidates = [
+        {
+            "source_id": 1,
+            "raw_event_id": 10,
+            "unique_event_id": 100,
+            "city": "SP",
+            "event_date": datetime(2026, 1, 2),
+            "headline": "Test",
+        }
+    ]
+    event = _minimal_event(content_class="aggregate_statistics", title="Stats")
+    source_row = ("body " * 50, "headline", None, "Publisher", "http://x")
+    session = AsyncMock()
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=None)
+    execute_result = MagicMock()
+    execute_result.fetchone.return_value = source_row
+    session.execute = AsyncMock(return_value=execute_result)
+
+    with patch(
+        "app.services.batch_jobs.find_reextract_candidates",
+        new=AsyncMock(return_value=candidates),
+    ), patch(
+        "app.services.batch_jobs.async_session_maker",
+        return_value=session,
+    ), patch(
+        "app.services.extraction.extract_event_from_content",
+        return_value=event,
+    ), patch(
+        "app.services.batch_jobs.update_raw_event_in_place",
+        new=AsyncMock(),
+    ) as update_mock:
+        audit = await reextract_sources(dry_run=False, limit=5, concurrency=1)
+
+    assert audit["would_discard"] == 1
+    assert audit["updated"] == 0
+    update_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_enqueue_drain_uses_namespaced_pool():
+    redis = AsyncMock()
+    redis.enqueue_job = AsyncMock()
+    redis.close = AsyncMock()
+
+    with patch(
+        "app.tasks.worker.create_arq_pool",
+        new=AsyncMock(return_value=redis),
+    ), patch(
+        "app.tasks.worker.get_arq_queue_name",
+        return_value="arquivo:test",
+    ):
+        result = await enqueue_drain(stages=["enrich", "geocode"])
+
+    assert result["queue"] == "arquivo:test"
+    assert result["enqueued"] == ["enrich:50", "geocode:200"]
+    assert redis.enqueue_job.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_enqueue_drain_rejects_unknown_stage():
+    with pytest.raises(ValueError, match="Unknown drain stages"):
+        await enqueue_drain(stages=["nope"])
+
+
+def test_all_drain_stages_complete():
+    assert set(ALL_DRAIN_STAGES) == {
+        "classify",
+        "download",
+        "extract",
+        "dedup",
+        "enrich",
+        "geocode",
+    }
+
+
+@pytest.mark.asyncio
+async def test_flag_unique_needs_enrichment_noop_on_empty():
+    assert await flag_unique_needs_enrichment([]) == 0
+
+
+@pytest.mark.asyncio
+async def test_clear_geocode_noop_on_empty():
+    assert await clear_geocode_for_requeue([]) == 0
+
+
+@pytest.mark.asyncio
+async def test_update_raw_event_in_place_sets_fields():
+    raw = MagicMock()
+    raw.id = 10
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = raw
+
+    session = AsyncMock()
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=None)
+    session.execute = AsyncMock(return_value=result)
+    session.add = MagicMock()
+    session.commit = AsyncMock()
+
+    with patch("app.services.batch_jobs.async_session_maker", return_value=session):
+        await update_raw_event_in_place(
+            10,
+            {"title": "New", "city": "Campinas", "extraction_data": {"a": 1}},
+        )
+
+    assert raw.title == "New"
+    assert raw.city == "Campinas"
+    session.commit.assert_awaited_once()

--- a/docs/prod-backfill-runbook.md
+++ b/docs/prod-backfill-runbook.md
@@ -7,10 +7,46 @@ near-duplicate merge + requeue misclassified discarded sources.
 
 Related code:
 - `backend/app/services/backfill.py` — candidate selection + requeue
+- `backend/app/services/batch_jobs.py` — unified batch re-run helpers
+- `backend/scripts/pipeline_batch.py` — CLI for reclassify / reextract / reenrich / drain
 - `backend/scripts/backfill_prod_cleanup.py` — combined merge + reclassify
 - `backend/scripts/backfill_reclassify_discarded.py` — reclassify only
 - `backend/scripts/merge_duplicate_events.py` — merge only (existing)
 - `scripts/run_prod_backfill.sh` — VPS wrapper
+
+---
+
+## Pipeline batch CLI
+
+Unified toolkit for post-deploy re-runs (inside the API container). Always prefer
+`--dry-run` on staging first.
+
+```bash
+# In-place re-extract (does NOT create duplicate raw_event rows)
+docker compose -p staging exec -T api \
+  python scripts/pipeline_batch.py reextract --since 2026-01-01 --dry-run
+
+docker compose -p staging exec -T api \
+  python scripts/pipeline_batch.py reextract --since 2026-01-01 --limit 20 --execute --enqueue
+
+# Flag uniques for enrichment / clear sticky geocode
+python scripts/pipeline_batch.py reenrich --since 2026-01-01 --execute --enqueue
+python scripts/pipeline_batch.py regeocode --ids 12,34 --execute --enqueue
+
+# Requeue discarded classification FNs (same as backfill_reclassify_discarded)
+python scripts/pipeline_batch.py reclassify --signal heuristic_true --dry-run
+
+# Drain backlog on the namespaced ARQ queue (arquivo:{env})
+python scripts/pipeline_batch.py drain --stages classify,download,extract,enrich
+
+# RSS window recollect
+python scripts/pipeline_batch.py recollect --when 1d
+```
+
+`reextract` overwrites the existing `raw_event` and sets linked
+`unique_event.needs_enrichment = true`. If the new LLM output would discard
+(`content_class != incident`), history is left unchanged and the id is listed
+under `would_discard`.
 
 ---
 
@@ -20,9 +56,7 @@ Related code:
 |-------|----------------------|-------------------------|
 | Duplicate `unique_event` rows | Auto-merge on link + batch dedup | One-shot exact + near-dup merge |
 | Wrong headline classification | `classification_heuristics` on new articles | Requeue discarded false negatives |
-| Wrong extraction on old rows | `extraction_heuristics` on new extractions | Requeued sources re-extract via pipeline |
-
-Existing extracted events are **not** bulk re-extracted unless their source is requeued and processed again.
+| Wrong extraction on old rows | `extraction_heuristics` on new extractions | `pipeline_batch.py reextract` (in-place) |
 
 ---
 
@@ -83,23 +117,11 @@ docker compose -p staging exec -T api \
 bash scripts/run_prod_backfill.sh staging --execute --since 2026-01-01
 ```
 
-Enqueue pipeline (script prints this block; run it):
+Enqueue pipeline drain (namespaced queue):
 
 ```bash
-docker compose -p staging exec -T api python - <<'PY'
-import asyncio
-from arq import create_pool
-from arq.connections import RedisSettings
-
-async def main():
-    redis = await create_pool(RedisSettings(host="redis", port=6379))
-    await redis.enqueue_job("classify_pending_task", 300, 10)
-    await redis.enqueue_job("download_classified_task", 200)
-    await redis.enqueue_job("extract_ready_task", 100)
-    await redis.enqueue_job("batch_enrich_task", 50)
-
-asyncio.run(main())
-PY
+docker compose -p staging exec -T api \
+  python scripts/pipeline_batch.py drain --stages classify,download,extract,enrich
 ```
 
 Monitor:


### PR DESCRIPTION
## Summary
- Add ops CLI (`pipeline_batch.py`) for reclassify / in-place re-extract / reenrich / regeocode / drain / recollect
- Safe in-place re-extract (no duplicate raw_events); unlink + refresh source_count when city/date changes
- Fix ARQ enqueue onto namespaced `arquivo:{env}` queue

## Staging verification
- [x] Deploy Backend (develop) green
- [x] Staging `/api/health` OK
- [x] `pipeline_batch.py --help` on staging
- [x] `reextract --dry-run` returns candidates on staging

## Production test plan
- [ ] Deploy Backend (master) green
- [ ] Production health endpoints OK
- [ ] Pipeline status OK

Made with [Cursor](https://cursor.com)