### PR TITLE
feat(observability): scrape automoney funnel

### DIFF
--- a/.github/workflows/deploy-observability.yml
+++ b/.github/workflows/deploy-observability.yml
@@ -51,4 +51,5 @@ jobs:
             ufw allow from "$OBS_IP" to any port 8000 proto tcp comment 'Prometheus scrape API' >/dev/null 2>&1 || true
             ufw allow from "$OBS_IP" to any port 9091 proto tcp comment 'Prometheus scrape worker' >/dev/null 2>&1 || true
             ufw allow from "$OBS_IP" to any port 9100 proto tcp comment 'Prometheus scrape node_exporter' >/dev/null 2>&1 || true
-            echo "UFW rules for $OBS_IP → :8000/:9091/:9100 applied"
+            ufw allow from "$OBS_IP" to any port 8011 proto tcp comment 'Prometheus scrape automoney' >/dev/null 2>&1 || true
+            echo "UFW rules for $OBS_IP → :8000/:9091/:9100/:8011 applied"

--- a/docs/observability-self-hosted.md
+++ b/docs/observability-self-hosted.md
@@ -7,8 +7,9 @@ visualized in Grafana.
 |----------|------------|
 | Pipeline dashboard | https://observability.carabetta.xyz/d/arquivo-pipeline |
 | Host resources dashboard | https://observability.carabetta.xyz/d/arquivo-hosts |
+| Automoney funnel dashboard | https://observability.carabetta.xyz/d/automoney-funnel |
 | Observability VPS | `62.238.12.182` (`/opt/arquivo-observability`) |
-| Production scrape targets | `77.42.72.111:8000` (API), `:9091` (worker), `:9100` (node_exporter) |
+| Production scrape targets | `77.42.72.111:8000` (API), `:9091` (worker), `:9100` (node_exporter), `:8011` (automoney) |
 | Observability scrape targets | `node_exporter:9100` (obs VPS host metrics, Docker network) |
 
 ## Architecture

--- a/infra/observability/deploy.sh
+++ b/infra/observability/deploy.sh
@@ -52,7 +52,8 @@ OBS_IP="$1"
 ufw allow from "$OBS_IP" to any port 8000 proto tcp comment 'Prometheus scrape API' >/dev/null 2>&1 || true
 ufw allow from "$OBS_IP" to any port 9091 proto tcp comment 'Prometheus scrape worker' >/dev/null 2>&1 || true
 ufw allow from "$OBS_IP" to any port 9100 proto tcp comment 'Prometheus scrape node_exporter' >/dev/null 2>&1 || true
-echo "UFW rules for $OBS_IP → :8000/:9091/:9100 applied"
+ufw allow from "$OBS_IP" to any port 8011 proto tcp comment 'Prometheus scrape automoney' >/dev/null 2>&1 || true
+echo "UFW rules for $OBS_IP → :8000/:9091/:9100/:8011 applied"
 REMOTE
 
-echo "=== Done: https://${DOMAIN}/d/arquivo-pipeline and /d/arquivo-hosts ==="
+echo "=== Done: https://${DOMAIN}/d/arquivo-pipeline /d/arquivo-hosts /d/automoney-funnel ==="

