### PR TITLE
Country-aware classifier and content-gate for Chile (issue #129)

### DIFF
--- a/backend/app/services/classification.py
+++ b/backend/app/services/classification.py
@@ -95,6 +95,7 @@ CLASSIFIQUE COMO MORTE VIOLENTA (is_violent_death = true):
 - Corpo, restos mortais ou ossada encontrados com indícios de violência
 - Tiroteio/confronto/operação policial que deixa mortos (inclui jargão: "neutralizado",
   "CPF cancelado" no sentido de pessoa morta)
+  (ES: operativos de Carabineros, PDI — forças policiais chilenas)
 - Feminicídio, latrocínio, homicídio, chacina, execução
   (ES: femicidio, homicidio, asesinato, balacera)
 - Vítima que MORRE: "não resistiu aos ferimentos", "morre após ser baleado"
@@ -151,6 +152,7 @@ Use a manchete apenas como contexto. Baseie a decisão principalmente no corpo d
 CLASSIFIQUE COMO MORTE VIOLENTA (is_violent_death = true):
 - Morte violenta no Brasil ou Chile descrita no corpo: homicídio, tiroteio, operação policial com morte
   (ES: homicidio, asesinato, balacera, operativo policial)
+  (Forças policiais chilenas: Carabineros, PDI)
 - Corpo/restos encontrados com indícios de violência
 - Feminicídio, latrocínio, chacina, execução
   (ES: femicidio, homicidio, asesinato)

--- a/backend/app/services/classification.py
+++ b/backend/app/services/classification.py
@@ -21,20 +21,21 @@ class ViolentDeathClassification(BaseModel):
     is_violent_death: bool = Field(
         ...,
         description="""
-        TRUE only if the headline is about one or more NEW violent deaths in Brazil
+        TRUE only if the headline is about one or more NEW violent deaths in Brazil or Chile
         (homicides, murders, killings, police operations with deaths).
 
         Examples of TRUE:
-        - "Homem é morto a tiros em operação policial"
-        - "Corpo é encontrado com marcas de violência"
-        - "Tiroteio deixa dois mortos na Zona Norte"
-        - "Mulher é assassinada pelo ex-marido"
+        - "Homem é morto a tiros em operação policial" (Brazil)
+        - "Corpo é encontrado com marcas de violência" (Brazil)
+        - "Tiroteio deixa dois mortos na Zona Norte" (Brazil)
+        - "Mulher é assassinada pelo ex-marido" (Brazil)
+        - "Hombre asesinado en operativo policial en Santiago" (Chile)
 
         Examples of FALSE:
         - "Polícia prende suspeito de roubo"
         - "Homem sobrevive após ser baleado"
         - "Vítima de facadas chora no julgamento do agressor" (victim alive)
-        - "Atirador em massa no Texas recebe pena de morte" (foreign event)
+        - "Atirador em massa no Texas recebe pena de morte" (foreign: outside BR/CL)
         - "Operação apreende drogas e armas"
         """
     )

--- a/backend/app/services/classification.py
+++ b/backend/app/services/classification.py
@@ -82,28 +82,32 @@ class ViolentDeathClassification(BaseModel):
 
 # System prompt for classification
 CLASSIFICATION_SYSTEM_PROMPT = """
-Você é um classificador de manchetes de notícias do GOOGLE NEWS BRASIL. Sua tarefa é:
-1. Determinar se a manchete indica NOTÍCIA sobre MORTE(S) VIOLENTA(S) no Brasil.
+Você é um classificador de manchetes de notícias do Google News. Sua tarefa é:
+1. Determinar se a manchete indica NOTÍCIA sobre MORTE(S) VIOLENTA(S) no Brasil ou no Chile.
 2. Determinar se descreve UM ÚNICO INCIDENTE específico (is_single_incident).
 
-Este filtro alimenta um arquivo de violência no Rio de Janeiro. Manchetes sobre mortes
-violentas no exterior NÃO entram, mesmo que mencionem tiroteio, guerra ou assassinato.
+Este filtro alimenta um arquivo de violência que cobre Brasil e Chile. Manchetes sobre mortes
+violentas em outros países NÃO entram, mesmo que mencionem tiroteio, guerra ou assassinato.
 
 CLASSIFIQUE COMO MORTE VIOLENTA (is_violent_death = true):
-- Morte violenta no Brasil: morto(s), assassinado(s), executado(s), baleado(s) MORTO
+- Morte violenta no Brasil ou Chile: morto(s), assassinado(s), executado(s), baleado(s) MORTO
+  (PT: morto, assassinado, baleado; ES: asesinado, muerto, baleado)
 - Corpo, restos mortais ou ossada encontrados com indícios de violência
 - Tiroteio/confronto/operação policial que deixa mortos (inclui jargão: "neutralizado",
   "CPF cancelado" no sentido de pessoa morta)
 - Feminicídio, latrocínio, homicídio, chacina, execução
+  (ES: femicidio, homicidio, asesinato, balacera)
 - Vítima que MORRE: "não resistiu aos ferimentos", "morre após ser baleado"
+  (ES: "no resistió", "murió tras", "falleció")
 - Letalidade implícita: "crivado de balas", "CPF cancelado", "tombou/tombaram",
   "não deixa sobreviventes", "linchado até parar de respirar" — trate como morte violenta
   salvo se a manchete indicar sobrevivência (ferido, hospital, quadro estável)
 
 NÃO CLASSIFIQUE COMO MORTE VIOLENTA (is_violent_death = false):
-- Eventos FORA DO BRASIL (EUA, Europa, Rússia, Ucrânia, México, etc.), mesmo com mortes
+- Eventos FORA do Brasil e do Chile (EUA, Europa, Rússia, Ucrânia, México, etc.), mesmo com mortes
 - Vítima VIVA: sobrevive, ferido(s), hospitalizado, chora, presta depoimento, "vítima de
   X facadas" no julgamento (sobrevivente), tentativa de homicídio sem morte
+  (ES: sobrevivió, herido, hospitalizado)
 - Tiroteio, operação ou confronto SEM menção a morte ou feridos mortos
 - Prisões, mandados, julgamentos, pena de morte como sentença judicial (notícia jurídica)
 - Apreensões de armas/drogas, políticas de segurança
@@ -112,13 +116,14 @@ NÃO CLASSIFIQUE COMO MORTE VIOLENTA (is_violent_death = false):
 - Arsenal apreendido para crimes futuros (crime frustrado, sem morte na notícia)
 
 INCIDENTE ÚNICO (is_single_incident = true):
-- Um homicídio ou tiroteio específico no Brasil, em local identificável
+- Um homicídio ou tiroteio específico no Brasil ou Chile, em local identificável
 - "Tiroteio deixa dois mortos na Zona Norte" (um evento)
 - "Homem é morto a tiros em operação policial"
+- "Hombre asesinado en Santiago" (ES)
 
 NÃO É INCIDENTE ÚNICO (is_single_incident = false) — descarte mesmo se mencionar mortes:
 - Estatísticas agregadas: balanço anual, CVLI, "X mortes em 2025", "no estado", painéis
-- Notícias estrangeiras: terremotos, guerras, desastres fora do Brasil
+- Notícias estrangeiras: terremotos, guerras, desastres fora do Brasil e do Chile
 - Suicídios (mesmo violentos)
 - Crueldade contra animais
 - Resumos com múltiplos incidentes não relacionados
@@ -127,25 +132,28 @@ NÃO É INCIDENTE ÚNICO (is_single_incident = false) — descarte mesmo se menc
 Use content_class_hint quando aplicável: incident, aggregate_statistics, foreign,
 non_incident, suicide, accident_disaster.
 
-Baseie-se APENAS no texto da manchete. Em dúvida sobre local (Brasil vs exterior), procure
-topônimos estrangeiros (Texas, EUA, Rússia, Ucrânia) ou contexto claramente internacional.
+Baseie-se APENAS no texto da manchete. Em dúvida sobre local (Brasil/Chile vs exterior), procure
+topônimos estrangeiros (Texas, EUA, Rússia, Ucrânia, México) ou contexto claramente internacional.
+Chile e Brasil são IN; outros países são OUT.
 """
 
 CONTENT_CLASSIFICATION_SYSTEM_PROMPT = """
-Você é um classificador de ARTIGOS JORNALÍSTICOS do Google News Brasil. A manchete já passou
+Você é um classificador de ARTIGOS JORNALÍSTICOS do Google News. A manchete já passou
 por um filtro inicial, mas o CORPO do artigo pode revelar que a matéria NÃO descreve um
-incidente único de morte violenta no Brasil.
+incidente único de morte violenta no Brasil ou no Chile.
 
 Sua tarefa:
-1. Determinar se o artigo trata de MORTE(S) VIOLENTA(S) no Brasil.
+1. Determinar se o artigo trata de MORTE(S) VIOLENTA(S) no Brasil ou no Chile.
 2. Determinar se descreve UM ÚNICO INCIDENTE específico (is_single_incident).
 
 Use a manchete apenas como contexto. Baseie a decisão principalmente no corpo do artigo.
 
 CLASSIFIQUE COMO MORTE VIOLENTA (is_violent_death = true):
-- Morte violenta no Brasil descrita no corpo: homicídio, tiroteio, operação policial com morte
+- Morte violenta no Brasil ou Chile descrita no corpo: homicídio, tiroteio, operação policial com morte
+  (ES: homicidio, asesinato, balacera, operativo policial)
 - Corpo/restos encontrados com indícios de violência
 - Feminicídio, latrocínio, chacina, execução
+  (ES: femicidio, homicidio, asesinato)
 - CASO ENTERRADO em matéria estatística: se uma matéria de balanço/estatísticas descreve
   em detalhe UM caso concreto cujo ÓBITO É RECENTE (ocorreu há horas/dias, ex.: "na noite
   de ontem"), classifique is_violent_death = true e is_single_incident = true — o caso
@@ -156,11 +164,12 @@ pauta é julgamento/condenação de crime antigo = false (o óbito não é novo)
 detalhes do caso. Matéria estatística que cita uma morte ocorrida ontem = true.
 
 NÃO CLASSIFIQUE COMO MORTE VIOLENTA (is_violent_death = false):
-- Eventos FORA DO BRASIL (desastres, guerras, crimes internacionais) — atenção a cidades
-  homônimas: o corpo pode revelar que "Belém" é no Texas, etc.
+- Eventos FORA do Brasil e do Chile (desastres, guerras, crimes internacionais em EUA, México,
+  Europa, etc.) — atenção a cidades homônimas: o corpo pode revelar que "Belém" é no Texas, etc.
 - VÍTIMA SOBREVIVEU: se o corpo informa que a vítima foi socorrida, está internada,
   estável ou sobreviveu, NÃO há morte violenta — mesmo em "tentativa de feminicídio"
   ou ataque brutal. Sem óbito, is_violent_death = false.
+  (ES: sobrevivió, hospitalizado, estable)
 - Matéria sobre PROCESSO JUDICIAL: julgamento, júri, condenação, absolvição, prisão ou
   investigação de crime que já ocorreu no passado. A pauta é o processo, não um novo
   óbito — mesmo que o corpo descreva os homicídios julgados, is_violent_death = false.
@@ -170,8 +179,9 @@ NÃO CLASSIFIQUE COMO MORTE VIOLENTA (is_violent_death = false):
 - Apreensões, políticas, análises sem caso específico
 
 INCIDENTE ÚNICO (is_single_incident = true):
-- Um homicídio ou tiroteio específico no Brasil, em local identificável
+- Um homicídio ou tiroteio específico no Brasil ou Chile, em local identificável
 - Um evento claramente delimitado ("tiroteio deixa dois mortos na Zona Norte")
+  (ES: "balacera deja dos muertos en Santiago")
 - ATENÇÃO: mesmo em matéria com tom estatístico, se o corpo DESCREVE um incidente
   específico (vítima, local e circunstâncias identificáveis), classifique
   is_single_incident = true — o caso concreto prevalece sobre o enquadramento da matéria.
@@ -179,7 +189,7 @@ INCIDENTE ÚNICO (is_single_incident = true):
 NÃO É INCIDENTE ÚNICO (is_single_incident = false) — descarte:
 - Estatísticas agregadas SEM caso concreto descrito: balanço anual, CVLI, totais
   estaduais/nacionais, "X mortes em 2025"
-- Notícias estrangeiras mesmo que a manchete pareça local
+- Notícias estrangeiras fora do Brasil e do Chile mesmo que a manchete pareça local
 - Suicídios, crueldade contra animais, acidentes sem homicídio doloso
 - Resumos com múltiplos incidentes não relacionados
 

--- a/backend/app/services/classification_heuristics.py
+++ b/backend/app/services/classification_heuristics.py
@@ -14,14 +14,19 @@ _SURVIVAL_PATTERNS = (
     re.compile(r"\bsobrevive\b", re.IGNORECASE),
     re.compile(r"\bsobreviveu\b", re.IGNORECASE),
     re.compile(r"\bsobreviveram\b", re.IGNORECASE),
+    re.compile(r"\bsobrevivio\b", re.IGNORECASE),  # ES
+    re.compile(r"\bsobrevivió\b", re.IGNORECASE),  # ES
+    re.compile(r"\bsobrevivieron\b", re.IGNORECASE),  # ES
     re.compile(r"quadro estavel", re.IGNORECASE),
     re.compile(r"quadro estável", re.IGNORECASE),
     re.compile(r"\bhospital\b", re.IGNORECASE),
+    re.compile(r"\bhospitalizado\b", re.IGNORECASE),  # ES/PT
     re.compile(r"centro cirurgico", re.IGNORECASE),
     re.compile(r"centro cirúrgico", re.IGNORECASE),
     re.compile(r"\binternad", re.IGNORECASE),
     re.compile(r"\bsocorrid", re.IGNORECASE),
     re.compile(r"\bferid[oa]s?\b", re.IGNORECASE),
+    re.compile(r"\bherid[oa]s?\b", re.IGNORECASE),  # ES
     re.compile(r"chora ao ver", re.IGNORECASE),
     re.compile(r"banco dos reus", re.IGNORECASE),
     re.compile(r"banco dos réus", re.IGNORECASE),
@@ -43,6 +48,13 @@ _FOREIGN_MARKERS = (
     " mexico",
     " méxico",
     " base militar russa",
+    " argentina",
+    " peru",
+    " colombia",
+    " bolivia",
+    " ecuador",
+    " uruguay",
+    " paraguay",
 )
 
 _METAPHOR_MARKERS = (
@@ -71,9 +83,16 @@ _EXPLICIT_DEATH_MARKERS = (
     "não resistiu",
     "nao resiste",
     "não resiste",
+    "no resistio",  # ES
+    "no resistió",  # ES
     "morre no hospital",
     "morre apos",
     "morre após",
+    "muere en hospital",  # ES
+    "murio tras",  # ES
+    "murió tras",  # ES
+    "fallecio",  # ES
+    "falleció",  # ES
     "veio a obito",
     "veio a óbito",
     "faleceu",
@@ -82,6 +101,8 @@ _EXPLICIT_DEATH_MARKERS = (
     "óbito",
     "encontrado morto",
     "achado morto",
+    "encontrado muerto",  # ES
+    "hallado muerto",  # ES
 )
 
 _NON_DEATH_POLICE_MARKERS = (
@@ -93,6 +114,8 @@ _NON_DEATH_POLICE_MARKERS = (
 _IMPLIED_FATAL_MARKERS = (
     "crivado de balas",
     "crivada de balas",
+    "acribillado",  # ES
+    "acribillada",  # ES
     "restos mortais",
     "carbonizado no porta-malas",
     "carbonizado no portamalas",
@@ -118,11 +141,15 @@ _IMPLIED_FATAL_MARKERS = (
     "não resiste",
     "feminicidio",
     "feminicídio",
+    "femicidio",  # ES
     "homicidio doloso",
     "homicídio doloso",
+    "homicidio",  # ES
+    "asesinato",  # ES
     "duplo homicidio",
     "duplo homicídio",
     "chacina",
+    "balacera",  # ES
 )
 
 _TROCA_TIROS = re.compile(r"troca tiros", re.IGNORECASE)

--- a/backend/app/services/classification_heuristics.py
+++ b/backend/app/services/classification_heuristics.py
@@ -146,10 +146,20 @@ _IMPLIED_FATAL_MARKERS = (
     "homicídio doloso",
     "homicidio",  # ES
     "asesinato",  # ES
+    "asesinado",  # ES past participle
+    "asesinada",  # ES past participle
     "duplo homicidio",
     "duplo homicídio",
     "chacina",
     "balacera",  # ES
+    " morto ",  # PT/ES past participle (with spaces to force violent death)
+    " morta ",
+    " mortos ",
+    " mortas ",
+    " muerto ",  # ES past participle
+    " muerta ",
+    " muertos ",
+    " muertas ",
 )
 
 _TROCA_TIROS = re.compile(r"troca tiros", re.IGNORECASE)

--- a/backend/app/services/content_filters.py
+++ b/backend/app/services/content_filters.py
@@ -82,7 +82,7 @@ _FOREIGN_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
     (
         "foreign_earthquake",
         re.compile(
-            r"\bterremoto.{0,80}\b(venezuela|chile|turquia|turkey|m[eé]xico|haiti|afeganist[aã]o)\b",
+            r"\bterremoto.{0,80}\b(venezuela|turquia|turkey|m[eé]xico|haiti|afeganist[aã]o)\b",
             re.IGNORECASE,
         ),
     ),
@@ -96,7 +96,7 @@ _FOREIGN_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
     (
         "foreign_mass_shooting",
         re.compile(
-            r"\b(atirador|tiroteio|mass\s+shooting).{0,40}\b(eua|estados\s+unidos|texas|california|paris|londres)\b",
+            r"\b(atirador|tiroteio|mass\s+shooting|tiroteo).{0,40}\b(eua|estados\s+unidos|texas|california|paris|londres|m[eé]xico|argentina|per[uú]|colombia|bolivia)\b",
             re.IGNORECASE,
         ),
     ),

--- a/backend/app/services/content_filters.py
+++ b/backend/app/services/content_filters.py
@@ -96,7 +96,9 @@ _FOREIGN_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
     (
         "foreign_mass_shooting",
         re.compile(
-            r"\b(atirador|tiroteio|mass\s+shooting|tiroteo).{0,40}\b(eua|estados\s+unidos|texas|california|paris|londres|m[eé]xico|argentina|per[uú]|colombia|bolivia)\b",
+            r"\b(atirador|tiroteio|mass\s+shooting|tiroteo).{0,40}"
+            r"\b(eua|estados\s+unidos|texas|california|paris|londres|"
+            r"m[eé]xico|argentina|per[uú]|colombia|bolivia)\b",
             re.IGNORECASE,
         ),
     ),

--- a/backend/app/services/download.py
+++ b/backend/app/services/download.py
@@ -80,12 +80,11 @@ async def _fetch_html(url: str) -> tuple[int, str]:
     can classify the reason.
     """
     settings = get_settings()
-    
     # Country-aware Accept-Language header (issue #129)
     accept_language = "pt-BR,pt;q=0.9,en;q=0.8"
     if ".cl/" in url or url.endswith(".cl"):
         accept_language = "es-CL,es;q=0.9,pt-BR;q=0.8,pt;q=0.7,en;q=0.6"
-    
+
     headers = {
         "User-Agent": settings.download_user_agent,
         "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",

--- a/backend/app/services/download.py
+++ b/backend/app/services/download.py
@@ -80,10 +80,16 @@ async def _fetch_html(url: str) -> tuple[int, str]:
     can classify the reason.
     """
     settings = get_settings()
+    
+    # Country-aware Accept-Language header (issue #129)
+    accept_language = "pt-BR,pt;q=0.9,en;q=0.8"
+    if ".cl/" in url or url.endswith(".cl"):
+        accept_language = "es-CL,es;q=0.9,pt-BR;q=0.8,pt;q=0.7,en;q=0.6"
+    
     headers = {
         "User-Agent": settings.download_user_agent,
         "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
-        "Accept-Language": "pt-BR,pt;q=0.9,en;q=0.8",
+        "Accept-Language": accept_language,
     }
     async with httpx.AsyncClient(
         follow_redirects=True,

--- a/backend/app/services/extraction.py
+++ b/backend/app/services/extraction.py
@@ -51,18 +51,18 @@ para resolver datas relativas mencionadas no texto.
 
 RESOLUÇÃO DE DATAS RELATIVAS:
 Se a notícia foi publicada em 21/12/2025 e o texto menciona:
-- "ontem" -> 20/12/2025
-- "anteontem" -> 19/12/2025
-- "na sexta-feira" -> calcule qual sexta-feira mais recente antes da publicação
-- "nesta semana" -> semana da publicação
-- "há três dias" -> 18/12/2025
+- "ontem" → 20/12/2025
+- "anteontem" → 19/12/2025
+- "na sexta-feira" → calcule qual sexta-feira mais recente antes da publicação
+- "nesta semana" → semana da publicação
+- "há três dias" → 18/12/2025
 
 QUANDO PODE INFERIR A DATA (has_explicit_date = TRUE):
 1. Data completa explícita: "15 de dezembro de 2025", "20/11/2025"
 2. Data relativa COM referência de publicação: "ontem" quando você sabe a data de publicação
 3. Dia da semana COM número entre parênteses: "domingo (10)", "sexta-feira (12)" —
    PRIORIZE o número do dia do mês sobre o dia da semana quando houver conflito
-   (ex.: publicação em 11/03/2025 + "domingo (10)" -> 2025-03-10, não o domingo anterior).
+   (ex.: publicação em 11/03/2025 + "domingo (10)" → 2025-03-10, não o domingo anterior).
 
 QUANDO NÃO PODE INFERIR (has_explicit_date = FALSE):
 1. Termos vagos sem referência: "recentemente", "há alguns dias", "no início da semana"
@@ -71,7 +71,7 @@ QUANDO NÃO PODE INFERIR (has_explicit_date = FALSE):
 4. O texto NÃO menciona quando o crime ocorreu: a data de publicação sozinha NÃO é a
    data do evento — ela serve apenas para resolver expressões relativas do texto.
    Se o artigo não diz QUANDO o crime aconteceu, date = null MESMO que pareça recente.
-5. Apenas mês/ano sem dia ("em setembro de 2024") -> date = null
+5. Apenas mês/ano sem dia ("em setembro de 2024") → date = null
 
 ATENÇÃO - DATA DO CRIME vs DATA DA DESCOBERTA:
 O campo date refere-se à data em que o CRIME ocorreu. Use date = null (has_explicit_date
@@ -80,7 +80,7 @@ corpo em decomposição, ossada, "a morte não foi recente". Nesses casos a data
 é desconhecida mesmo que a data da descoberta seja conhecida.
 Fora desses casos, a data em que a vítima foi morta/encontrada informada no texto É a
 data do evento — use-a normalmente, inclusive quando o corpo foi encontrado horas ou
-até um dia após o crime (ex.: "encontrada morta na noite do dia 18" -> 18).
+até um dia após o crime (ex.: "encontrada morta na noite do dia 18" → 18).
 
 O campo date_verification funciona como um VERIFICADOR:
 1. has_explicit_date = TRUE se você consegue determinar a data completa (dia/mês/ano)
@@ -96,9 +96,9 @@ IMPORTANTE:
 
 SOBRE LOCALIZAÇÃO (location_info.state):
 - Preencha o estado (UF) quando estiver explícito no texto OU quando a cidade for
-  inequívoca: capitais e cidades notórias (Recife -> PE, Manaus -> AM, Belém -> PA,
-  Campina Grande -> PB, Londrina -> PR), ou quando o contexto identifica a região
-  ("Grande Vitória" -> ES, "capital de Rondônia" -> Porto Velho/RO, "Baixada Fluminense" -> RJ).
+  inequívoca: capitais e cidades notórias (Recife → PE, Manaus → AM, Belém → PA,
+  Campina Grande → PB, Londrina → PR), ou quando o contexto identifica a região
+  ("Grande Vitória" → ES, "capital de Rondônia" → Porto Velho/RO, "Baixada Fluminense" → RJ).
 - location_info.city: se o texto identifica a cidade indiretamente ("capital de
   Rondônia", "Grande Vitória"), preencha com o nome da cidade correspondente.
 - Se o nome da cidade é ambíguo entre estados e o texto não desambigua
@@ -142,8 +142,8 @@ Se event_family = "nao_classificado":
 - "outro"
 
 REGRAS:
-- Sem óbito -> event_family = "tentativa", nunca "homicidio"
-- Morte culposa/acidente sem dolo -> event_family = "acidente_fatal"
+- Sem óbito → event_family = "tentativa", nunca "homicidio"
+- Morte culposa/acidente sem dolo → event_family = "acidente_fatal"
 - Feminicídio, latrocínio e qualificado são SUBTIPOS de homicidio, não famílias separadas
 - event_family = "homicidio" exige content_class = "incident"
 
@@ -162,7 +162,7 @@ Defina content_class em todo JSON de saída. Valores permitidos:
 
 SOBRE number_of_victims — NUNCA USE TOTAIS AGREGADOS:
 - Conte APENAS as vítimas FATAIS do incidente (mortos), NUNCA inclua feridos.
-  Ex.: "três mortos e um ferido" -> number_of_victims = 3, não 4.
+  Ex.: "três mortos e um ferido" → number_of_victims = 3, não 4.
 - Conte APENAS as vítimas do incidente específico descrito (máximo 20).
 - NUNCA use totais anuais, CVLI, "4.241 mortes em 2025", balanço estadual ou estatísticas
   de painel como number_of_victims — mesmo que sejam o tema da matéria.
@@ -171,8 +171,8 @@ SOBRE number_of_victims — NUNCA USE TOTAIS AGREGADOS:
   embutido; caso contrário a extração será descartada downstream.
 
 SOBRE homicide_dynamic.method — OBRIGATÓRIO PREENCHER:
-- Use um valor do enum quando o texto indicar o meio (tiros -> "Arma de fogo",
-  facadas -> "Arma branca", traumatismo craniano -> "Objeto contundente").
+- Use um valor do enum quando o texto indicar o meio (tiros → "Arma de fogo",
+  facadas → "Arma branca", traumatismo craniano → "Objeto contundente").
 - "Não especificado" quando a matéria diz que o método/causa não foi determinado
   ou não divulgado, ou quando há pouquíssima informação sobre a dinâmica.
 - Não deixe null se o texto menciona tiros, disparos, facadas ou equivalentes.
@@ -206,7 +206,7 @@ SOBRE AGENTES DE SEGURANÇA (vítimas e autores identificáveis):
 
 SOBRE VÍTIMA POLÍTICA (identifiable_victims[].political_role):
 - Preencher political_role SOMENTE quando o texto identifica a vítima como política ou candidata.
-- is_politician_or_candidate=true; status=elected | candidate | former_elected (ex-vereador -> former_elected).
+- is_politician_or_candidate=true; status=elected | candidate | former_elected (ex-vereador → former_elected).
 - office: cargo sem prefixo "ex-" (ex.: "vereador" mesmo para ex-vereador).
 - party: sigla/nome conforme texto; null se não mencionado — NÃO inferir partido.
 
@@ -253,18 +253,18 @@ para resolver fechas relativas mencionadas en el texto.
 
 RESOLUCIÓN DE FECHAS RELATIVAS:
 Si la noticia fue publicada el 21/12/2025 y el texto menciona:
-- "ayer" -> 20/12/2025
-- "anteayer" -> 19/12/2025
-- "el viernes" -> calcula cuál viernes más reciente antes de la publicación
-- "esta semana" -> semana de la publicación
-- "hace tres días" -> 18/12/2025
+- "ayer" → 20/12/2025
+- "anteayer" → 19/12/2025
+- "el viernes" → calcula cuál viernes más reciente antes de la publicación
+- "esta semana" → semana de la publicación
+- "hace tres días" → 18/12/2025
 
 CUÁNDO PUEDES INFERIR LA FECHA (has_explicit_date = TRUE):
 1. Fecha completa explícita: "15 de diciembre de 2025", "20/11/2025"
 2. Fecha relativa CON referencia de publicación: "ayer" cuando conoces la fecha de publicación
 3. Día de la semana CON número entre paréntesis: "domingo (10)", "viernes (12)" —
    PRIORIZA el número del día del mes sobre el día de la semana cuando haya conflicto
-   (ej.: publicación el 11/03/2025 + "domingo (10)" -> 2025-03-10, no el domingo anterior).
+   (ej.: publicación el 11/03/2025 + "domingo (10)" → 2025-03-10, no el domingo anterior).
 
 CUÁNDO NO PUEDES INFERIR (has_explicit_date = FALSE):
 1. Términos vagos sin referencia: "recientemente", "hace algunos días", "a principios de semana"
@@ -273,7 +273,7 @@ CUÁNDO NO PUEDES INFERIR (has_explicit_date = FALSE):
 4. El texto NO menciona cuándo ocurrió el crimen: la fecha de publicación sola NO es la
    fecha del evento — sirve solo para resolver expresiones relativas del texto.
    Si el artículo no dice CUÁNDO sucedió el crimen, date = null AUNQUE parezca reciente.
-5. Solo mes/año sin día ("en septiembre de 2024") -> date = null
+5. Solo mes/año sin día ("en septiembre de 2024") → date = null
 
 ATENCIÓN - FECHA DEL CRIMEN vs FECHA DEL DESCUBRIMIENTO:
 El campo date se refiere a la fecha en que el CRIMEN ocurrió. Usa date = null (has_explicit_date
@@ -282,7 +282,7 @@ cuerpo en descomposición, restos óseos, "la muerte no fue reciente". En esos c
 es desconocida aunque la fecha del descubrimiento sea conocida.
 Fuera de esos casos, la fecha en que la víctima fue asesinada/encontrada informada en el texto ES la
 fecha del evento — úsala normalmente, incluso cuando el cuerpo fue encontrado horas o
-hasta un día después del crimen (ej.: "encontrada muerta la noche del 18" -> 18).
+hasta un día después del crimen (ej.: "encontrada muerta la noche del 18" → 18).
 
 El campo date_verification funciona como un VERIFICADOR:
 1. has_explicit_date = TRUE si puedes determinar la fecha completa (día/mes/año)
@@ -299,8 +299,8 @@ IMPORTANTE:
 SOBRE LOCALIZACIÓN (location_info.state):
 - Llena la región cuando esté explícita en el texto O cuando la ciudad sea
   inequívoca: capitales y ciudades conocidas (Valparaíso, Concepción, Antofagasta),
-  o cuando el contexto identifica la región ("Región Metropolitana" -> Metropolitana,
-  "capital de Chile" -> Santiago/Metropolitana).
+  o cuando el contexto identifica la región ("Región Metropolitana" → Metropolitana,
+  "capital de Chile" → Santiago/Metropolitana).
 - location_info.city: si el texto identifica la ciudad indirectamente ("capital de Chile",
   "Gran Santiago"), llena con el nombre de la ciudad correspondiente.
 - location_info.state: usa el nombre completo de la región chilena (Metropolitana, Valparaíso,
@@ -344,8 +344,8 @@ Si event_family = "nao_classificado":
 - "outro"
 
 REGLAS:
-- Sin muerte -> event_family = "tentativa", nunca "homicidio"
-- Muerte culposa/accidente sin dolo -> event_family = "acidente_fatal"
+- Sin muerte → event_family = "tentativa", nunca "homicidio"
+- Muerte culposa/accidente sin dolo → event_family = "acidente_fatal"
 - Femicidio, robo con homicidio y calificado son SUBTIPOS de homicidio, no familias separadas
 - event_family = "homicidio" exige content_class = "incident"
 
@@ -364,7 +364,7 @@ Define content_class en todo JSON de salida. Valores permitidos:
 
 SOBRE number_of_victims — NUNCA USES TOTALES AGREGADOS:
 - Cuenta SOLAMENTE las víctimas FATALES del incidente (muertos), NUNCA incluyas heridos.
-  Ej.: "tres muertos y un herido" -> number_of_victims = 3, no 4.
+  Ej.: "tres muertos y un herido" → number_of_victims = 3, no 4.
 - Cuenta SOLAMENTE las víctimas del incidente específico descrito (máximo 20).
 - NUNCA uses totales anuales, "4.241 muertes en 2025", balance regional o estadísticas
   de panel como number_of_victims — aunque sean el tema de la noticia.
@@ -373,8 +373,8 @@ SOBRE number_of_victims — NUNCA USES TOTALES AGREGADOS:
   incluido; de lo contrario la extracción será descartada downstream.
 
 SOBRE homicide_dynamic.method — OBLIGATORIO COMPLETAR:
-- Usa un valor del enum cuando el texto indique el medio (tiros -> "Arma de fogo",
-  puñaladas -> "Arma branca", traumatismo craneal -> "Objeto contundente").
+- Usa un valor del enum cuando el texto indique el medio (tiros → "Arma de fogo",
+  puñaladas → "Arma branca", traumatismo craneal → "Objeto contundente").
 - "Não especificado" cuando la noticia dice que el método/causa no fue determinado
   o no fue divulgado, o cuando hay muy poca información sobre la dinámica.
 - No dejes null si el texto menciona disparos, balazos, puñaladas o equivalentes.
@@ -409,7 +409,7 @@ SOBRE AGENTES DE SEGURIDAD (víctimas y autores identificables):
 
 SOBRE VÍCTIMA POLÍTICA (identifiable_victims[].political_role):
 - Completar political_role SOLAMENTE cuando el texto identifica a la víctima como político o candidato.
-- is_politician_or_candidate=true; status=elected | candidate | former_elected (ex-concejal -> former_elected).
+- is_politician_or_candidate=true; status=elected | candidate | former_elected (ex-concejal → former_elected).
 - office: cargo sin prefijo "ex-" (ej.: "concejal" incluso para ex-concejal).
 - party: sigla/nombre según texto; null si no mencionado — NO inferir partido.
 
@@ -452,18 +452,18 @@ para resolver datas relativas mencionadas no texto.
 
 RESOLUÇÃO DE DATAS RELATIVAS:
 Se a notícia foi publicada em 21/12/2025 e o texto menciona:
-- "ontem" -> 20/12/2025
-- "anteontem" -> 19/12/2025
-- "na sexta-feira" -> calcule qual sexta-feira mais recente antes da publicação
-- "nesta semana" -> semana da publicação
-- "há três dias" -> 18/12/2025
+- "ontem" → 20/12/2025
+- "anteontem" → 19/12/2025
+- "na sexta-feira" → calcule qual sexta-feira mais recente antes da publicação
+- "nesta semana" → semana da publicação
+- "há três dias" → 18/12/2025
 
 QUANDO PODE INFERIR A DATA (has_explicit_date = TRUE):
 1. Data completa explícita: "15 de dezembro de 2025", "20/11/2025"
 2. Data relativa COM referência de publicação: "ontem" quando você sabe a data de publicação
 3. Dia da semana COM número entre parênteses: "domingo (10)", "sexta-feira (12)" —
    PRIORIZE o número do dia do mês sobre o dia da semana quando houver conflito
-   (ex.: publicação em 11/03/2025 + "domingo (10)" -> 2025-03-10, não o domingo anterior).
+   (ex.: publicação em 11/03/2025 + "domingo (10)" → 2025-03-10, não o domingo anterior).
 
 QUANDO NÃO PODE INFERIR (has_explicit_date = FALSE):
 1. Termos vagos sem referência: "recentemente", "há alguns dias", "no início da semana"
@@ -472,7 +472,7 @@ QUANDO NÃO PODE INFERIR (has_explicit_date = FALSE):
 4. O texto NÃO menciona quando o crime ocorreu: a data de publicação sozinha NÃO é a
    data do evento — ela serve apenas para resolver expressões relativas do texto.
    Se o artigo não diz QUANDO o crime aconteceu, date = null MESMO que pareça recente.
-5. Apenas mês/ano sem dia ("em setembro de 2024") -> date = null
+5. Apenas mês/ano sem dia ("em setembro de 2024") → date = null
 
 ATENÇÃO - DATA DO CRIME vs DATA DA DESCOBERTA:
 O campo date refere-se à data em que o CRIME ocorreu. Use date = null (has_explicit_date
@@ -481,7 +481,7 @@ corpo em decomposição, ossada, "a morte não foi recente". Nesses casos a data
 é desconhecida mesmo que a data da descoberta seja conhecida.
 Fora desses casos, a data em que a vítima foi morta/encontrada informada no texto É a
 data do evento — use-a normalmente, inclusive quando o corpo foi encontrado horas ou
-até um dia após o crime (ex.: "encontrada morta na noite do dia 18" -> 18).
+até um dia após o crime (ex.: "encontrada morta na noite do dia 18" → 18).
 
 O campo date_verification funciona como um VERIFICADOR:
 1. has_explicit_date = TRUE se você consegue determinar a data completa (dia/mês/ano)
@@ -497,9 +497,9 @@ IMPORTANTE:
 
 SOBRE LOCALIZAÇÃO (location_info.state):
 - Preencha o estado (UF) quando estiver explícito no texto OU quando a cidade for
-  inequívoca: capitais e cidades notórias (Recife -> PE, Manaus -> AM, Belém -> PA,
-  Campina Grande -> PB, Londrina -> PR), ou quando o contexto identifica a região
-  ("Grande Vitória" -> ES, "capital de Rondônia" -> Porto Velho/RO, "Baixada Fluminense" -> RJ).
+  inequívoca: capitais e cidades notórias (Recife → PE, Manaus → AM, Belém → PA,
+  Campina Grande → PB, Londrina → PR), ou quando o contexto identifica a região
+  ("Grande Vitória" → ES, "capital de Rondônia" → Porto Velho/RO, "Baixada Fluminense" → RJ).
 - location_info.city: se o texto identifica a cidade indiretamente ("capital de
   Rondônia", "Grande Vitória"), preencha com o nome da cidade correspondente.
 - Se o nome da cidade é ambíguo entre estados e o texto não desambigua
@@ -541,8 +541,8 @@ Se event_family = "nao_classificado":
 - "outro"
 
 REGRAS:
-- Sem óbito -> event_family = "tentativa", nunca "homicidio"
-- Morte culposa/acidente sem dolo -> event_family = "acidente_fatal"
+- Sem óbito → event_family = "tentativa", nunca "homicidio"
+- Morte culposa/acidente sem dolo → event_family = "acidente_fatal"
 - Feminicídio, latrocínio e qualificado são SUBTIPOS de homicidio, não famílias separadas
 - event_family = "homicidio" exige content_class = "incident"
 
@@ -561,7 +561,7 @@ Defina content_class em todo JSON de saída. Valores permitidos:
 
 SOBRE number_of_victims — NUNCA USE TOTAIS AGREGADOS:
 - Conte APENAS as vítimas FATAIS do incidente (mortos), NUNCA inclua feridos.
-  Ex.: "três mortos e um ferido" -> number_of_victims = 3, não 4.
+  Ex.: "três mortos e um ferido" → number_of_victims = 3, não 4.
 - Conte APENAS as vítimas do incidente específico descrito (máximo 20).
 - NUNCA use totais anuais, CVLI, "4.241 mortes em 2025", balanço estadual ou estatísticas
   de painel como number_of_victims — mesmo que sejam o tema da matéria.
@@ -570,8 +570,8 @@ SOBRE number_of_victims — NUNCA USE TOTAIS AGREGADOS:
   embutido; caso contrário a extração será descartada downstream.
 
 SOBRE homicide_dynamic.method — OBRIGATÓRIO PREENCHER:
-- Use um valor do enum quando o texto indicar o meio (tiros -> "Arma de fogo",
-  facadas -> "Arma branca", traumatismo craniano -> "Objeto contundente").
+- Use um valor do enum quando o texto indicar o meio (tiros → "Arma de fogo",
+  facadas → "Arma branca", traumatismo craniano → "Objeto contundente").
 - "Não especificado" quando a matéria diz que o método/causa não foi determinado
   ou não divulgado, ou quando há pouquíssima informação sobre a dinâmica.
 - Não deixe null se o texto menciona tiros, disparos, facadas ou equivalentes.
@@ -605,7 +605,7 @@ SOBRE AGENTES DE SEGURANÇA (vítimas e autores identificáveis):
 
 SOBRE VÍTIMA POLÍTICA (identifiable_victims[].political_role):
 - Preencher political_role SOMENTE quando o texto identifica a vítima como política ou candidata.
-- is_politician_or_candidate=true; status=elected | candidate | former_elected (ex-vereador -> former_elected).
+- is_politician_or_candidate=true; status=elected | candidate | former_elected (ex-vereador → former_elected).
 - office: cargo sem prefixo "ex-" (ex.: "vereador" mesmo para ex-vereador).
 - party: sigla/nome conforme texto; null se não mencionado — NÃO inferir partido.
 

--- a/backend/app/services/extraction.py
+++ b/backend/app/services/extraction.py
@@ -51,18 +51,18 @@ para resolver datas relativas mencionadas no texto.
 
 RESOLUÇÃO DE DATAS RELATIVAS:
 Se a notícia foi publicada em 21/12/2025 e o texto menciona:
-- "ontem" → 20/12/2025
-- "anteontem" → 19/12/2025
-- "na sexta-feira" → calcule qual sexta-feira mais recente antes da publicação
-- "nesta semana" → semana da publicação
-- "há três dias" → 18/12/2025
+- "ontem" -> 20/12/2025
+- "anteontem" -> 19/12/2025
+- "na sexta-feira" -> calcule qual sexta-feira mais recente antes da publicação
+- "nesta semana" -> semana da publicação
+- "há três dias" -> 18/12/2025
 
 QUANDO PODE INFERIR A DATA (has_explicit_date = TRUE):
 1. Data completa explícita: "15 de dezembro de 2025", "20/11/2025"
 2. Data relativa COM referência de publicação: "ontem" quando você sabe a data de publicação
 3. Dia da semana COM número entre parênteses: "domingo (10)", "sexta-feira (12)" —
    PRIORIZE o número do dia do mês sobre o dia da semana quando houver conflito
-   (ex.: publicação em 11/03/2025 + "domingo (10)" → 2025-03-10, não o domingo anterior).
+   (ex.: publicação em 11/03/2025 + "domingo (10)" -> 2025-03-10, não o domingo anterior).
 
 QUANDO NÃO PODE INFERIR (has_explicit_date = FALSE):
 1. Termos vagos sem referência: "recentemente", "há alguns dias", "no início da semana"
@@ -71,7 +71,7 @@ QUANDO NÃO PODE INFERIR (has_explicit_date = FALSE):
 4. O texto NÃO menciona quando o crime ocorreu: a data de publicação sozinha NÃO é a
    data do evento — ela serve apenas para resolver expressões relativas do texto.
    Se o artigo não diz QUANDO o crime aconteceu, date = null MESMO que pareça recente.
-5. Apenas mês/ano sem dia ("em setembro de 2024") → date = null
+5. Apenas mês/ano sem dia ("em setembro de 2024") -> date = null
 
 ATENÇÃO - DATA DO CRIME vs DATA DA DESCOBERTA:
 O campo date refere-se à data em que o CRIME ocorreu. Use date = null (has_explicit_date
@@ -80,7 +80,7 @@ corpo em decomposição, ossada, "a morte não foi recente". Nesses casos a data
 é desconhecida mesmo que a data da descoberta seja conhecida.
 Fora desses casos, a data em que a vítima foi morta/encontrada informada no texto É a
 data do evento — use-a normalmente, inclusive quando o corpo foi encontrado horas ou
-até um dia após o crime (ex.: "encontrada morta na noite do dia 18" → 18).
+até um dia após o crime (ex.: "encontrada morta na noite do dia 18" -> 18).
 
 O campo date_verification funciona como um VERIFICADOR:
 1. has_explicit_date = TRUE se você consegue determinar a data completa (dia/mês/ano)
@@ -96,9 +96,9 @@ IMPORTANTE:
 
 SOBRE LOCALIZAÇÃO (location_info.state):
 - Preencha o estado (UF) quando estiver explícito no texto OU quando a cidade for
-  inequívoca: capitais e cidades notórias (Recife → PE, Manaus → AM, Belém → PA,
-  Campina Grande → PB, Londrina → PR), ou quando o contexto identifica a região
-  ("Grande Vitória" → ES, "capital de Rondônia" → Porto Velho/RO, "Baixada Fluminense" → RJ).
+  inequívoca: capitais e cidades notórias (Recife -> PE, Manaus -> AM, Belém -> PA,
+  Campina Grande -> PB, Londrina -> PR), ou quando o contexto identifica a região
+  ("Grande Vitória" -> ES, "capital de Rondônia" -> Porto Velho/RO, "Baixada Fluminense" -> RJ).
 - location_info.city: se o texto identifica a cidade indiretamente ("capital de
   Rondônia", "Grande Vitória"), preencha com o nome da cidade correspondente.
 - Se o nome da cidade é ambíguo entre estados e o texto não desambigua
@@ -142,8 +142,8 @@ Se event_family = "nao_classificado":
 - "outro"
 
 REGRAS:
-- Sem óbito → event_family = "tentativa", nunca "homicidio"
-- Morte culposa/acidente sem dolo → event_family = "acidente_fatal"
+- Sem óbito -> event_family = "tentativa", nunca "homicidio"
+- Morte culposa/acidente sem dolo -> event_family = "acidente_fatal"
 - Feminicídio, latrocínio e qualificado são SUBTIPOS de homicidio, não famílias separadas
 - event_family = "homicidio" exige content_class = "incident"
 
@@ -162,7 +162,7 @@ Defina content_class em todo JSON de saída. Valores permitidos:
 
 SOBRE number_of_victims — NUNCA USE TOTAIS AGREGADOS:
 - Conte APENAS as vítimas FATAIS do incidente (mortos), NUNCA inclua feridos.
-  Ex.: "três mortos e um ferido" → number_of_victims = 3, não 4.
+  Ex.: "três mortos e um ferido" -> number_of_victims = 3, não 4.
 - Conte APENAS as vítimas do incidente específico descrito (máximo 20).
 - NUNCA use totais anuais, CVLI, "4.241 mortes em 2025", balanço estadual ou estatísticas
   de painel como number_of_victims — mesmo que sejam o tema da matéria.
@@ -171,8 +171,8 @@ SOBRE number_of_victims — NUNCA USE TOTAIS AGREGADOS:
   embutido; caso contrário a extração será descartada downstream.
 
 SOBRE homicide_dynamic.method — OBRIGATÓRIO PREENCHER:
-- Use um valor do enum quando o texto indicar o meio (tiros → "Arma de fogo",
-  facadas → "Arma branca", traumatismo craniano → "Objeto contundente").
+- Use um valor do enum quando o texto indicar o meio (tiros -> "Arma de fogo",
+  facadas -> "Arma branca", traumatismo craniano -> "Objeto contundente").
 - "Não especificado" quando a matéria diz que o método/causa não foi determinado
   ou não divulgado, ou quando há pouquíssima informação sobre a dinâmica.
 - Não deixe null se o texto menciona tiros, disparos, facadas ou equivalentes.
@@ -206,7 +206,7 @@ SOBRE AGENTES DE SEGURANÇA (vítimas e autores identificáveis):
 
 SOBRE VÍTIMA POLÍTICA (identifiable_victims[].political_role):
 - Preencher political_role SOMENTE quando o texto identifica a vítima como política ou candidata.
-- is_politician_or_candidate=true; status=elected | candidate | former_elected (ex-vereador → former_elected).
+- is_politician_or_candidate=true; status=elected | candidate | former_elected (ex-vereador -> former_elected).
 - office: cargo sem prefixo "ex-" (ex.: "vereador" mesmo para ex-vereador).
 - party: sigla/nome conforme texto; null se não mencionado — NÃO inferir partido.
 
@@ -253,18 +253,18 @@ para resolver fechas relativas mencionadas en el texto.
 
 RESOLUCIÓN DE FECHAS RELATIVAS:
 Si la noticia fue publicada el 21/12/2025 y el texto menciona:
-- "ayer" → 20/12/2025
-- "anteayer" → 19/12/2025
-- "el viernes" → calcula cuál viernes más reciente antes de la publicación
-- "esta semana" → semana de la publicación
-- "hace tres días" → 18/12/2025
+- "ayer" -> 20/12/2025
+- "anteayer" -> 19/12/2025
+- "el viernes" -> calcula cuál viernes más reciente antes de la publicación
+- "esta semana" -> semana de la publicación
+- "hace tres días" -> 18/12/2025
 
 CUÁNDO PUEDES INFERIR LA FECHA (has_explicit_date = TRUE):
 1. Fecha completa explícita: "15 de diciembre de 2025", "20/11/2025"
 2. Fecha relativa CON referencia de publicación: "ayer" cuando conoces la fecha de publicación
 3. Día de la semana CON número entre paréntesis: "domingo (10)", "viernes (12)" —
    PRIORIZA el número del día del mes sobre el día de la semana cuando haya conflicto
-   (ej.: publicación el 11/03/2025 + "domingo (10)" → 2025-03-10, no el domingo anterior).
+   (ej.: publicación el 11/03/2025 + "domingo (10)" -> 2025-03-10, no el domingo anterior).
 
 CUÁNDO NO PUEDES INFERIR (has_explicit_date = FALSE):
 1. Términos vagos sin referencia: "recientemente", "hace algunos días", "a principios de semana"
@@ -273,7 +273,7 @@ CUÁNDO NO PUEDES INFERIR (has_explicit_date = FALSE):
 4. El texto NO menciona cuándo ocurrió el crimen: la fecha de publicación sola NO es la
    fecha del evento — sirve solo para resolver expresiones relativas del texto.
    Si el artículo no dice CUÁNDO sucedió el crimen, date = null AUNQUE parezca reciente.
-5. Solo mes/año sin día ("en septiembre de 2024") → date = null
+5. Solo mes/año sin día ("en septiembre de 2024") -> date = null
 
 ATENCIÓN - FECHA DEL CRIMEN vs FECHA DEL DESCUBRIMIENTO:
 El campo date se refiere a la fecha en que el CRIMEN ocurrió. Usa date = null (has_explicit_date
@@ -282,7 +282,7 @@ cuerpo en descomposición, restos óseos, "la muerte no fue reciente". En esos c
 es desconocida aunque la fecha del descubrimiento sea conocida.
 Fuera de esos casos, la fecha en que la víctima fue asesinada/encontrada informada en el texto ES la
 fecha del evento — úsala normalmente, incluso cuando el cuerpo fue encontrado horas o
-hasta un día después del crimen (ej.: "encontrada muerta la noche del 18" → 18).
+hasta un día después del crimen (ej.: "encontrada muerta la noche del 18" -> 18).
 
 El campo date_verification funciona como un VERIFICADOR:
 1. has_explicit_date = TRUE si puedes determinar la fecha completa (día/mes/año)
@@ -299,8 +299,8 @@ IMPORTANTE:
 SOBRE LOCALIZACIÓN (location_info.state):
 - Llena la región cuando esté explícita en el texto O cuando la ciudad sea
   inequívoca: capitales y ciudades conocidas (Valparaíso, Concepción, Antofagasta),
-  o cuando el contexto identifica la región ("Región Metropolitana" → Metropolitana,
-  "capital de Chile" → Santiago/Metropolitana).
+  o cuando el contexto identifica la región ("Región Metropolitana" -> Metropolitana,
+  "capital de Chile" -> Santiago/Metropolitana).
 - location_info.city: si el texto identifica la ciudad indirectamente ("capital de Chile",
   "Gran Santiago"), llena con el nombre de la ciudad correspondiente.
 - location_info.state: usa el nombre completo de la región chilena (Metropolitana, Valparaíso,
@@ -344,8 +344,8 @@ Si event_family = "nao_classificado":
 - "outro"
 
 REGLAS:
-- Sin muerte → event_family = "tentativa", nunca "homicidio"
-- Muerte culposa/accidente sin dolo → event_family = "acidente_fatal"
+- Sin muerte -> event_family = "tentativa", nunca "homicidio"
+- Muerte culposa/accidente sin dolo -> event_family = "acidente_fatal"
 - Femicidio, robo con homicidio y calificado son SUBTIPOS de homicidio, no familias separadas
 - event_family = "homicidio" exige content_class = "incident"
 
@@ -364,7 +364,7 @@ Define content_class en todo JSON de salida. Valores permitidos:
 
 SOBRE number_of_victims — NUNCA USES TOTALES AGREGADOS:
 - Cuenta SOLAMENTE las víctimas FATALES del incidente (muertos), NUNCA incluyas heridos.
-  Ej.: "tres muertos y un herido" → number_of_victims = 3, no 4.
+  Ej.: "tres muertos y un herido" -> number_of_victims = 3, no 4.
 - Cuenta SOLAMENTE las víctimas del incidente específico descrito (máximo 20).
 - NUNCA uses totales anuales, "4.241 muertes en 2025", balance regional o estadísticas
   de panel como number_of_victims — aunque sean el tema de la noticia.
@@ -373,8 +373,8 @@ SOBRE number_of_victims — NUNCA USES TOTALES AGREGADOS:
   incluido; de lo contrario la extracción será descartada downstream.
 
 SOBRE homicide_dynamic.method — OBLIGATORIO COMPLETAR:
-- Usa un valor del enum cuando el texto indique el medio (tiros → "Arma de fogo",
-  puñaladas → "Arma branca", traumatismo craneal → "Objeto contundente").
+- Usa un valor del enum cuando el texto indique el medio (tiros -> "Arma de fogo",
+  puñaladas -> "Arma branca", traumatismo craneal -> "Objeto contundente").
 - "Não especificado" cuando la noticia dice que el método/causa no fue determinado
   o no fue divulgado, o cuando hay muy poca información sobre la dinámica.
 - No dejes null si el texto menciona disparos, balazos, puñaladas o equivalentes.
@@ -409,7 +409,7 @@ SOBRE AGENTES DE SEGURIDAD (víctimas y autores identificables):
 
 SOBRE VÍCTIMA POLÍTICA (identifiable_victims[].political_role):
 - Completar political_role SOLAMENTE cuando el texto identifica a la víctima como político o candidato.
-- is_politician_or_candidate=true; status=elected | candidate | former_elected (ex-concejal → former_elected).
+- is_politician_or_candidate=true; status=elected | candidate | former_elected (ex-concejal -> former_elected).
 - office: cargo sin prefijo "ex-" (ej.: "concejal" incluso para ex-concejal).
 - party: sigla/nombre según texto; null si no mencionado — NO inferir partido.
 
@@ -452,18 +452,18 @@ para resolver datas relativas mencionadas no texto.
 
 RESOLUÇÃO DE DATAS RELATIVAS:
 Se a notícia foi publicada em 21/12/2025 e o texto menciona:
-- "ontem" → 20/12/2025
-- "anteontem" → 19/12/2025
-- "na sexta-feira" → calcule qual sexta-feira mais recente antes da publicação
-- "nesta semana" → semana da publicação
-- "há três dias" → 18/12/2025
+- "ontem" -> 20/12/2025
+- "anteontem" -> 19/12/2025
+- "na sexta-feira" -> calcule qual sexta-feira mais recente antes da publicação
+- "nesta semana" -> semana da publicação
+- "há três dias" -> 18/12/2025
 
 QUANDO PODE INFERIR A DATA (has_explicit_date = TRUE):
 1. Data completa explícita: "15 de dezembro de 2025", "20/11/2025"
 2. Data relativa COM referência de publicação: "ontem" quando você sabe a data de publicação
 3. Dia da semana COM número entre parênteses: "domingo (10)", "sexta-feira (12)" —
    PRIORIZE o número do dia do mês sobre o dia da semana quando houver conflito
-   (ex.: publicação em 11/03/2025 + "domingo (10)" → 2025-03-10, não o domingo anterior).
+   (ex.: publicação em 11/03/2025 + "domingo (10)" -> 2025-03-10, não o domingo anterior).
 
 QUANDO NÃO PODE INFERIR (has_explicit_date = FALSE):
 1. Termos vagos sem referência: "recentemente", "há alguns dias", "no início da semana"
@@ -472,7 +472,7 @@ QUANDO NÃO PODE INFERIR (has_explicit_date = FALSE):
 4. O texto NÃO menciona quando o crime ocorreu: a data de publicação sozinha NÃO é a
    data do evento — ela serve apenas para resolver expressões relativas do texto.
    Se o artigo não diz QUANDO o crime aconteceu, date = null MESMO que pareça recente.
-5. Apenas mês/ano sem dia ("em setembro de 2024") → date = null
+5. Apenas mês/ano sem dia ("em setembro de 2024") -> date = null
 
 ATENÇÃO - DATA DO CRIME vs DATA DA DESCOBERTA:
 O campo date refere-se à data em que o CRIME ocorreu. Use date = null (has_explicit_date
@@ -481,7 +481,7 @@ corpo em decomposição, ossada, "a morte não foi recente". Nesses casos a data
 é desconhecida mesmo que a data da descoberta seja conhecida.
 Fora desses casos, a data em que a vítima foi morta/encontrada informada no texto É a
 data do evento — use-a normalmente, inclusive quando o corpo foi encontrado horas ou
-até um dia após o crime (ex.: "encontrada morta na noite do dia 18" → 18).
+até um dia após o crime (ex.: "encontrada morta na noite do dia 18" -> 18).
 
 O campo date_verification funciona como um VERIFICADOR:
 1. has_explicit_date = TRUE se você consegue determinar a data completa (dia/mês/ano)
@@ -497,9 +497,9 @@ IMPORTANTE:
 
 SOBRE LOCALIZAÇÃO (location_info.state):
 - Preencha o estado (UF) quando estiver explícito no texto OU quando a cidade for
-  inequívoca: capitais e cidades notórias (Recife → PE, Manaus → AM, Belém → PA,
-  Campina Grande → PB, Londrina → PR), ou quando o contexto identifica a região
-  ("Grande Vitória" → ES, "capital de Rondônia" → Porto Velho/RO, "Baixada Fluminense" → RJ).
+  inequívoca: capitais e cidades notórias (Recife -> PE, Manaus -> AM, Belém -> PA,
+  Campina Grande -> PB, Londrina -> PR), ou quando o contexto identifica a região
+  ("Grande Vitória" -> ES, "capital de Rondônia" -> Porto Velho/RO, "Baixada Fluminense" -> RJ).
 - location_info.city: se o texto identifica a cidade indiretamente ("capital de
   Rondônia", "Grande Vitória"), preencha com o nome da cidade correspondente.
 - Se o nome da cidade é ambíguo entre estados e o texto não desambigua
@@ -541,8 +541,8 @@ Se event_family = "nao_classificado":
 - "outro"
 
 REGRAS:
-- Sem óbito → event_family = "tentativa", nunca "homicidio"
-- Morte culposa/acidente sem dolo → event_family = "acidente_fatal"
+- Sem óbito -> event_family = "tentativa", nunca "homicidio"
+- Morte culposa/acidente sem dolo -> event_family = "acidente_fatal"
 - Feminicídio, latrocínio e qualificado são SUBTIPOS de homicidio, não famílias separadas
 - event_family = "homicidio" exige content_class = "incident"
 
@@ -561,7 +561,7 @@ Defina content_class em todo JSON de saída. Valores permitidos:
 
 SOBRE number_of_victims — NUNCA USE TOTAIS AGREGADOS:
 - Conte APENAS as vítimas FATAIS do incidente (mortos), NUNCA inclua feridos.
-  Ex.: "três mortos e um ferido" → number_of_victims = 3, não 4.
+  Ex.: "três mortos e um ferido" -> number_of_victims = 3, não 4.
 - Conte APENAS as vítimas do incidente específico descrito (máximo 20).
 - NUNCA use totais anuais, CVLI, "4.241 mortes em 2025", balanço estadual ou estatísticas
   de painel como number_of_victims — mesmo que sejam o tema da matéria.
@@ -570,8 +570,8 @@ SOBRE number_of_victims — NUNCA USE TOTAIS AGREGADOS:
   embutido; caso contrário a extração será descartada downstream.
 
 SOBRE homicide_dynamic.method — OBRIGATÓRIO PREENCHER:
-- Use um valor do enum quando o texto indicar o meio (tiros → "Arma de fogo",
-  facadas → "Arma branca", traumatismo craniano → "Objeto contundente").
+- Use um valor do enum quando o texto indicar o meio (tiros -> "Arma de fogo",
+  facadas -> "Arma branca", traumatismo craniano -> "Objeto contundente").
 - "Não especificado" quando a matéria diz que o método/causa não foi determinado
   ou não divulgado, ou quando há pouquíssima informação sobre a dinâmica.
 - Não deixe null se o texto menciona tiros, disparos, facadas ou equivalentes.
@@ -605,7 +605,7 @@ SOBRE AGENTES DE SEGURANÇA (vítimas e autores identificáveis):
 
 SOBRE VÍTIMA POLÍTICA (identifiable_victims[].political_role):
 - Preencher political_role SOMENTE quando o texto identifica a vítima como política ou candidata.
-- is_politician_or_candidate=true; status=elected | candidate | former_elected (ex-vereador → former_elected).
+- is_politician_or_candidate=true; status=elected | candidate | former_elected (ex-vereador -> former_elected).
 - office: cargo sem prefixo "ex-" (ex.: "vereador" mesmo para ex-vereador).
 - party: sigla/nome conforme texto; null se não mencionado — NÃO inferir partido.
 

--- a/backend/tests/test_classification_filters.py
+++ b/backend/tests/test_classification_filters.py
@@ -173,3 +173,117 @@ async def test_classify_source_discards_non_violent_death(classification_db):
     assert result is False
     await classification_db.refresh(source)
     assert source.status == SourceStatus.discarded
+
+
+# Country-aware tests for issue #129
+@pytest.mark.asyncio
+async def test_classify_source_passes_chilean_homicide(classification_db):
+    """ES homicide headline in Santiago should be classified as violent death."""
+    from app.models.source_google_news import SourceStatus
+
+    source = _source(
+        google_news_id="chile-1",
+        headline="Hombre asesinado a balazos en operativo policial en Santiago",
+    )
+    classification_db.add(source)
+    await classification_db.commit()
+    await classification_db.refresh(source)
+
+    with patch(
+        "app.services.classification.classify_headline",
+        return_value=_classification(
+            is_violent_death=True,
+            is_single_incident=True,
+            reasoning="Homicide in Chile",
+        ),
+    ):
+        result = await classify_source(source.id)
+
+    assert result is True
+    await classification_db.refresh(source)
+    assert source.status == SourceStatus.ready_for_download
+
+
+@pytest.mark.asyncio
+async def test_classify_source_discards_us_shooting(classification_db):
+    """US shooting should be discarded as foreign event."""
+    from app.models.source_google_news import SourceStatus
+
+    source = _source(
+        google_news_id="us-1",
+        headline="Mass shooting in Texas leaves 5 dead",
+    )
+    classification_db.add(source)
+    await classification_db.commit()
+    await classification_db.refresh(source)
+
+    with patch(
+        "app.services.classification.classify_headline",
+        return_value=_classification(
+            is_violent_death=False,
+            is_single_incident=False,
+            content_class_hint="foreign",
+            reasoning="Foreign event outside Brazil and Chile",
+        ),
+    ):
+        result = await classify_source(source.id)
+
+    assert result is False
+    await classification_db.refresh(source)
+    assert source.status == SourceStatus.discarded
+
+
+@pytest.mark.asyncio
+async def test_classify_source_passes_brazilian_homicide(classification_db):
+    """PT homicide in São Paulo should still be classified as violent death."""
+    from app.models.source_google_news import SourceStatus
+
+    source = _source(
+        google_news_id="brazil-1",
+        headline="Homem é morto a tiros em operação policial em São Paulo",
+    )
+    classification_db.add(source)
+    await classification_db.commit()
+    await classification_db.refresh(source)
+
+    with patch(
+        "app.services.classification.classify_headline",
+        return_value=_classification(
+            is_violent_death=True,
+            is_single_incident=True,
+            reasoning="Homicide in Brazil",
+        ),
+    ):
+        result = await classify_source(source.id)
+
+    assert result is True
+    await classification_db.refresh(source)
+    assert source.status == SourceStatus.ready_for_download
+
+
+@pytest.mark.asyncio
+async def test_classify_source_discards_survivor_es(classification_db):
+    """ES headline with survivor (sobrevivió) should be discarded."""
+    from app.models.source_google_news import SourceStatus
+
+    source = _source(
+        google_news_id="survivor-es-1",
+        headline="Hombre sobrevivió tras ser baleado en asalto",
+    )
+    classification_db.add(source)
+    await classification_db.commit()
+    await classification_db.refresh(source)
+
+    with patch(
+        "app.services.classification.classify_headline",
+        return_value=_classification(
+            is_violent_death=False,
+            is_single_incident=False,
+            reasoning="Victim survived, no death",
+        ),
+    ):
+        result = await classify_source(source.id)
+
+    assert result is False
+    await classification_db.refresh(source)
+    assert source.status == SourceStatus.discarded

--- a/backend/tests/test_classification_heuristics.py
+++ b/backend/tests/test_classification_heuristics.py
@@ -8,6 +8,20 @@ from app.services.classification_heuristics import (
 )
 
 
+def test_violent_death_field_description_includes_chile():
+    """Pydantic field description must include Brazil AND Chile, not just Brazil."""
+    field_info = ViolentDeathClassification.model_fields["is_violent_death"]
+    description = field_info.description or ""
+    
+    # Must mention both countries
+    assert "Brazil" in description or "Brasil" in description
+    assert "Chile" in description
+    
+    # Must not say "only in Brazil" or "in Brazil (homicides"
+    assert "in Brazil\n" not in description
+    assert "in Brazil (" not in description
+
+
 def _result(is_violent_death: bool) -> ViolentDeathClassification:
     return ViolentDeathClassification(
         is_violent_death=is_violent_death,

--- a/backend/tests/test_classification_heuristics.py
+++ b/backend/tests/test_classification_heuristics.py
@@ -65,3 +65,60 @@ def test_morre_no_hospital_is_violent_death_not_survival():
     headline = "Homem baleado em Santo André não resiste e morre no hospital"
     assert not should_force_non_violent_death(headline)
     assert should_force_violent_death(headline)
+
+
+# Country-aware heuristic tests for issue #129
+def test_spanish_asesinato_forces_violent_death():
+    """ES homicide headline with 'asesinato' should be classified as violent death."""
+    headline = "Hombre asesinado a balazos en operativo policial en Santiago"
+    assert should_force_violent_death(headline)
+    result = apply_classification_heuristics(headline, _result(False))
+    assert result.is_violent_death is True
+
+
+def test_us_shooting_foreign_marker_forces_false():
+    """US shooting should be rejected by foreign heuristic."""
+    headline = "Mass shooting in Texas leaves 5 dead"
+    assert should_force_non_violent_death(headline)
+    result = apply_classification_heuristics(headline, _result(True))
+    assert result.is_violent_death is False
+
+
+def test_portuguese_homicide_sao_paulo_passes():
+    """PT homicide in São Paulo should be classified as violent death."""
+    headline = "Homem é morto a tiros em operação policial em São Paulo"
+    assert should_force_violent_death(headline)
+    result = apply_classification_heuristics(headline, _result(False))
+    assert result.is_violent_death is True
+
+
+def test_spanish_sobrevivio_survivor_forces_false():
+    """ES headline with 'sobrevivió' (survivor) should be rejected."""
+    headline = "Hombre sobrevivió tras ser baleado en asalto"
+    assert should_force_non_violent_death(headline)
+    result = apply_classification_heuristics(headline, _result(True))
+    assert result.is_violent_death is False
+
+
+def test_chilean_carabineros_not_treated_as_foreign():
+    """Carabineros marker should prevent Chilean police ops from being rejected as foreign.
+    
+    This tests that the presence of 'Carabineros' doesn't trigger foreign rejection,
+    allowing Chilean police operations to be properly classified.
+    """
+    headline = "Carabineros detiene a sospechoso tras tiroteo en Santiago"
+    # Should not be forced as non-violent (not foreign)
+    assert not should_force_non_violent_death(headline)
+
+
+def test_chilean_pdi_not_treated_as_foreign():
+    """PDI marker should prevent Chilean police ops from being rejected as foreign.
+    
+    This tests that the presence of 'PDI' doesn't trigger foreign rejection,
+    allowing Chilean police operations to be properly classified.
+    """
+    headline = "PDI investiga caso de femicidio en Valparaíso"
+    # Should not be forced as non-violent (not foreign)
+    assert not should_force_non_violent_death(headline)
+    # And femicidio should force violent death
+    assert should_force_violent_death(headline)

--- a/backend/tests/test_content_filters.py
+++ b/backend/tests/test_content_filters.py
@@ -56,3 +56,27 @@ def test_heuristic_passes_single_incident():
         "do Rio de Janeiro na noite de sábado. A vítima ainda não foi identificada."
     )
     assert apply_content_heuristics(headline, content) is None
+
+
+def test_heuristic_passes_chilean_homicide_not_earthquake():
+    """Chilean homicide should not be rejected by earthquake regex (issue #129)."""
+    headline = "Hombre asesinado en Santiago"
+    content = (
+        "Un hombre fue asesinado a balazos durante un operativo policial "
+        "en Santiago de Chile. Las autoridades investigan el caso."
+    )
+    # Should not match earthquake pattern since Chile was removed from it
+    assert apply_content_heuristics(headline, content) is None
+
+
+def test_heuristic_still_rejects_venezuela_earthquake():
+    """Venezuelan earthquake should still be rejected as foreign."""
+    headline = "Terremoto deixa mortos"
+    content = (
+        "Um terremoto de magnitude 6,5 atingiu a Venezuela e deixou "
+        "dezenas de mortos em várias cidades."
+    )
+    match = apply_content_heuristics(headline, content)
+    assert match is not None
+    assert match.hint == "foreign"
+    assert match.rule == "foreign_earthquake"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #129

## Summary
Makes the headline classifier and article content-gate country-aware for Brazil **and** Chile. Previously the system only covered Brazil and treated Chile as "exterior."

## Changes

### Classification Prompts
- Updated `CLASSIFICATION_SYSTEM_PROMPT` to cover "Brasil ou Chile" instead of just "Brasil"
- Updated `CONTENT_CLASSIFICATION_SYSTEM_PROMPT` similarly for content-gate
- Added Spanish examples to prompts (asesinato, femicidio, balacera)
- Added Carabineros and PDI as Chilean police force markers
- Changed "Google News Brasil" to "Google News" (more generic)

### Heuristics
Added Spanish markers alongside existing Portuguese ones:
- **Survival patterns**: `sobrevivió`, `hospitalizado`, `herido`
- **Death markers**: `murió tras`, `falleció`, `no resistió`
- **Fatal markers**: `asesinato`, `asesinado`/`asesinada`, `homicidio`, `femicidio`, `balacera`, `acribillado`
- **Past participles**: ` morto `, ` morta `, ` muerto `, ` muerta ` (with spaces to force violent death classification)
- **Foreign markers**: Extended list to explicitly exclude other Latin American countries (Argentina, Peru, Colombia, etc.) but **not** Chile

### Content Filters
- Removed `chile` from earthquake regex (only matches earthquakes in Venezuela, Turkey, Mexico, Haiti, Afghanistan)
- Chilean homicides are no longer falsely rejected as "foreign earthquake"
- Venezuelan earthquakes still correctly rejected

### Download Headers
- `Accept-Language` now includes `es-CL` for `.cl` domains
- Brazilian domains still get `pt-BR` as before

### Tests
Added tests at **public heuristic interface** (not mocked):
- ✅ `test_spanish_asesinato_forces_violent_death` - ES "asesinado" marker forces violent death
- ✅ `test_us_shooting_foreign_marker_forces_false` - US/Texas shooting rejected by foreign heuristic
- ✅ `test_portuguese_homicide_sao_paulo_passes` - PT "morto" forces violent death
- ✅ `test_spanish_sobrevivio_survivor_forces_false` - ES "sobrevivió" survivor marker forces rejection
- ✅ `test_chilean_carabineros_not_treated_as_foreign` - Carabineros not treated as foreign
- ✅ `test_chilean_pdi_not_treated_as_foreign` - PDI not treated as foreign

Also added content-gate tests:
- ✅ `test_heuristic_passes_chilean_homicide_not_earthquake` - Chilean homicides not rejected by earthquake regex
- ✅ `test_heuristic_still_rejects_venezuela_earthquake` - Venezuelan earthquakes still rejected

**All 28 tests passing** (12 heuristic + 9 classification filter + 7 content filter)

## What's NOT included (out of scope for #129)
- Country persistence (UniqueEvent.country, enrichment) — tracked in issue #128
- Geocoding, extraction schema changes
- Issues #130, #131

## Deployment Notes
- Canonical type slugs remain Portuguese as specified
- This is a recall change only, not taxonomy translation
- Ready to merge into `develop` for staging deployment
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ff5ba24f-472d-4ea3-869b-b744e82a20e8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ff5ba24f-472d-4ea3-869b-b744e82a20e8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

