### PR TITLE
feat: persist UniqueEvent.country from ingest (stop hardcoding Brasil)

### DIFF
--- a/backend/alembic/versions/i8j9k0l1m2n3_add_country_field_to_source_and_raw_event.py
+++ b/backend/alembic/versions/i8j9k0l1m2n3_add_country_field_to_source_and_raw_event.py
@@ -1,0 +1,49 @@
+"""add_country_field_to_source_and_raw_event
+
+Revision ID: i8j9k0l1m2n3
+Revises: h7i8j9k0l1m2
+Create Date: 2026-08-19 23:00:00.000000
+
+Add country field to source_google_news and raw_event tables to support
+multi-country ingestion (BR, CL) and stop hardcoding "Brasil" in UniqueEvent.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+import sqlmodel
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'i8j9k0l1m2n3'
+down_revision: Union[str, Sequence[str], None] = 'h7i8j9k0l1m2'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add country field to source_google_news and raw_event."""
+    # Add country to source_google_news
+    op.add_column('source_google_news', sa.Column('country', sqlmodel.sql.sqltypes.AutoString(length=2), nullable=True))
+    op.create_index(op.f('ix_source_google_news_country'), 'source_google_news', ['country'], unique=False)
+    
+    # Backfill existing source_google_news records with BR
+    op.execute("UPDATE source_google_news SET country = 'BR' WHERE country IS NULL")
+    
+    # Add country to raw_event
+    op.add_column('raw_event', sa.Column('country', sqlmodel.sql.sqltypes.AutoString(length=2), nullable=True))
+    op.create_index(op.f('ix_raw_event_country'), 'raw_event', ['country'], unique=False)
+    
+    # Backfill existing raw_event records with BR
+    op.execute("UPDATE raw_event SET country = 'BR' WHERE country IS NULL")
+
+
+def downgrade() -> None:
+    """Remove country field from source_google_news and raw_event."""
+    # Drop from raw_event
+    op.drop_index(op.f('ix_raw_event_country'), table_name='raw_event')
+    op.drop_column('raw_event', 'country')
+    
+    # Drop from source_google_news
+    op.drop_index(op.f('ix_source_google_news_country'), table_name='source_google_news')
+    op.drop_column('source_google_news', 'country')

--- a/backend/app/models/raw_event.py
+++ b/backend/app/models/raw_event.py
@@ -26,6 +26,7 @@ class RawEventBase(SQLModel):
     time_of_day: str | None = Field(default=None, max_length=20)
     
     # Location (key fields for filtering)
+    country: str | None = Field(default="BR", max_length=2, index=True)
     city: str | None = Field(default=None, max_length=100, index=True)
     state: str | None = Field(default=None, max_length=50)
     neighborhood: str | None = Field(default=None, max_length=100)

--- a/backend/app/models/source_google_news.py
+++ b/backend/app/models/source_google_news.py
@@ -56,6 +56,9 @@ class SourceGoogleNewsBase(SQLModel):
     # Search context (which query found this)
     search_query: str | None = Field(default=None, max_length=256)
     
+    # Country (ISO 3166-1 alpha-2: BR, CL, etc.)
+    country: str | None = Field(default="BR", max_length=2, index=True)
+    
     # Pipeline status (stored as VARCHAR — avoids native Postgres enum drift)
     status: SourceStatus = Field(
         default=SourceStatus.ready_for_classification,

--- a/backend/app/routers/public.py
+++ b/backend/app/routers/public.py
@@ -491,11 +491,17 @@ async def get_rankings(
                 UniqueEvent.event_date <= end,
             )
         )
-        if country:
-            country_name = COUNTRY_NAMES.get(country.upper())
-            if country_name:
+    if country:
+        country_name = COUNTRY_NAMES.get(country.upper())
+        if country_name:
+            # Match both canonical code and legacy "Brasil" for BR
+            if country.upper() == "BR":
+                query = query.where(
+                    (UniqueEvent.country == country_name) | (UniqueEvent.country == country.upper())
+                )
+            else:
                 query = query.where(UniqueEvent.country == country_name)
-        return query
+    return query
     
     current_query = build_query(current_start, now)
     prev_query = build_query(prev_start, prev_end)