--- a/infra/observability/grafana/dashboards/automoney-funnel.json
+++ b/infra/observability/grafana/dashboards/automoney-funnel.json
@@ -1,0 +1,242 @@
+{
+  "title": "Automoney - Funnel",
+  "uid": "automoney-funnel",
+  "schemaVersion": 39,
+  "version": 1,
+  "timezone": "browser",
+  "refresh": "1m",
+  "tags": ["automoney", "funnel"],
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "links": [
+    {
+      "title": "Host resources",
+      "url": "/d/arquivo-hosts",
+      "type": "link",
+      "icon": "dashboard"
+    },
+    {
+      "title": "go.verimaxi.com",
+      "url": "https://go.verimaxi.com/healthz",
+      "type": "link",
+      "icon": "external link",
+      "targetBlank": true
+    }
+  ],
+  "templating": { "list": [] },
+  "panels": [
+    {
+      "id": 100,
+      "type": "row",
+      "title": "Funnel health",
+      "gridPos": { "x": 0, "y": 0, "w": 24, "h": 1 },
+      "collapsed": false
+    },
+    {
+      "id": 1,
+      "title": "Scrape UP",
+      "type": "stat",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "x": 0, "y": 1, "w": 4, "h": 4 },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "value",
+        "textMode": "auto",
+        "graphMode": "none"
+      },
+      "targets": [
+        {
+          "expr": "up{job=\"automoney-prod-api\"}",
+          "legendFormat": "up",
+          "refId": "A",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            { "type": "value", "options": { "0": { "text": "DOWN", "color": "red" }, "1": { "text": "UP", "color": "green" } } }
+          ],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "red", "value": null }, { "color": "green", "value": 1 }] }
+        }
+      }
+    },
+    {
+      "id": 2,
+      "title": "Kill switch",
+      "type": "stat",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "x": 4, "y": 1, "w": 4, "h": 4 },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "value",
+        "textMode": "auto",
+        "graphMode": "none"
+      },
+      "targets": [
+        {
+          "expr": "automoney_kill_switch",
+          "legendFormat": "kill",
+          "refId": "A",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            { "type": "value", "options": { "0": { "text": "OFF", "color": "green" }, "1": { "text": "ON", "color": "red" } } }
+          ],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "red", "value": 1 }] }
+        }
+      }
+    },
+    {
+      "id": 3,
+      "title": "Daily spend / cap",
+      "type": "stat",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "x": 8, "y": 1, "w": 6, "h": 4 },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "value",
+        "textMode": "auto",
+        "graphMode": "none"
+      },
+      "targets": [
+        {
+          "expr": "automoney_daily_spend_usd",
+          "legendFormat": "spend",
+          "refId": "A",
+          "instant": true
+        },
+        {
+          "expr": "automoney_daily_spend_cap_usd",
+          "legendFormat": "cap",
+          "refId": "B",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "currencyUSD",
+          "decimals": 2
+        }
+      }
+    },
+    {
+      "id": 4,
+      "title": "Clicks / conv (24h)",
+      "type": "stat",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "x": 14, "y": 1, "w": 10, "h": 4 },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "value",
+        "textMode": "auto",
+        "graphMode": "none"
+      },
+      "targets": [
+        {
+          "expr": "automoney_clicks_24h",
+          "legendFormat": "clicks",
+          "refId": "A",
+          "instant": true
+        },
+        {
+          "expr": "automoney_conversions_24h",
+          "legendFormat": "conversions",
+          "refId": "B",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 101,
+      "type": "row",
+      "title": "Heartbeats",
+      "gridPos": { "x": 0, "y": 5, "w": 24, "h": 1 },
+      "collapsed": false
+    },
+    {
+      "id": 5,
+      "title": "Heartbeat age",
+      "description": "Seconds since last_tick / last_hotmart_sync / last_spend_push. Tick should be < 2h; spend push < 26h.",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "x": 0, "y": 6, "w": 24, "h": 8 },
+      "targets": [
+        {
+          "expr": "automoney_heartbeat_age_seconds",
+          "legendFormat": "{{job}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 7200 },
+              { "color": "red", "value": 93600 }
+            ]
+          }
+        }
+      },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "multi" }
+      }
+    },
+    {
+      "id": 102,
+      "type": "row",
+      "title": "Spend",
+      "gridPos": { "x": 0, "y": 14, "w": 24, "h": 1 },
+      "collapsed": false
+    },
+    {
+      "id": 6,
+      "title": "Daily spend vs cap",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "x": 0, "y": 15, "w": 24, "h": 8 },
+      "targets": [
+        {
+          "expr": "automoney_daily_spend_usd",
+          "legendFormat": "spend",
+          "refId": "A"
+        },
+        {
+          "expr": "automoney_daily_spend_cap_usd",
+          "legendFormat": "cap",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "currencyUSD",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        }
+      },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "multi" }
+      }
+    }
+  ]
+}

