### PR TITLE
feat: geocode Chile with region=cl (fixes #131)

### DIFF
--- a/backend/app/services/geocoding.py
+++ b/backend/app/services/geocoding.py
@@ -196,6 +196,7 @@ async def geocode_address(
     input_granularity: str = PRECISION_CITY,
     client: httpx.AsyncClient | None = None,
     restrict_country: bool = False,
+    country: str | None = None,
 ) -> dict | None:
     """
     Call the Google Maps Geocoding API for a query string.
@@ -207,14 +208,32 @@ async def geocode_address(
         logger.warning("[Geocode] GOOGLE_MAPS_API_KEY not set; skipping geocoding")
         return None
 
+    # Normalize country: CL, BR, or legacy "Brasil" → BR
+    normalized_country = "BR"
+    if country:
+        if country.upper() == "CL":
+            normalized_country = "CL"
+        elif country.upper() in ("BR", "BRASIL"):
+            normalized_country = "BR"
+
+    # Set region and language based on country
+    if normalized_country == "CL":
+        region_code = "cl"
+        language_code = "es"
+        country_component = "CL"
+    else:
+        region_code = "br"
+        language_code = "pt-BR"
+        country_component = "BR"
+
     params = {
         "address": query,
         "key": settings.google_maps_api_key,
-        "region": "br",
-        "language": "pt-BR",
+        "region": region_code,
+        "language": language_code,
     }
     if restrict_country:
-        params["components"] = "country:BR"
+        params["components"] = f"country:{country_component}"
 
     owns_client = client is None
     if owns_client:
@@ -453,13 +472,16 @@ async def geocode_unique_event(
         return False
 
     granularity = _input_granularity(event)
+    
+    # Get country from event (CL, BR, or legacy "Brasil")
+    event_country = getattr(event, "country", None) or "BR"
 
-    # In-run cache keyed on (query, granularity) avoids duplicate billed calls
+    # In-run cache keyed on (query, granularity, country) avoids duplicate billed calls
     # for identical addresses (e.g. many city-only events in the same city).
-    cache_key = (query, granularity)
+    cache_key = (query, granularity, event_country)
     fields = cache.get(cache_key) if cache is not None else None
     if fields is None:
-        fields = await geocode_address(query, granularity, client=client)
+        fields = await geocode_address(query, granularity, client=client, country=event_country)
         if cache is not None:
             cache[cache_key] = fields
 

--- a/backend/tests/test_geocode_chile.py
+++ b/backend/tests/test_geocode_chile.py
@@ -1,0 +1,149 @@
+"""Tests for Chile geocoding with region=cl (issue #131)."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.services.geocoding import geocode_address, PRECISION_CITY
+
+
+@pytest.mark.asyncio
+async def test_geocode_chile_santiago_uses_cl_region():
+    """Santiago, Metropolitana + country CL → point in Chile (not Brazil)."""
+    # Mock Google Maps API response for Chilean Santiago
+    from unittest.mock import Mock
+    
+    mock_response = Mock()
+    mock_response.raise_for_status = Mock()
+    mock_response.json = Mock(return_value={
+        "status": "OK",
+        "results": [
+            {
+                "formatted_address": "Santiago, Región Metropolitana, Chile",
+                "geometry": {
+                    "location": {"lat": -33.4489, "lng": -70.6693},
+                    "location_type": "APPROXIMATE",
+                },
+                "place_id": "ChIJL68lS64hYpYRhB07b0sMDUw",
+                "types": ["locality", "political"],
+            }
+        ],
+    })
+
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_response)
+
+    with patch("app.services.geocoding.get_settings") as mock_settings:
+        mock_settings.return_value.google_maps_api_key = "test-key"
+        
+        result = await geocode_address(
+            "Santiago, Metropolitana, Chile",
+            input_granularity=PRECISION_CITY,
+            client=mock_client,
+            country="CL",
+        )
+
+    # Verify the result is in Chile (latitude around -33)
+    assert result is not None
+    assert result["latitude"] == -33.4489
+    assert result["longitude"] == -70.6693
+    
+    # Verify Google was called with region=cl and language=es
+    mock_client.get.assert_called_once()
+    call_args = mock_client.get.call_args
+    assert call_args.kwargs["params"]["region"] == "cl"
+    assert call_args.kwargs["params"]["language"] == "es"
+
+
+@pytest.mark.asyncio
+async def test_geocode_brazil_santiago_uses_br_region():
+    """Santiago, RS + country BR → point in Brazil (not Chile)."""
+    # Mock Google Maps API response for Brazilian Santiago
+    from unittest.mock import Mock
+    
+    mock_response = Mock()
+    mock_response.raise_for_status = Mock()
+    mock_response.json = Mock(return_value={
+        "status": "OK",
+        "results": [
+            {
+                "formatted_address": "Santiago, RS, Brasil",
+                "geometry": {
+                    "location": {"lat": -29.1917, "lng": -54.8669},
+                    "location_type": "APPROXIMATE",
+                },
+                "place_id": "ChIJcSL_aLRsGpURbufr5LRwBu0",
+                "types": ["locality", "political"],
+            }
+        ],
+    })
+
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_response)
+
+    with patch("app.services.geocoding.get_settings") as mock_settings:
+        mock_settings.return_value.google_maps_api_key = "test-key"
+        
+        result = await geocode_address(
+            "Santiago, RS, Brasil",
+            input_granularity=PRECISION_CITY,
+            client=mock_client,
+            country="BR",
+        )
+
+    # Verify the result is in Brazil (latitude around -29)
+    assert result is not None
+    assert result["latitude"] == -29.1917
+    assert result["longitude"] == -54.8669
+    
+    # Verify Google was called with region=br and language=pt-BR
+    mock_client.get.assert_called_once()
+    call_args = mock_client.get.call_args
+    assert call_args.kwargs["params"]["region"] == "br"
+    assert call_args.kwargs["params"]["language"] == "pt-BR"
+
+
+@pytest.mark.asyncio
+async def test_geocode_legacy_brasil_uses_br_region():
+    """Legacy country value "Brasil" → uses BR settings."""
+    from unittest.mock import Mock
+    
+    mock_response = Mock()
+    mock_response.raise_for_status = Mock()
+    mock_response.json = Mock(return_value={
+        "status": "OK",
+        "results": [
+            {
+                "formatted_address": "Rio de Janeiro, RJ, Brasil",
+                "geometry": {
+                    "location": {"lat": -22.9068, "lng": -43.1729},
+                    "location_type": "APPROXIMATE",
+                },
+                "place_id": "ChIJW6AIkVXemwARTtIvZ2xC3FA",
+                "types": ["locality", "political"],
+            }
+        ],
+    })
+
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_response)
+
+    with patch("app.services.geocoding.get_settings") as mock_settings:
+        mock_settings.return_value.google_maps_api_key = "test-key"
+        
+        result = await geocode_address(
+            "Rio de Janeiro, Brasil",
+            input_granularity=PRECISION_CITY,
+            client=mock_client,
+            country="Brasil",
+        )
+
+    # Verify the result
+    assert result is not None
+    assert result["latitude"] == -22.9068
+    
+    # Verify Google was called with region=br (legacy "Brasil" → BR)
+    mock_client.get.assert_called_once()
+    call_args = mock_client.get.call_args
+    assert call_args.kwargs["params"]["region"] == "br"
+    assert call_args.kwargs["params"]["language"] == "pt-BR"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 📝 Descrição

