### PR TITLE
Wire Chile into hourly ingest path

### DIFF
--- a/CHILE_INGEST_CHANGES.md
+++ b/CHILE_INGEST_CHANGES.md
@@ -1,0 +1,145 @@
+# Chile Ingest Integration - Changes Summary
+
+## Problem
+Chile support landed in PR #119 (merged to develop), but the live cron and API endpoints did not actually call the Chile ingestion functions. The hourly ingest path (`ingest_cities_hourly` → `ingest_cities_task`) was hard-coded to only ingest Brazilian cities.
+
+## Solution
+Modified `ingest_cities_task` to automatically ingest **both** Brazil and Chile when no explicit city list is provided (the hourly/cron path). When an explicit city list is provided, the behavior remains unchanged (Brazilian cities only).
+
+## Changes Made
+
+### 1. `backend/app/tasks/pipeline.py` - `ingest_cities_task()`
+
+**Before:**
+```python
+from app.services.ingestion import ingest_all_cities
+
+result = await ingest_all_cities(cities=cities, when=when, resolve_urls=True)
+```
+
+**After:**
+```python
+from app.services.ingestion import ingest_all_cities, ingest_all_countries
+
+# When cities is None (hourly/cron path), ingest all countries.
+# When an explicit city list is provided, use Brazil as default.
+if cities is None:
+    result = await ingest_all_countries(when=when, resolve_urls=True)
+else:
+    result = await ingest_all_cities(cities=cities, when=when, resolve_urls=True, country="BR")
+```
+
+### 2. `backend/app/routers/pipeline.py` - API Endpoint Docstrings
+
+Updated the following endpoints to reflect multi-country support:
+
+- **`POST /pipeline/ingest-cities`**: Changed from "Brazilian cities" to "cities across all countries (BR + CL)"
+- **`POST /pipeline/full`**: Updated to indicate ingestion from all configured cities (BR + CL)
+
+## Behavior
+
+### Hourly Cron (cities=None)
+```python
+# Worker cron at minute :05
+ingest_cities_hourly()
+  → ingest_cities_task(ctx, cities=None, when="1h")
+    → ingest_all_countries(when="1h", resolve_urls=True)
+      → ingest_all_cities(country="BR") + ingest_all_cities(country="CL")
+```
+
+**Result**: Both Brazilian and Chilean news sources are collected.
+
+### API Call Without Cities (cities=None)
+```bash
+curl -X POST "http://localhost:8010/api/pipeline/ingest-cities?when=1h"
+```
+
+**Result**: Same as hourly cron - both countries are ingested.
+
+### API Call With Explicit Cities
+```bash
+curl -X POST "http://localhost:8010/api/pipeline/ingest-cities?when=1h&cities=São%20Paulo,Rio%20de%20Janeiro"
+```
+
+**Result**: Only the specified Brazilian cities are ingested (existing behavior preserved).
+
+## Testing
+
+### Manual Verification Steps (requires Docker)
+
+1. **Start the dev stack:**
+   ```bash
+   docker compose -f docker-compose.dev.yml -f docker-compose.dev.override.yml up -d --build
+   ```
+
+2. **Trigger a manual ingest:**
+   ```bash
+   curl -X POST "http://localhost:8010/api/pipeline/ingest-cities?when=1h"
+   ```
+
+3. **Check the logs for both BR and CL:**
+   ```bash
+   docker compose -f docker-compose.dev.yml logs -f worker
+   ```
+
+   Expected log output:
+   ```
+   [INGEST_CITIES] Starting with when=1h
+   Starting multi-country ingestion (BR + CL)
+   Starting PARALLEL city ingestion for 52 cities in BR
+   Starting PARALLEL city ingestion for 15 cities in CL
+   ...
+   MULTI-COUNTRY INGESTION COMPLETE
+   Total entries: <count>
+   Total sources: <count>
+   ```
+
+4. **Verify Chilean sources in database:**
+   ```bash
+   docker compose -f docker-compose.dev.yml exec api python -c "
+   import asyncio
+   from app.database import async_session_maker
+   from app.models import SourceGoogleNews
+   from sqlmodel import select
+
+   async def check():
+       async with async_session_maker() as session:
+           # Check for Chilean news sources
+           result = await session.exec(
+               select(SourceGoogleNews)
+               .where(SourceGoogleNews.search_query.like('%Santiago%'))
+               .limit(5)
+           )
+           sources = result.all()
+           print(f'Found {len(sources)} Chilean sources')
+           for s in sources:
+               print(f'  - {s.headline} ({s.search_query})')
+   
+   asyncio.run(check())
+   "
+   ```
+
+## Deployment
+
+These changes should be deployed following the standard workflow:
+
+1. ✅ **Local** - Develop and test on feature branch (this PR)
+2. ⏳ **Develop** - Merge to `develop` → auto-deploy to staging
+3. ⏳ **Production** - After staging verification, merge `develop` to `master`
+
+### Staging Verification Checklist
+
+Before promoting to production:
+
+- [ ] Hourly cron runs successfully at :05
+- [ ] Chilean sources appear in staging database
+- [ ] Classification/download/extract works for Chilean sources
+- [ ] Pipeline metrics show Chilean city processing
+- [ ] No errors in staging worker logs
+
+## Related Files
+
+- `backend/app/services/ingestion.py` - Contains `ingest_all_countries()`
+- `backend/app/services/cities_chile.py` - Chilean city configuration
+- `backend/app/tasks/worker.py` - Worker cron configuration
+- `.github/workflows/deploy-backend.yml` - Backend CI/CD pipeline

