### PR TITLE
Fix TypeScript build errors in Rankings page after PR #125

### DIFF
--- a/frontend/src/pages/public/Rankings.tsx
+++ b/frontend/src/pages/public/Rankings.tsx
@@ -48,7 +48,7 @@ function DeltaBadge({ delta, label }: { delta: number; label: string }) {
 }
 
 function RankingTable({ title, rows, labelField, onRowClick, emptyMessage }: RankingTableProps) {
-  const { t } = useI18n();
+  const { t, lang } = useI18n();
   const [expanded, setExpanded] = useState(true);
   
   if (rows.length === 0) {

--- a/frontend/src/pages/public/Rankings.tsx
+++ b/frontend/src/pages/public/Rankings.tsx
@@ -103,8 +103,8 @@ function RankingTable({ title, rows, labelField, onRowClick, emptyMessage }: Ran
             <tbody className="bg-white divide-y divide-stone-200">
               {displayRows.map((row, idx) => {
                 const label = row[labelField] as string || 'N/A';
-                const displayLabel = labelField === 'type' ? formatTypeStatLabel(label) : 
-                                   labelField === 'method' ? translateMethod(label) : 
+                const displayLabel = labelField === 'type' ? formatTypeStatLabel(label, lang) : 
+                                   labelField === 'method' ? translateMethod(label, lang) : 
                                    label;
                 return (
                   <tr
@@ -153,7 +153,7 @@ function RankingTable({ title, rows, labelField, onRowClick, emptyMessage }: Ran
 }
 
 export function Rankings() {
-  const { t } = useI18n();
+  const { t, lang } = useI18n();
   const navigate = useNavigate();
   const isMobile = useIsMobile();
   
@@ -197,6 +197,16 @@ export function Rankings() {
   const handleMethodClick = (method: string) => {
     // Deep link to map filtered to this method
     navigate(`/?method=${encodeURIComponent(method)}`);
+  };
+
+  const handleOpenMethodology = () => {
+    setAboutOpen(false);
+    setMethodologyOpen(true);
+  };
+
+  const handleSetMode = (mode: 'data') => {
+    // Navigate to data page when user clicks the data link in methodology
+    navigate('/dados');
   };
 
   return (
@@ -354,8 +364,8 @@ export function Rankings() {
         </div>
       </main>
 
-      <AboutModal open={aboutOpen} onClose={() => setAboutOpen(false)} />
-      <MethodologyPanel open={methodologyOpen} onClose={() => setMethodologyOpen(false)} />
+      <AboutModal open={aboutOpen} onClose={() => setAboutOpen(false)} onOpenMethodology={handleOpenMethodology} />
+      <MethodologyPanel open={methodologyOpen} onClose={() => setMethodologyOpen(false)} onSetMode={handleSetMode} />
     </div>
   );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Fixes TypeScript build errors that occurred after PR #125 was merged to develop, causing the staging frontend deploy (GitHub Actions run 32312165726) to fail.

## Changes
- Added `lang` parameter to `formatTypeStatLabel()` and `translateMethod()` calls in Rankings.tsx
- Added `onOpenMethodology` prop to `AboutModal` component (allows opening methodology from about modal)
- Added `onSetMode` prop to `MethodologyPanel` component (handles navigation to data page)
- Extracted `lang` from `useI18n()` in both `RankingTable` and `Rankings` components

## Testing
- ✅ `npm run build` passes successfully in frontend
- All functionality from PR #125 remains intact:
  - Rankings page at `/estatisticas`
  - Filters (period, country)
  - Map deep-links
  - Methodology note
  - Chile-empty-safe handling

## Related
- Fixes build failure from PR #125
- Follows same patterns as MapExplorer.tsx for modal component usage
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b8edd1f2-69be-4d9b-ae49-6f930e501a02?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b8edd1f2-69be-4d9b-ae49-6f930e501a02&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