--- a/infra/observability/prometheus/prometheus.yml
+++ b/infra/observability/prometheus/prometheus.yml
@@ -46,3 +46,13 @@ scrape_configs:
         labels:
           environment: observability
           host: obs
+
+  - job_name: automoney-prod-api
+    metrics_path: /metrics
+    scheme: http
+    static_configs:
+      - targets: ["77.42.72.111:8011"]
+        labels:
+          environment: production
+          service: api
+          project: automoney

--- a/infra/observability/prometheus/rules/automoney-alerts.yml
+++ b/infra/observability/prometheus/rules/automoney-alerts.yml
@@ -1,0 +1,75 @@
+groups:
+  - name: automoney_critical
+    rules:
+      - alert: AutomoneyApiScrapeDown
+        expr: up{job="automoney-prod-api"} == 0
+        for: 5m
+        labels:
+          severity: critical
+          agent: "true"
+          category: scrape
+          project: automoney
+        annotations:
+          summary: "Automoney API metrics scrape down"
+          description: "Prometheus cannot scrape automoney :8011 on {{ $labels.instance }}."
+
+      - alert: AutomoneyKillSwitch
+        expr: automoney_kill_switch == 1
+        for: 2m
+        labels:
+          severity: critical
+          agent: "true"
+          category: kill_switch
+          project: automoney
+        annotations:
+          summary: "Automoney kill switch active"
+          description: "Daily spend kill switch is on. /go returns 503 until cleared."
+
+      - alert: AutomoneyTickStale
+        expr: automoney_heartbeat_age_seconds{job="last_tick"} > 7200
+        for: 10m
+        labels:
+          severity: critical
+          agent: "true"
+          category: heartbeat
+          project: automoney
+        annotations:
+          summary: "Automoney tick.py heartbeat stale (> 2h)"
+          description: "last_tick age is {{ $value | printf \"%.0f\" }}s. Cron or container may be down."
+
+  - name: automoney_warning
+    rules:
+      - alert: AutomoneyHotmartSyncStale
+        expr: automoney_heartbeat_age_seconds{job="last_hotmart_sync"} > 7200
+        for: 10m
+        labels:
+          severity: warning
+          category: heartbeat
+          project: automoney
+        annotations:
+          summary: "Automoney Hotmart sync stale (> 2h)"
+          description: "last_hotmart_sync age is {{ $value | printf \"%.0f\" }}s."
+
+      - alert: AutomoneySpendPushStale
+        expr: automoney_heartbeat_age_seconds{job="last_spend_push"} > 93600
+        for: 30m
+        labels:
+          severity: warning
+          category: heartbeat
+          project: automoney
+        annotations:
+          summary: "Automoney Ads spend push stale (> 26h)"
+          description: "last_spend_push age is {{ $value | printf \"%.0f\" }}s. Google Ads Script may not be posting."
+
+      - alert: AutomoneySpendNearCap
+        expr: |
+          automoney_daily_spend_cap_usd > 0
+          and (automoney_daily_spend_usd / automoney_daily_spend_cap_usd) > 0.9
+        for: 15m
+        labels:
+          severity: warning
+          category: spend
+          project: automoney
+        annotations:
+          summary: "Automoney daily spend > 90% of cap"
+          description: "Spend {{ $value | printf \"%.2f\" }} of cap ratio for 15+ minutes."


### PR DESCRIPTION
## Summary
- Add `automoney-prod-api` scrape job (`77.42.72.111:8011`)
- Alert rules + Grafana dashboard `/d/automoney-funnel`
- Open UFW `:8011` from obs VPS in deploy/CI

## Test plan
- [ ] Obs deploy succeeds (CI or `bash infra/observability/deploy.sh`)
- [ ] `up{job="automoney-prod-api"} == 1` after automoney app redeploy
- [ ] Dashboard https://observability.carabetta.xyz/d/automoney-funnel loads series

Made with [Cursor](https://cursor.com)