--- a/backend/app/routers/pipeline.py
+++ b/backend/app/routers/pipeline.py
@@ -43,13 +43,13 @@ async def get_arq_pool():
 @router.post("/full")
 async def run_full_pipeline_endpoint(
     when: str = Query("1h", description="Time filter (e.g., '1h', '1d', '3d')"),
-    cities: str | None = Query(None, description="Comma-separated city names (optional, uses all 52 cities if not provided)"),
+    cities: str | None = Query(None, description="Comma-separated city names (optional, uses all countries if not provided)"),
 ):
     """
     🚀 Run the COMPLETE pipeline from ingestion to enrichment.
     
     **Pipeline stages:**
-    1. **Ingest** - Fetch news from Google News for all Brazilian cities
+    1. **Ingest** - Fetch news from Google News for all configured cities (BR + CL)
     2. **Classify** - Filter headlines using AI (violent death detection)
     3. **Download** - Fetch full article content
     4. **Extract** - Extract structured event data using LLM
@@ -72,7 +72,7 @@ async def run_full_pipeline_endpoint(
         "status": "queued",
         "job_id": job.job_id,
         "task": "ingest_cities_full_pipeline",
-        "message": f"Full pipeline started (when={when}, cities={'custom list' if city_list else 'all 52'})",
+        "message": f"Full pipeline started (when={when}, cities={'custom list' if city_list else 'all countries'})",
         "stages": [
             "1. Ingest (Google News RSS)",
             "2. Classify (AI headline filter)",
@@ -134,10 +134,10 @@ async def run_city_ingestion(
     when: str = Query("1h", description="Time filter (default 1h for hourly)"),
 ):
     """
-    Ingest news for ALL configured Brazilian cities with adaptive sharding.
+    Ingest news for ALL configured cities across all countries (BR + CL).
     
-    - Fetches news for 52+ major cities
-    - Automatically shards high-volume cities (São Paulo, Rio, etc.)
+    - Fetches news for 52+ Brazilian cities and Chilean cities
+    - Automatically shards high-volume cities (São Paulo, Rio, Santiago, etc.)
     - Rate limited to respect Google's limits
     
     This is the main production ingestion endpoint for hourly runs.
@@ -150,7 +150,7 @@ async def run_city_ingestion(
         "status": "queued",
         "job_id": job.job_id,
         "task": "ingest_cities_task",
-        "message": "City ingestion task queued (52+ cities)",
+        "message": "City ingestion task queued (all countries)",
     }
 
 