Implementa geocodificação específica para eventos chilenos usando `region=cl`, `language=es` no Google Maps Geocoding API, conforme descrito na issue #131.

### Mudanças principais:
- Adiciona parâmetro `country` à função `geocode_address()`
- Usa `region=cl` e `language=es` para eventos chilenos (país = "CL")
- Mantém `region=br` e `language=pt-BR` para eventos brasileiros (país = "BR" ou "Brasil")
- Normaliza valores de país legado ("Brasil" → "BR")
- Passa o país do `UniqueEvent` para a função de geocodificação

## 🔗 Issue Relacionada

Closes #131

## 🏷️ Tipo de Mudança

- [x] ✨ Nova feature (mudança que adiciona funcionalidade)
- [x] 🐛 Bug fix (mudança que corrige um problema)

## 🧪 Como Foi Testado?

- [x] Testes unitários
- [x] Testado em desenvolvimento local

**Abordagem TDD:**
1. ✅ Escrito testes falhando (Red)
2. ✅ Implementado código mínimo para passar (Green)
3. ✅ Verificado que testes existentes ainda passam

**Testes adicionados:**
- `test_geocode_chile_santiago_uses_cl_region()` - Verifica que "Santiago, Metropolitana" + país CL retorna coordenadas chilenas e usa `region=cl`
- `test_geocode_brazil_santiago_uses_br_region()` - Verifica que "Santiago, RS" + país BR retorna coordenadas brasileiras e usa `region=br`
- `test_geocode_legacy_brasil_uses_br_region()` - Verifica retrocompatibilidade com valor legado "Brasil"

**Resultado dos testes:**
```
tests/test_geocode_chile.py::test_geocode_chile_santiago_uses_cl_region PASSED
tests/test_geocode_chile.py::test_geocode_brazil_santiago_uses_br_region PASSED
tests/test_geocode_chile.py::test_geocode_legacy_brasil_uses_br_region PASSED
tests/test_geocode_protection.py (todos passaram)
```

## ✅ Checklist

- [x] Meu código segue o guia de estilo do projeto
- [x] Realizei uma auto-revisão do meu código
- [x] Minhas mudanças não geram novos warnings
- [x] Adicionei testes que provam que meu fix/feature funciona
- [x] Testes unitários novos e existentes passam localmente
- [x] Quaisquer mudanças dependentes foram mergeadas (issue #128 já mergeada em develop)

## 📚 Documentação

- [x] Docstrings/comentários no código

## 💬 Notas Adicionais

- Esta implementação segue a abordagem TDD requisitada (Red → Green)
- Os testes são focados no "seam" da função de geocodificação (`geocode_address`)
- Não faz chamadas de API reais no CI (usa mocks)
- Mantém retrocompatibilidade total com eventos brasileiros
- Branch criado a partir do develop atual que inclui o commit fb7974ec (issue #128)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b8881fc5-9e04-40b7-9fe2-288754498fb8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b8881fc5-9e04-40b7-9fe2-288754498fb8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