@@ -508,6 +514,16 @@ async def get_rankings(
     prev_events = prev_result.scalars().all()
     
     # Helper to aggregate rankings
+    def normalize_country_for_display(country_code: str | None) -> str | None:
+        """Normalize country codes to display names, treating legacy 'Brasil' as BR."""
+        if not country_code:
+            return None
+        # Treat legacy "Brasil" as "BR"
+        if country_code == "Brasil":
+            country_code = "BR"
+        # Map country codes to display names
+        return COUNTRY_NAMES.get(country_code.upper(), country_code)
+    
     def aggregate_by_field(events, field_name):
         """Aggregate events by a field, counting victims and events."""
         aggregated = {}
@@ -515,6 +531,11 @@ async def get_rankings(
             key = getattr(event, field_name)
             if not key:
                 continue
+            # Normalize country field for aggregation
+            if field_name == "country":
+                key = normalize_country_for_display(key)
+                if not key:
+                    continue
             if key not in aggregated:
                 aggregated[key] = {"events": 0, "victims": 0}
             aggregated[key]["events"] += 1

--- a/backend/app/routers/public.py
+++ b/backend/app/routers/public.py
@@ -491,17 +491,17 @@ async def get_rankings(
                 UniqueEvent.event_date <= end,
             )
         )
-    if country:
-        country_name = COUNTRY_NAMES.get(country.upper())
-        if country_name:
-            # Match both canonical code and legacy "Brasil" for BR
+        if country:
+            # Match canonical codes (BR, CL) and legacy "Brasil" for BR
             if country.upper() == "BR":
+                # BR matches both canonical "BR" and legacy "Brasil"
                 query = query.where(
-                    (UniqueEvent.country == country_name) | (UniqueEvent.country == country.upper())
+                    (UniqueEvent.country == "BR") | (UniqueEvent.country == "Brasil")
                 )
-            else:
-                query = query.where(UniqueEvent.country == country_name)
-    return query
+            elif country.upper() == "CL":
+                # CL matches canonical "CL" stored value
+                query = query.where(UniqueEvent.country == "CL")
+        return query
     
     current_query = build_query(current_start, now)
     prev_query = build_query(prev_start, prev_end)

--- a/backend/app/services/enrichment.py
+++ b/backend/app/services/enrichment.py
@@ -1128,7 +1128,7 @@ async def create_unique_event_from_cluster(cluster: list[RawEvent]) -> UniqueEve
                 "event_date": best.event_date,
                 "date_precision": best.date_precision,
                 "time_of_day": best.time_of_day,
-                "country": "Brasil",
+                "country": best.country or "BR",  # Use RawEvent country, default to BR
                 "state": best.state,
                 "city": best.city,
                 "neighborhood": best.neighborhood,
@@ -1369,6 +1369,7 @@ async def process_pending_deduplication(limit: int = 200) -> dict:
         raw_event = RawEvent(
             id=row.id,
             event_date=parse_datetime(row.event_date),
+            country=getattr(row, "country", "BR"),
             city=row.city,
             state=row.state,
             neighborhood=row.neighborhood,

--- a/backend/app/services/extraction.py
+++ b/backend/app/services/extraction.py
@@ -840,7 +840,7 @@ async def extract_source(source_id: int) -> RawEvent | None:
     async with async_session_maker() as session:
         result = await session.execute(
             text("""
-                SELECT id, headline, content, published_at, publisher_name, resolved_url 
+                SELECT id, headline, content, published_at, publisher_name, resolved_url, country 
                 FROM source_google_news 
                 WHERE id = :id
             """),
@@ -852,7 +852,7 @@ async def extract_source(source_id: int) -> RawEvent | None:
             logger.warning(f"Source {source_id} not found")
             return None
 
-        source_id_db, headline, content, published_at, publisher_name, resolved_url = row
+        source_id_db, headline, content, published_at, publisher_name, resolved_url, country = row
 
     if not content:
         logger.warning(f"Source {source_id} has no content")
@@ -997,6 +997,7 @@ async def extract_source(source_id: int) -> RawEvent | None:
     async with async_session_maker() as session:
         raw_event = RawEvent(
             source_google_news_id=source_id,
+            country=country or "BR",  # Use source country, default to BR
             **fields,
         )
 

--- a/backend/app/services/ingestion.py
+++ b/backend/app/services/ingestion.py
@@ -446,6 +446,7 @@ async def ingest_city(
                         publisher_url=publisher_url,
                         published_at=published_at,
                         search_query=entry.get("_search_query"),
+                        country=entry.get("_country", country),  # Use tagged country or fallback
                         status=SourceStatus.ready_for_classification,
                         fetched_at=datetime.utcnow(),
                     )

--- a/backend/tests/test_persist_country.py
+++ b/backend/tests/test_persist_country.py
@@ -1,0 +1,176 @@
+"""Tests for persisting country from ingest to UniqueEvent."""
+
+import pytest
+from datetime import datetime
+from decimal import Decimal
+
+from app.models.unique_event import UniqueEvent
+from app.models.raw_event import RawEvent
+from app.models.source_google_news import SourceGoogleNews, SourceStatus
+from app.services.enrichment import create_unique_event_from_cluster
+
+
+@pytest.mark.asyncio
+async def test_chilean_fixture_stores_country_cl(async_session):
+    """Test 1: UniqueEvent persistence - Chilean fixture stores country CL (not Brasil)."""
+    # Create a Chilean SourceGoogleNews
+    source = SourceGoogleNews(
+        google_news_id="test_cl_001",
+        google_news_url="https://news.google.com/test_cl",
+        headline="Homicidio en Santiago",
+        publisher_name="Test CL Publisher",
+        search_query="homicidio Santiago",
+        status=SourceStatus.extracted,
+        country="CL",
+    )
+    async_session.add(source)
+    await async_session.commit()
+    await async_session.refresh(source)
+    
+    # Create a RawEvent from Chilean source
+    raw_event = RawEvent(
+        source_google_news_id=source.id,
+        event_family="homicidio",
+        event_subtype="simples",
+        event_date=datetime(2026, 8, 15, 14, 30),
+        city="Santiago",
+        state="Metropolitana",
+        title="Homicidio en Santiago centro",
+        chronological_description="Una persona murió",
+        victim_count=1,
+        extraction_data={
+            "location_info": {
+                "city": "Santiago",
+                "region": "Metropolitana",
+                "country": "CL",
+            }
+        },
+        country="CL",
+    )
+    async_session.add(raw_event)
+    await async_session.commit()
+    await async_session.refresh(raw_event)
+    
+    # Create UniqueEvent from cluster
+    unique_event = await create_unique_event_from_cluster([raw_event])
+    
+    # Refresh to get the persisted state
+    await async_session.refresh(unique_event)
+    
+    # Assert: country should be CL, not "Brasil"
+    assert unique_event.country == "CL", f"Expected country='CL', got '{unique_event.country}'"
+    assert unique_event.country != "Brasil", "Country should not be hardcoded to Brasil"
+    assert unique_event.city == "Santiago"
+    assert unique_event.state == "Metropolitana"
+
+
+@pytest.mark.asyncio
+async def test_rankings_country_breakdown_with_cl_and_legacy_brasil(app, async_session):
+    """Test 2: Public rankings country breakdown - CL row appears, Brasil treated as BR."""
+    from datetime import timedelta
+    from httpx import AsyncClient
+    from app.database import get_session
+    
+    now = datetime.utcnow()
+    current_start = now - timedelta(days=30)
+    
+    # Create events with different country values:
+    # - New CL event with canonical code
+    # - Legacy Brasil event (should be treated as BR)
+    # - New BR event with canonical code
+    events = [
+        UniqueEvent(
+            title="Chilean event",
+            event_date=current_start + timedelta(days=1),
+            country="CL",  # Canonical code
+            state="Metropolitana",
+            city="Santiago",
+            event_family="homicidio",
+            event_subtype="simples",
+            content_class="incident",
+            victim_count=1,
+            latitude=Decimal("-33.4489"),
+            longitude=Decimal("-70.6693"),
+            source_count=1,
+        ),
+        UniqueEvent(
+            title="Legacy Brasil event",
+            event_date=current_start + timedelta(days=2),
+            country="Brasil",  # Legacy display name (should be treated as BR)
+            state="RJ",
+            city="Rio de Janeiro",
+            event_family="homicidio",
+            event_subtype="simples",
+            content_class="incident",
+            victim_count=1,
+            latitude=Decimal("-22.9068"),
+            longitude=Decimal("-43.1729"),
+            source_count=1,
+        ),
+        UniqueEvent(
+            title="New BR event",
+            event_date=current_start + timedelta(days=3),
+            country="BR",  # Canonical code
+            state="SP",
+            city="São Paulo",
+            event_family="homicidio",
+            event_subtype="simples",
+            content_class="incident",
+            victim_count=1,
+            latitude=Decimal("-23.5505"),
+            longitude=Decimal("-46.6333"),
+            source_count=1,
+        ),
+    ]
+    
+    for event in events:
+        async_session.add(event)
+    await async_session.commit()
+    
+    app.dependency_overrides[get_session] = lambda: async_session
+    
+    async with AsyncClient(app=app, base_url="http://test") as client:
+        response = await client.get("/api/public/stats/rankings?days=30")
+        assert response.status_code == 200
+        data = response.json()
+        
+        # Total should include all 3 events
+        assert data["total_events"] == 3
+        assert data["total_victims"] == 3
+        
+        # Countries breakdown
+        countries = data["countries"]
+        assert len(countries) == 2, f"Expected 2 countries (BR and CL), got {len(countries)}: {countries}"
+        
+        # Find BR and CL in results
+        country_map = {c["country"]: c for c in countries}
+        
+        # CL should appear with display name "Chile"
+        assert "Chile" in country_map, f"Chile not found in countries: {list(country_map.keys())}"
+        chile = country_map["Chile"]
+        assert chile["victim_count"] == 1
+        assert chile["event_count"] == 1
+        
+        # BR should appear with display name "Brasil" and count BOTH legacy "Brasil" and new "BR" events
+        assert "Brasil" in country_map, f"Brasil not found in countries: {list(country_map.keys())}"
+        brasil = country_map["Brasil"]
+        assert brasil["victim_count"] == 2, f"Expected 2 victims for Brasil (legacy + new), got {brasil['victim_count']}"
+        assert brasil["event_count"] == 2, f"Expected 2 events for Brasil (legacy + new), got {brasil['event_count']}"
+        
+        # Test country filter: ?country=CL should show only Chilean event
+        response_cl = await client.get("/api/public/stats/rankings?days=30&country=CL")
+        assert response_cl.status_code == 200
+        data_cl = response_cl.json()
+        assert data_cl["total_events"] == 1
+        assert len(data_cl["cities"]) == 1
+        assert data_cl["cities"][0]["city"] == "Santiago"
+        
+        # Test country filter: ?country=BR should show both legacy and new BR events
+        response_br = await client.get("/api/public/stats/rankings?days=30&country=BR")
+        assert response_br.status_code == 200
+        data_br = response_br.json()
+        assert data_br["total_events"] == 2, f"Expected 2 events for BR filter, got {data_br['total_events']}"
+        assert len(data_br["cities"]) == 2
+        city_names = {c["city"] for c in data_br["cities"]}
+        assert "Rio de Janeiro" in city_names
+        assert "São Paulo" in city_names


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements issue #128: Persist `UniqueEvent.country` from ingest instead of hardcoding "Brasil".

## Changes

### Data Flow
- **SourceGoogleNews**: Added `country` field (ISO 3166-1 alpha-2: BR, CL)
- **RawEvent**: Added `country` field, passed from `SourceGoogleNews` during extraction
- **UniqueEvent**: Now uses country from `RawEvent` instead of hardcoding "Brasil"

### Key Implementation
- Store canonical country codes (`BR`, `CL`) instead of display names
- Ingestion: Tag entries with country during `ingest_city` and store in `SourceGoogleNews`
- Extraction: Read country from `SourceGoogleNews` and pass to `RawEvent`
- Deduplication: Use `RawEvent.country` when creating `UniqueEvent` from cluster

### Public API
- Rankings endpoint treats legacy `"Brasil"` rows as `BR` during aggregation
- Country filter `?country=BR` matches both canonical `"BR"` and legacy `"Brasil"` values
- Country filter `?country=CL` matches canonical `"CL"` stored value
- Display names remain UI-level (Brasil/Chile in response)

### Migration
- Added migration `i8j9k0l1m2n3` to add country field to `source_google_news` and `raw_event`
- Backfills existing records with `BR` as default

## Tests

Added `test_persist_country.py` with two test seams:

1. **UniqueEvent persistence**: Chilean fixture with country `CL` survives extract and stores `CL` (not "Brasil")
2. **Public rankings country breakdown**: 
   - CL row appears under `country=CL`
   - Legacy `"Brasil"` rows are treated as BR
   - Filter `?country=BR` shows both legacy "Brasil" and new "BR" events

## TDD Approach

✅ Written tests first (RED)  
✅ Implemented minimal code to pass (GREEN)  
✅ Verified through two agreed test seams

## Bug Fix (commit 5f32d21)

Fixed critical bugs in `get_rankings`:
- **Indentation**: `build_query` now properly returns the filtered query (was returning at module level)
- **Country filter**: Now matches canonical codes (`BR`, `CL`) not display names (`"Brasil"`, `"Chile"`)
- Filter `?country=CL` now correctly matches stored `"CL"` values
- Filter `?country=BR` matches both `"BR"` and legacy `"Brasil"`

## Out of Scope

As requested, this PR does NOT include:
- Spanish classifier
- geocode region=cl
- CHILEAN_QUERY_TERMS
- Official stats integration
- Next country support
- Rates per 100k population
- Frontend rankings polish beyond country field support

Closes #128
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a2dc770f-45ac-430c-8317-b7bf0445be94?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a2dc770f-45ac-430c-8317-b7bf0445be94&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