--- a/backend/app/routers/pipeline.py
+++ b/backend/app/routers/pipeline.py
@@ -136,7 +136,7 @@ async def run_city_ingestion(
     """
     Ingest news for ALL configured cities across all countries (BR + CL).
     
-    - Fetches news for 52+ Brazilian cities and Chilean cities
+    - Fetches news for 52+ cities in Brazil and major cities in Chile
     - Automatically shards high-volume cities (São Paulo, Rio, Santiago, etc.)
     - Rate limited to respect Google's limits
     

--- a/backend/app/tasks/pipeline.py
+++ b/backend/app/tasks/pipeline.py
@@ -528,7 +528,7 @@ async def ingest_cities_task(
     
     Args:
         ctx: ARQ context (contains redis connection)
-        cities: Optional list of cities. If None, uses CITIES from config.
+        cities: Optional list of cities. If None, ingests all countries (BR + CL).
         when: Time filter (default "1h" for hourly)
         enqueue_classify: When True, enqueue ``classify_pending_task`` after ingest.
     
@@ -541,9 +541,14 @@ async def ingest_cities_task(
     # Notify job started
     await notify_job_started("ingest_cities", {"when": when})
     
-    from app.services.ingestion import ingest_all_cities
+    from app.services.ingestion import ingest_all_cities, ingest_all_countries
     
-    result = await ingest_all_cities(cities=cities, when=when, resolve_urls=True)
+    # When cities is None (hourly/cron path), ingest all countries.
+    # When an explicit city list is provided, use Brazil as default.
+    if cities is None:
+        result = await ingest_all_countries(when=when, resolve_urls=True)
+    else:
+        result = await ingest_all_cities(cities=cities, when=when, resolve_urls=True, country="BR")
     
     total_sources = result['total_sources_created']
     logger.info(f"[INGEST_CITIES] Complete: {total_sources} new sources")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 📝 Descrição

Este PR conecta o suporte do Chile ao caminho de ingestão horária, para que staging/prod realmente coletem notícias chilenas.

### Problema
O suporte do Chile foi adicionado no PR #119 (merged para develop). As funções `ingest_all_countries()` e `ingest_all_cities(..., country="CL")` existem em `backend/app/services/ingestion.py`.

Mas o cron ao vivo ainda não as chamava:
- `ingest_cities_hourly` → `ingest_cities_task` → `ingest_all_cities()` com padrão `country="BR"`
- O cron do worker (`backend/app/tasks/worker.py`) executa `ingest_cities_hourly` no minuto 5
- A API do pipeline `POST /pipeline/ingest-cities` ainda documenta "cidades brasileiras"

Então staging pode implantar o código do Chile e ainda nunca ingerir Chile.

### Solução
Quando `cities` é None (caminho horário/cron e `/ingest-cities`), ingere **ambos** Brasil e Chile (usando `ingest_all_countries`, que chama `ingest_all_cities` uma vez por país). Classificação/download/extração/enriquecimento downstream devem processar quaisquer novas fontes criadas (não são específicas do país).

Quando um chamador passa uma lista explícita de `cities`, mantém o comportamento atual (essas cidades, padrão BR).

Atualiza o docstring da API do pipeline para `/ingest-cities` para que não diga mais apenas Brasil.

## 🔗 Issue Relacionada

Relacionado ao PR #119 - adiciona a parte de integração que estava faltando.

## 🏷️ Tipo de Mudança

- [x] ✨ Nova feature (mudança que adiciona funcionalidade)
- [x] 📚 Documentação (mudança em documentação)

## 🧪 Como Foi Testado?

- [x] Testes manuais
- [x] Testado em desenvolvimento local

**Ambiente de teste:**
- OS: Linux 6.12.94+
- Verificação de sintaxe Python: ✓ Passou
- Testes de lógica: ✓ Passou (verificou que `ingest_all_countries()` é chamado quando cities=None)

**Nota:** Docker não estava disponível no ambiente de teste da nuvem, então os testes de integração completos devem ser executados em staging após merge.

### Verificação Manual em Staging (após deploy)

Após o deploy para staging, verificar:
1. O cron horário executa com sucesso no minuto :05
2. Fontes chilenas aparecem no banco de dados de staging
3. Classificação/download/extração funciona para fontes chilenas
4. As métricas do pipeline mostram processamento de cidades chilenas
5. Nenhum erro nos logs do worker de staging

## 📸 Screenshots (se aplicável)

N/A - Mudanças no backend apenas.

## ✅ Checklist

- [x] Meu código segue o guia de estilo do projeto
- [x] Realizei uma auto-revisão do meu código
- [x] Comentei meu código em áreas complexas
- [x] Atualizei a documentação correspondente
- [x] Minhas mudanças não geram novos warnings
- [ ] Adicionei testes que provam que meu fix/feature funciona (testes de integração completos requerem Docker)
- [ ] Testes unitários novos e existentes passam localmente (Docker não disponível no ambiente de teste)
- [x] Quaisquer mudanças dependentes foram mergeadas (PR #119)
- [ ] Atualizei o CHANGELOG (se aplicável)

## 📚 Documentação

- [x] Docstrings/comentários no código
- [x] API documentation (docstrings de endpoints atualizados)
- [x] Outro: `CHILE_INGEST_CHANGES.md` adicionado com documentação detalhada

## 🔍 Revisores Sugeridos

@JoaoCarabetta 

## 💬 Notas Adicionais

### Comportamento

**Cron Horário (cities=None):**
```python
ingest_cities_hourly()
  → ingest_cities_task(ctx, cities=None, when="1h")
    → ingest_all_countries(when="1h", resolve_urls=True)
      → ingest_all_cities(country="BR") + ingest_all_cities(country="CL")
```
**Resultado:** Fontes de notícias brasileiras E chilenas são coletadas.

**Chamada de API com Lista Explícita de Cidades:**
```bash
curl -X POST "http://localhost:8010/api/pipeline/ingest-cities?cities=São%20Paulo,Rio"
```
**Resultado:** Apenas as cidades brasileiras especificadas são ingeridas (comportamento existente preservado).

### Deployment Flow

Seguindo o fluxo padrão de deployment:
1. ✅ **Local** - Desenvolvido e testado no branch de feature
2. ⏳ **Develop** - Este PR → auto-deploy para staging
3. ⏳ **Produção** - Após verificação de staging, merge develop para master

### Arquivos Relacionados

- `backend/app/tasks/pipeline.py` - Lógica de `ingest_cities_task` modificada
- `backend/app/routers/pipeline.py` - Docstrings de API atualizados
- `backend/app/services/ingestion.py` - Contém `ingest_all_countries()` (do PR #119)
- `backend/app/services/cities_chile.py` - Configuração de cidades chilenas (do PR #119)

---

**Pronto para merge quando os revisores aprovarem. Staging irá coletar notícias chilenas após o deploy! 🇨🇱**
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-07a79fea-cd4a-4d2b-82eb-b670ac0a7821?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-07a79fea-cd4a-4d2b-82eb-b670ac0a7821&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

