### PR TITLE
feat: Add rates per 100k to /estatisticas using IBGE populations (BR)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,60 @@ Always follow the flow: **local -> develop -> prod**.
 Never deploy straight to production: changes must pass through `develop`/staging
 first.
 
+## IBGE Population Data (for /estatisticas rates)
+
+The `/estatisticas` rankings page shows rates per 100k using IBGE population data.
+This data must be loaded **once** after deploying the database migration.
+
+### One-time setup (after migration)
+
+**Local / Docker dev:**
+```bash
+docker compose -f docker-compose.dev.yml exec api python scripts/load_ibge_population.py
+```
+
+**Staging / Production (SSH):**
+```bash
+ssh hetzner-arv
+cd /root/arquivo-da-violencia
+docker exec arquivo-api python scripts/load_ibge_population.py --year 2022
+```
+
+**Verify:**
+```bash
+# Check table has data
+docker exec -it arquivo-api python -c "
+import asyncio
+from app.database import get_engine
+from sqlalchemy import text
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+async def check():
+    engine = get_engine()
+    async with AsyncSession(engine) as session:
+        result = await session.execute(text('SELECT COUNT(*) FROM ibge_population'))
+        count = result.scalar()
+        print(f'Population records: {count}')
+        if count > 5000:
+            print('✓ IBGE data loaded successfully')
+        else:
+            print('✗ Run: python scripts/load_ibge_population.py')
+
+asyncio.run(check())
+"
+```
+
+**What it does:**
+- Loads all ~5,570 Brazilian municipalities from geobr (`read_municipal_seat(year=2022)`)
+- Fetches Censo 2022 population data from SIDRA API (table 4714)
+- Joins and caches in `ibge_population` table
+- Enables rate per 100k calculations for cities and states on `/estatisticas`
+
+**Re-run with `--force` to reload:**
+```bash
+python scripts/load_ibge_population.py --force
+```
+
 ## Local development (Docker only)
 
 **Always run and test locally inside Docker.** Do not rely on host `npm install`,

--- a/backend/alembic/versions/j9k0l1m2n3o4_add_ibge_population_table.py
+++ b/backend/alembic/versions/j9k0l1m2n3o4_add_ibge_population_table.py
@@ -1,0 +1,49 @@
+"""add_ibge_population_table
+
+Revision ID: j9k0l1m2n3o4
+Revises: i8j9k0l1m2n3
+Create Date: 2026-08-19 23:54:00.000000
+
+Add IBGE population table to store cached population data for municipalities
+and states, supporting rate per 100k calculations.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+import sqlmodel
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'j9k0l1m2n3o4'
+down_revision: Union[str, Sequence[str], None] = 'i8j9k0l1m2n3'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Create ibge_population table."""
+    op.create_table(
+        'ibge_population',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('code_muni', sa.Integer(), nullable=True),
+        sa.Column('code_state', sqlmodel.sql.sqltypes.AutoString(length=2), nullable=True),
+        sa.Column('name_muni', sqlmodel.sql.sqltypes.AutoString(length=200), nullable=True),
+        sa.Column('name_state', sqlmodel.sql.sqltypes.AutoString(length=100), nullable=True),
+        sa.Column('abbrev_state', sqlmodel.sql.sqltypes.AutoString(length=2), nullable=True),
+        sa.Column('population', sa.Integer(), nullable=False),
+        sa.Column('year', sa.Integer(), nullable=False),
+        sa.Column('source', sqlmodel.sql.sqltypes.AutoString(length=100), nullable=False),
+        sa.Column('created_at', sa.DateTime(), nullable=False),
+        sa.Column('updated_at', sa.DateTime(), nullable=False),
+        sa.PrimaryKeyConstraint('id')
+    )
+    op.create_index(op.f('ix_ibge_population_code_muni'), 'ibge_population', ['code_muni'], unique=False)
+    op.create_index(op.f('ix_ibge_population_code_state'), 'ibge_population', ['code_state'], unique=False)
+
+
+def downgrade() -> None:
+    """Drop ibge_population table."""
+    op.drop_index(op.f('ix_ibge_population_code_state'), table_name='ibge_population')
+    op.drop_index(op.f('ix_ibge_population_code_muni'), table_name='ibge_population')
+    op.drop_table('ibge_population')

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -30,6 +30,7 @@ from app.models.pipeline_attempt import (
     PipelineAttemptBase,
     PipelineAttemptRead,
 )
+from app.models.ibge_population import IBGEPopulation
 
 __all__ = [
     # Source Google News
@@ -57,4 +58,6 @@ __all__ = [
     "PipelineAttempt",
     "PipelineAttemptBase",
     "PipelineAttemptRead",
+    # IBGE Population
+    "IBGEPopulation",
 ]

--- a/backend/app/models/ibge_population.py
+++ b/backend/app/models/ibge_population.py
@@ -1,0 +1,63 @@
+"""IBGE population data model."""
+
+from datetime import datetime
+from typing import Optional
+
+from sqlmodel import Field, SQLModel
+
+
+class IBGEPopulation(SQLModel, table=True):
+    """
+    Cached IBGE population data for municipalities and states.
+    
+    This table stores population estimates from IBGE (Instituto Brasileiro de
+    Geografia e Estatística) to avoid hitting external APIs on every request.
+    """
+    __tablename__ = "ibge_population"
+    
+    id: Optional[int] = Field(default=None, primary_key=True)
+    
+    # IBGE codes
+    code_muni: Optional[int] = Field(
+        default=None,
+        index=True,
+        description="7-digit IBGE municipal code (e.g. 3550308 for São Paulo)"
+    )
+    code_state: Optional[str] = Field(
+        default=None,
+        index=True,
+        max_length=2,
+        description="2-digit IBGE state code (e.g. 35 for SP)"
+    )
+    
+    # Location names
+    name_muni: Optional[str] = Field(default=None, max_length=200)
+    name_state: Optional[str] = Field(default=None, max_length=100)
+    abbrev_state: Optional[str] = Field(default=None, max_length=2)
+    
+    # Population data
+    population: int = Field(description="Population count")
+    year: int = Field(description="Census or estimate year (e.g. 2022)")
+    
+    # Metadata
+    source: str = Field(
+        default="IBGE",
+        max_length=100,
+        description="Data source (e.g. 'IBGE Censo 2022', 'IBGE Estimativa 2023')"
+    )
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    updated_at: datetime = Field(default_factory=datetime.utcnow)
+    
+    class Config:
+        json_schema_extra = {
+            "example": {
+                "code_muni": 3550308,
+                "code_state": "35",
+                "name_muni": "São Paulo",
+                "name_state": "São Paulo",
+                "abbrev_state": "SP",
+                "population": 11451245,
+                "year": 2022,
+                "source": "IBGE Censo 2022"
+            }
+        }

--- a/backend/app/routers/public.py
+++ b/backend/app/routers/public.py
@@ -475,11 +475,13 @@ async def get_rankings(
     Get rankings of cities, states/regions, countries, homicide types, and methods of death
     by victim count and event count for a given time period.
     
-    Includes delta vs previous equal period, and rate per 100k for matched BR locations.
+    Includes delta vs previous equal period, and rate per 100k for matched BR locations (cities and states).
     """
     from app.services.ibge_population import (
         lookup_city_codes,
+        lookup_state_codes,
         get_ibge_populations,
+        get_state_populations,
         calculate_rate_per_100k,
     )
     
@@ -572,43 +574,69 @@ async def get_rankings(
     total_victims = sum(e.victim_count or 0 for e in current_events)
     total_events = len(current_events)
     
-    # Lookup population data for BR cities only
-    population_data = {}
+    # Lookup population data for BR cities and states
+    city_population_data = {}
+    state_population_data = {}
     population_vintage = None
     
     # Only lookup populations if we have BR events
     is_br_only = country and country.upper() == "BR"
     has_br_events = not country or is_br_only
     
-    if has_br_events and cities_current:
-        # Build list of (city, state) pairs
-        city_list = []
-        state_list = []
-        for city, state in city_states.items():
-            if state:  # Only include cities with known states
-                city_list.append(city)
-                state_list.append(state)
-        
-        # Lookup IBGE codes
-        city_code_map = await lookup_city_codes(city_list, state_list)
-        
-        # Get code_munis
-        code_munis = list(city_code_map.values())
-        
-        if code_munis:
-            # Fetch population data
-            pop_data = await get_ibge_populations(session, code_munis)
+    if has_br_events:
+        # Lookup city populations
+        if cities_current:
+            # Build list of (city, state) pairs
+            city_list = []
+            state_list = []
+            for city, state in city_states.items():
+                if state:  # Only include cities with known states
+                    city_list.append(city)
+                    state_list.append(state)
             
-            # Map back to (city, state) keys
-            for (city, state), code_muni in city_code_map.items():
-                if code_muni in pop_data:
-                    population_data[(city, state)] = pop_data[code_muni]
-                    # Track the year for display (use the first one we find)
-                    if population_vintage is None:
-                        population_vintage = pop_data[code_muni]["year"]
+            # Lookup IBGE codes
+            city_code_map = await lookup_city_codes(session, city_list, state_list)
+            
+            # Get code_munis
+            code_munis = list(city_code_map.values())
+            
+            if code_munis:
+                # Fetch population data
+                pop_data = await get_ibge_populations(session, code_munis)
+                
+                # Map back to (city, state) keys
+                for (city, state), code_muni in city_code_map.items():
+                    if code_muni in pop_data:
+                        city_population_data[(city, state)] = pop_data[code_muni]
+                        # Track the year for display (use the first one we find)
+                        if population_vintage is None:
+                            population_vintage = pop_data[code_muni]["year"]
+        
+        # Lookup state populations
+        if states_current:
+            # Get list of unique states
+            state_list = list(states_current.keys())
+            
+            # Lookup state codes
+            state_code_map = await lookup_state_codes(session, state_list)
+            
+            # Get code_states
+            code_states = list(state_code_map.values())
+            
+            if code_states:
+                # Fetch aggregated state populations
+                state_pop_data = await get_state_populations(session, code_states)
+                
+                # Map back to state abbreviation keys
+                for state, code_state in state_code_map.items():
+                    if code_state in state_pop_data:
+                        state_population_data[state] = state_pop_data[code_state]
+                        # Track the year for display
+                        if population_vintage is None:
+                            population_vintage = state_pop_data[code_state]["year"]
     
     # Helper to format rankings with delta and rate
-    def format_rankings(current, prev, label_field="name", include_rate=False, city_states_map=None):
+    def format_rankings(current, prev, label_field="name", include_rate=False, city_states_map=None, state_pops=None):
         """Format rankings with victim count, event count, share, delta, and optionally rate per 100k."""
         rankings = []
         for key, data in current.items():
@@ -627,10 +655,23 @@ async def get_rankings(
             }
             
             # Add rate per 100k if available
-            if include_rate and city_states_map:
-                state = city_states_map.get(key)
-                if state and (key, state) in population_data:
-                    pop_info = population_data[(key, state)]
+            if include_rate:
+                # Try city lookup first (if city_states_map provided)
+                if city_states_map:
+                    state = city_states_map.get(key)
+                    if state and (key, state) in city_population_data:
+                        pop_info = city_population_data[(key, state)]
+                        row["population"] = pop_info["population"]
+                        row["rate_per_100k"] = calculate_rate_per_100k(
+                            data["victims"],
+                            pop_info["population"]
+                        )
+                    else:
+                        row["population"] = None
+                        row["rate_per_100k"] = None
+                # Try state lookup (if state_pops flag set)
+                elif state_pops and key in state_population_data:
+                    pop_info = state_population_data[key]
                     row["population"] = pop_info["population"]
                     row["rate_per_100k"] = calculate_rate_per_100k(
                         data["victims"],
@@ -663,7 +704,7 @@ async def get_rankings(
         "total_victims": total_victims,
         "total_events": total_events,
         "cities": format_rankings(cities_current, cities_prev, "city", include_rate=True, city_states_map=city_states),
-        "states": format_rankings(states_current, states_prev, "state"),
+        "states": format_rankings(states_current, states_prev, "state", include_rate=True, state_pops=True),
         "countries": format_rankings(countries_current, countries_prev, "country"),
         "homicide_types": format_rankings(types_current, types_prev, "type"),
         "methods": format_rankings(methods_current, methods_prev, "method"),

--- a/backend/app/routers/public.py
+++ b/backend/app/routers/public.py
@@ -475,8 +475,14 @@ async def get_rankings(
     Get rankings of cities, states/regions, countries, homicide types, and methods of death
     by victim count and event count for a given time period.
     
-    Includes delta vs previous equal period.
+    Includes delta vs previous equal period, and rate per 100k for matched BR locations.
     """
+    from app.services.ibge_population import (
+        lookup_city_codes,
+        get_ibge_populations,
+        calculate_rate_per_100k,
+    )
+    
     now = datetime.utcnow()
     current_start = now - timedelta(days=days)
     prev_start = now - timedelta(days=days * 2)
@@ -525,8 +531,10 @@ async def get_rankings(
         return COUNTRY_NAMES.get(country_code.upper(), country_code)
     
     def aggregate_by_field(events, field_name):
-        """Aggregate events by a field, counting victims and events."""
+        """Aggregate events by a field, counting victims and events, tracking city/state for rate calculation."""
         aggregated = {}
+        city_states = {}  # Track (city, state) pairs for rate calculation
+        
         for event in events:
             key = getattr(event, field_name)
             if not key:
@@ -538,38 +546,77 @@ async def get_rankings(
                     continue
             if key not in aggregated:
                 aggregated[key] = {"events": 0, "victims": 0}
+                # Store city/state pair for city rankings (for rate lookup)
+                if field_name == "city":
+                    city_states[key] = getattr(event, "state", None)
             aggregated[key]["events"] += 1
             aggregated[key]["victims"] += event.victim_count or 0
-        return aggregated
+        
+        return aggregated, city_states if field_name == "city" else {}
     
     # Aggregate current period
-    cities_current = aggregate_by_field(current_events, "city")
-    states_current = aggregate_by_field(current_events, "state")
-    countries_current = aggregate_by_field(current_events, "country")
-    types_current = aggregate_by_field(current_events, "homicide_type")
-    methods_current = aggregate_by_field(current_events, "method_of_death")
+    cities_current, city_states = aggregate_by_field(current_events, "city")
+    states_current, _ = aggregate_by_field(current_events, "state")
+    countries_current, _ = aggregate_by_field(current_events, "country")
+    types_current, _ = aggregate_by_field(current_events, "homicide_type")
+    methods_current, _ = aggregate_by_field(current_events, "method_of_death")
     
     # Aggregate previous period
-    cities_prev = aggregate_by_field(prev_events, "city")
-    states_prev = aggregate_by_field(prev_events, "state")
-    countries_prev = aggregate_by_field(prev_events, "country")
-    types_prev = aggregate_by_field(prev_events, "homicide_type")
-    methods_prev = aggregate_by_field(prev_events, "method_of_death")
+    cities_prev, _ = aggregate_by_field(prev_events, "city")
+    states_prev, _ = aggregate_by_field(prev_events, "state")
+    countries_prev, _ = aggregate_by_field(prev_events, "country")
+    types_prev, _ = aggregate_by_field(prev_events, "homicide_type")
+    methods_prev, _ = aggregate_by_field(prev_events, "method_of_death")
     
     # Calculate totals for share percentages
     total_victims = sum(e.victim_count or 0 for e in current_events)
     total_events = len(current_events)
     
-    # Helper to format rankings with delta
-    def format_rankings(current, prev, label_field="name"):
-        """Format rankings with victim count, event count, share, and delta."""
+    # Lookup population data for BR cities only
+    population_data = {}
+    population_vintage = None
+    
+    # Only lookup populations if we have BR events
+    is_br_only = country and country.upper() == "BR"
+    has_br_events = not country or is_br_only
+    
+    if has_br_events and cities_current:
+        # Build list of (city, state) pairs
+        city_list = []
+        state_list = []
+        for city, state in city_states.items():
+            if state:  # Only include cities with known states
+                city_list.append(city)
+                state_list.append(state)
+        
+        # Lookup IBGE codes
+        city_code_map = await lookup_city_codes(city_list, state_list)
+        
+        # Get code_munis
+        code_munis = list(city_code_map.values())
+        
+        if code_munis:
+            # Fetch population data
+            pop_data = await get_ibge_populations(session, code_munis)
+            
+            # Map back to (city, state) keys
+            for (city, state), code_muni in city_code_map.items():
+                if code_muni in pop_data:
+                    population_data[(city, state)] = pop_data[code_muni]
+                    # Track the year for display (use the first one we find)
+                    if population_vintage is None:
+                        population_vintage = pop_data[code_muni]["year"]
+    
+    # Helper to format rankings with delta and rate
+    def format_rankings(current, prev, label_field="name", include_rate=False, city_states_map=None):
+        """Format rankings with victim count, event count, share, delta, and optionally rate per 100k."""
         rankings = []
         for key, data in current.items():
             prev_data = prev.get(key, {"victims": 0, "events": 0})
             victim_delta = data["victims"] - prev_data["victims"]
             event_delta = data["events"] - prev_data["events"]
             
-            rankings.append({
+            row = {
                 label_field: key,
                 "victim_count": data["victims"],
                 "event_count": data["events"],
@@ -577,25 +624,56 @@ async def get_rankings(
                 "event_share": round(data["events"] / total_events * 100, 1) if total_events > 0 else 0,
                 "victim_delta": victim_delta,
                 "event_delta": event_delta,
-            })
+            }
+            
+            # Add rate per 100k if available
+            if include_rate and city_states_map:
+                state = city_states_map.get(key)
+                if state and (key, state) in population_data:
+                    pop_info = population_data[(key, state)]
+                    row["population"] = pop_info["population"]
+                    row["rate_per_100k"] = calculate_rate_per_100k(
+                        data["victims"],
+                        pop_info["population"]
+                    )
+                else:
+                    row["population"] = None
+                    row["rate_per_100k"] = None
+            
+            rankings.append(row)
         
-        # Sort by victim count descending
-        rankings.sort(key=lambda x: x["victim_count"], reverse=True)
+        # Sort by rate if available, otherwise by victim count
+        if include_rate and any(r.get("rate_per_100k") is not None for r in rankings):
+            # Sort by rate (nulls last), then by victim count
+            rankings.sort(
+                key=lambda x: (x.get("rate_per_100k") is None, -(x.get("rate_per_100k") or 0)),
+                reverse=False
+            )
+        else:
+            # Sort by victim count descending
+            rankings.sort(key=lambda x: x["victim_count"], reverse=True)
+        
         return rankings
     
-    return {
+    response = {
         "period_days": days,
         "period_start": current_start.date().isoformat(),
         "period_end": now.date().isoformat(),
         "country_filter": country,
         "total_victims": total_victims,
         "total_events": total_events,
-        "cities": format_rankings(cities_current, cities_prev, "city"),
+        "cities": format_rankings(cities_current, cities_prev, "city", include_rate=True, city_states_map=city_states),
         "states": format_rankings(states_current, states_prev, "state"),
         "countries": format_rankings(countries_current, countries_prev, "country"),
         "homicide_types": format_rankings(types_current, types_prev, "type"),
         "methods": format_rankings(methods_current, methods_prev, "method"),
     }
+    
+    # Add population vintage if we have population data
+    if population_vintage is not None:
+        response["population_vintage"] = population_vintage
+    
+    return response
 
 
 @router.get("/geocode")

--- a/backend/app/services/ibge_population.py
+++ b/backend/app/services/ibge_population.py
@@ -28,7 +28,9 @@ async def load_ibge_data_from_geobr_and_sidra(
     Load full IBGE municipality data from geobr + SIDRA and cache in database.
     
     This is the production path. Loads all ~5,570 Brazilian municipalities:
-    1. geobr.lookup_muni(name_muni="all", year=2022) → codes, names, state info
+    1. geobr.read_municipal_seat(year=2022) → codes, names, state info
+       Note: geobr.lookup_muni defaults to year=2010 (municipal seats).
+       For 2022, we use read_municipal_seat which has 2022 data.
     2. sidrapy.get_table(table_code="4714", ...) → population from Censo 2022
     3. Join by code_muni and store in ibge_population table
     
@@ -38,7 +40,9 @@ async def load_ibge_data_from_geobr_and_sidra(
         force_reload: If True, reload even if data exists
     
     Note:
-        Call this once on deployment or via admin script.
+        Call this once on deployment or via CLI script:
+        python scripts/load_ibge_population.py
+        
         Unit tests use load_ibge_population_fixture() instead.
     """
     # Check if data already loaded
@@ -53,11 +57,19 @@ async def load_ibge_data_from_geobr_and_sidra(
     logger.info(f"Loading IBGE municipality codes from geobr (year={year})...")
     
     try:
-        from geobr import lookup_muni
         import pandas as pd
         
-        # Load all municipalities from geobr
-        munis_df = lookup_muni(name_muni="all", year=year)
+        # Use read_municipal_seat instead of lookup_muni for 2022 data
+        # read_municipal_seat has data for 2022, lookup_muni defaults to 2010
+        from geobr import read_municipal_seat
+        
+        # Load all municipal seats with codes
+        logger.info("Fetching municipal seat data from geobr...")
+        gdf = read_municipal_seat(year=year, verbose=False)
+        
+        # Drop geometry column to work with regular DataFrame
+        munis_df = pd.DataFrame(gdf.drop(columns='geometry', errors='ignore'))
+        
         logger.info(f"Loaded {len(munis_df)} municipalities from geobr")
         
         # Load population data from SIDRA API

--- a/backend/app/services/ibge_population.py
+++ b/backend/app/services/ibge_population.py
@@ -2,65 +2,254 @@
 IBGE population data service for rate per 100k calculations.
 
 This module provides functions to:
-1. Lookup IBGE municipal codes (code_muni) from city/state names
-2. Fetch and cache IBGE population data
-3. Calculate rates per 100k population
+1. Load IBGE municipal codes from geobr (all BR municipalities)
+2. Fetch population data from IBGE SIDRA API (Censo 2022)
+3. Cache in database for fast lookups
+4. Calculate rates per 100k population
 
-Note: geobr is an R package. For Python, we use a fixture-based approach for testing
-and will load IBGE data from CSV in production.
+Unit tests use fixture data (no network calls).
+Production loads full IBGE dataset once from geobr + SIDRA.
 """
 
 from typing import Dict, Optional, Tuple
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
+from loguru import logger
 
 from app.models.ibge_population import IBGEPopulation
 
 
-# Mapping of (city_name, state_abbrev) to IBGE code_muni
-# This is a simplified lookup. In production, this would be loaded from a CSV
-# or database table with all Brazilian municipalities.
-CITY_CODE_MAPPING: Dict[Tuple[str, str], int] = {
-    ("São Paulo", "SP"): 3550308,
-    ("Rio de Janeiro", "RJ"): 3304557,
-    ("Salvador", "BA"): 2927408,
-    ("Brasília", "DF"): 5300108,
-    ("Fortaleza", "CE"): 2304400,
-    ("Belo Horizonte", "MG"): 3106200,
-    ("Manaus", "AM"): 1302603,
-    ("Curitiba", "PR"): 4106902,
-    ("Recife", "PE"): 2611606,
-    ("Porto Alegre", "RS"): 4314902,
-    # Add more cities as needed
-    ("Bauru", "SP"): 3505708,
-}
+async def load_ibge_data_from_geobr_and_sidra(
+    session: AsyncSession,
+    year: int = 2022,
+    force_reload: bool = False
+) -> None:
+    """
+    Load full IBGE municipality data from geobr + SIDRA and cache in database.
+    
+    This is the production path. Loads all ~5,570 Brazilian municipalities:
+    1. geobr.lookup_muni(name_muni="all", year=2022) → codes, names, state info
+    2. sidrapy.get_table(table_code="4714", ...) → population from Censo 2022
+    3. Join by code_muni and store in ibge_population table
+    
+    Args:
+        session: Database session
+        year: Census year (default 2022)
+        force_reload: If True, reload even if data exists
+    
+    Note:
+        Call this once on deployment or via admin script.
+        Unit tests use load_ibge_population_fixture() instead.
+    """
+    # Check if data already loaded
+    if not force_reload:
+        query = select(IBGEPopulation).limit(1)
+        result = await session.execute(query)
+        existing = result.scalar_one_or_none()
+        if existing:
+            logger.info(f"IBGE population data already loaded (vintage {existing.year})")
+            return
+    
+    logger.info(f"Loading IBGE municipality codes from geobr (year={year})...")
+    
+    try:
+        from geobr import lookup_muni
+        import pandas as pd
+        
+        # Load all municipalities from geobr
+        munis_df = lookup_muni(name_muni="all", year=year)
+        logger.info(f"Loaded {len(munis_df)} municipalities from geobr")
+        
+        # Load population data from SIDRA API
+        logger.info("Loading population data from SIDRA API (table 4714)...")
+        import sidrapy
+        
+        pop_df = sidrapy.get_table(
+            table_code="4714",
+            territorial_level="6",  # Municipality level
+            ibge_territorial_code="all",
+            variable="93",  # Population variable
+            period=str(year),
+        )
+        
+        # SIDRA columns: D1C (code_muni), D1N (name), V (value/population)
+        # Clean and prepare population data
+        pop_df = pop_df[['D1C', 'D1N', 'V']].copy()
+        pop_df.columns = ['code_muni_str', 'name_muni_sidra', 'population_str']
+        pop_df['code_muni'] = pd.to_numeric(pop_df['code_muni_str'], errors='coerce')
+        pop_df['population'] = pd.to_numeric(pop_df['population_str'], errors='coerce')
+        pop_df = pop_df.dropna(subset=['code_muni', 'population'])
+        pop_df['code_muni'] = pop_df['code_muni'].astype(int)
+        pop_df['population'] = pop_df['population'].astype(int)
+        
+        logger.info(f"Loaded {len(pop_df)} municipality populations from SIDRA")
+        
+        # Join geobr codes with SIDRA populations
+        merged = munis_df.merge(
+            pop_df[['code_muni', 'population']],
+            on='code_muni',
+            how='left'
+        )
+        
+        # Store in database
+        count = 0
+        for _, row in merged.iterrows():
+            if pd.isna(row.get('population')):
+                continue  # Skip municipalities without population data
+            
+            pop = IBGEPopulation(
+                code_muni=int(row['code_muni']),
+                code_state=str(row['code_state']),
+                name_muni=str(row['name_muni']),
+                name_state=str(row['name_state']) if pd.notna(row.get('name_state')) else None,
+                abbrev_state=str(row['abbrev_state']) if pd.notna(row.get('abbrev_state')) else None,
+                population=int(row['population']),
+                year=year,
+                source=f"IBGE Censo {year} (geobr + SIDRA)"
+            )
+            session.add(pop)
+            count += 1
+        
+        await session.commit()
+        logger.info(f"Stored {count} municipalities with population data in database")
+        
+    except ImportError as e:
+        logger.error(f"Missing required package: {e}. Install with: pip install geobr sidrapy")
+        raise
+    except Exception as e:
+        logger.error(f"Failed to load IBGE data: {e}")
+        raise
 
 
 async def lookup_city_codes(
+    session: AsyncSession,
     cities: list[str],
     states: list[str]
 ) -> Dict[Tuple[str, str], int]:
     """
     Lookup IBGE municipal codes for a list of (city, state) pairs.
     
+    Queries the ibge_population table (loaded from geobr).
+    No hardcoded mapping - works for any city in the IBGE database.
+    
     Args:
+        session: Database session
         cities: List of city names
         states: List of state abbreviations (e.g. "SP", "RJ")
     
     Returns:
         Dictionary mapping (city, state) tuples to IBGE code_muni
-    
-    Note:
-        In production, this would query geobr data or a preloaded lookup table.
-        For now, uses a hardcoded mapping for common cities.
     """
+    if not cities:
+        return {}
+    
+    # Build lookup of (city, state) pairs
+    city_state_pairs = [(city, state) for city, state in zip(cities, states) if city and state]
+    if not city_state_pairs:
+        return {}
+    
+    # Query database for matching municipalities
+    # Try exact match first, could add fuzzy matching later
     result = {}
-    for city, state in zip(cities, states):
-        if city and state:
-            key = (city, state)
-            if key in CITY_CODE_MAPPING:
-                result[key] = CITY_CODE_MAPPING[key]
+    
+    for city, state in city_state_pairs:
+        query = select(IBGEPopulation).where(
+            IBGEPopulation.name_muni == city,
+            IBGEPopulation.abbrev_state == state
+        )
+        db_result = await session.execute(query)
+        pop = db_result.scalar_one_or_none()
+        
+        if pop and pop.code_muni:
+            result[(city, state)] = pop.code_muni
+    
     return result
+
+
+async def lookup_state_codes(
+    session: AsyncSession,
+    states: list[str]
+) -> Dict[str, str]:
+    """
+    Lookup IBGE state codes for a list of state abbreviations.
+    
+    Args:
+        session: Database session
+        states: List of state abbreviations (e.g. "SP", "RJ")
+    
+    Returns:
+        Dictionary mapping state abbreviation to code_state (e.g. "SP" → "35")
+    """
+    if not states:
+        return {}
+    
+    result = {}
+    
+    for state in states:
+        if not state:
+            continue
+        
+        # Query for any municipality in that state to get code_state
+        query = select(IBGEPopulation).where(
+            IBGEPopulation.abbrev_state == state
+        ).limit(1)
+        
+        db_result = await session.execute(query)
+        pop = db_result.scalar_one_or_none()
+        
+        if pop and pop.code_state:
+            result[state] = pop.code_state
+    
+    return result
+
+
+async def get_state_populations(
+    session: AsyncSession,
+    code_states: list[str]
+) -> Dict[str, dict]:
+    """
+    Get aggregated state populations by summing all municipalities in each state.
+    
+    Args:
+        session: Database session
+        code_states: List of IBGE state codes (e.g. ["35", "33"])
+    
+    Returns:
+        Dictionary mapping code_state to population data:
+        {
+            "35": {
+                "name": "São Paulo",
+                "population": 44411238,
+                "year": 2022
+            }
+        }
+    """
+    if not code_states:
+        return {}
+    
+    # Query all municipalities for these states
+    query = select(IBGEPopulation).where(
+        IBGEPopulation.code_state.in_(code_states)
+    )
+    result = await session.execute(query)
+    populations = result.scalars().all()
+    
+    # Aggregate by state
+    state_data = {}
+    for pop in populations:
+        if not pop.code_state:
+            continue
+        
+        if pop.code_state not in state_data:
+            state_data[pop.code_state] = {
+                "name": pop.name_state or pop.abbrev_state,
+                "population": 0,
+                "year": pop.year
+            }
+        
+        state_data[pop.code_state]["population"] += pop.population
+    
+    return state_data
 
 
 async def get_ibge_populations(
@@ -112,7 +301,9 @@ async def load_ibge_population_fixture(session: AsyncSession) -> None:
     Load fixture population data for testing.
     
     This loads a small set of known Brazilian municipalities for testing purposes.
-    In production, this would be replaced by a script that loads the full IBGE dataset.
+    In production, use load_ibge_data_from_geobr_and_sidra() instead.
+    
+    Includes São Paulo, Rio, Bauru, and Campinas (to prove lookup isn't a hardcoded allowlist).
     """
     # Sample data from IBGE Censo 2022
     fixtures = [
@@ -124,7 +315,7 @@ async def load_ibge_population_fixture(session: AsyncSession) -> None:
             "abbrev_state": "SP",
             "population": 11451245,
             "year": 2022,
-            "source": "IBGE Censo 2022"
+            "source": "IBGE Censo 2022 (fixture)"
         },
         {
             "code_muni": 3304557,
@@ -134,7 +325,7 @@ async def load_ibge_population_fixture(session: AsyncSession) -> None:
             "abbrev_state": "RJ",
             "population": 6211423,
             "year": 2022,
-            "source": "IBGE Censo 2022"
+            "source": "IBGE Censo 2022 (fixture)"
         },
         {
             "code_muni": 3505708,
@@ -144,7 +335,18 @@ async def load_ibge_population_fixture(session: AsyncSession) -> None:
             "abbrev_state": "SP",
             "population": 379297,
             "year": 2022,
-            "source": "IBGE Censo 2022"
+            "source": "IBGE Censo 2022 (fixture)"
+        },
+        {
+            # Extra city NOT in any hardcoded list - proves lookup works via DB
+            "code_muni": 3509502,
+            "code_state": "35",
+            "name_muni": "Campinas",
+            "name_state": "São Paulo",
+            "abbrev_state": "SP",
+            "population": 1213792,
+            "year": 2022,
+            "source": "IBGE Censo 2022 (fixture)"
         },
     ]
     

--- a/backend/app/services/ibge_population.py
+++ b/backend/app/services/ibge_population.py
@@ -1,0 +1,179 @@
+"""
+IBGE population data service for rate per 100k calculations.
+
+This module provides functions to:
+1. Lookup IBGE municipal codes (code_muni) from city/state names
+2. Fetch and cache IBGE population data
+3. Calculate rates per 100k population
+
+Note: geobr is an R package. For Python, we use a fixture-based approach for testing
+and will load IBGE data from CSV in production.
+"""
+
+from typing import Dict, Optional, Tuple
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.models.ibge_population import IBGEPopulation
+
+
+# Mapping of (city_name, state_abbrev) to IBGE code_muni
+# This is a simplified lookup. In production, this would be loaded from a CSV
+# or database table with all Brazilian municipalities.
+CITY_CODE_MAPPING: Dict[Tuple[str, str], int] = {
+    ("São Paulo", "SP"): 3550308,
+    ("Rio de Janeiro", "RJ"): 3304557,
+    ("Salvador", "BA"): 2927408,
+    ("Brasília", "DF"): 5300108,
+    ("Fortaleza", "CE"): 2304400,
+    ("Belo Horizonte", "MG"): 3106200,
+    ("Manaus", "AM"): 1302603,
+    ("Curitiba", "PR"): 4106902,
+    ("Recife", "PE"): 2611606,
+    ("Porto Alegre", "RS"): 4314902,
+    # Add more cities as needed
+    ("Bauru", "SP"): 3505708,
+}
+
+
+async def lookup_city_codes(
+    cities: list[str],
+    states: list[str]
+) -> Dict[Tuple[str, str], int]:
+    """
+    Lookup IBGE municipal codes for a list of (city, state) pairs.
+    
+    Args:
+        cities: List of city names
+        states: List of state abbreviations (e.g. "SP", "RJ")
+    
+    Returns:
+        Dictionary mapping (city, state) tuples to IBGE code_muni
+    
+    Note:
+        In production, this would query geobr data or a preloaded lookup table.
+        For now, uses a hardcoded mapping for common cities.
+    """
+    result = {}
+    for city, state in zip(cities, states):
+        if city and state:
+            key = (city, state)
+            if key in CITY_CODE_MAPPING:
+                result[key] = CITY_CODE_MAPPING[key]
+    return result
+
+
+async def get_ibge_populations(
+    session: AsyncSession,
+    code_munis: list[int]
+) -> Dict[int, dict]:
+    """
+    Get IBGE population data for a list of municipal codes.
+    
+    Args:
+        session: Database session
+        code_munis: List of IBGE municipal codes
+    
+    Returns:
+        Dictionary mapping code_muni to population data:
+        {
+            code_muni: {
+                "name": str,
+                "population": int,
+                "year": int
+            }
+        }
+    """
+    if not code_munis:
+        return {}
+    
+    # Query cached population data
+    query = select(IBGEPopulation).where(
+        IBGEPopulation.code_muni.in_(code_munis)
+    )
+    result = await session.execute(query)
+    populations = result.scalars().all()
+    
+    # Build result dictionary
+    pop_dict = {}
+    for pop in populations:
+        if pop.code_muni:
+            pop_dict[pop.code_muni] = {
+                "name": pop.name_muni,
+                "population": pop.population,
+                "year": pop.year
+            }
+    
+    return pop_dict
+
+
+async def load_ibge_population_fixture(session: AsyncSession) -> None:
+    """
+    Load fixture population data for testing.
+    
+    This loads a small set of known Brazilian municipalities for testing purposes.
+    In production, this would be replaced by a script that loads the full IBGE dataset.
+    """
+    # Sample data from IBGE Censo 2022
+    fixtures = [
+        {
+            "code_muni": 3550308,
+            "code_state": "35",
+            "name_muni": "São Paulo",
+            "name_state": "São Paulo",
+            "abbrev_state": "SP",
+            "population": 11451245,
+            "year": 2022,
+            "source": "IBGE Censo 2022"
+        },
+        {
+            "code_muni": 3304557,
+            "code_state": "33",
+            "name_muni": "Rio de Janeiro",
+            "name_state": "Rio de Janeiro",
+            "abbrev_state": "RJ",
+            "population": 6211423,
+            "year": 2022,
+            "source": "IBGE Censo 2022"
+        },
+        {
+            "code_muni": 3505708,
+            "code_state": "35",
+            "name_muni": "Bauru",
+            "name_state": "São Paulo",
+            "abbrev_state": "SP",
+            "population": 379297,
+            "year": 2022,
+            "source": "IBGE Censo 2022"
+        },
+    ]
+    
+    for fixture in fixtures:
+        # Check if already exists
+        query = select(IBGEPopulation).where(
+            IBGEPopulation.code_muni == fixture["code_muni"]
+        )
+        result = await session.execute(query)
+        existing = result.scalar_one_or_none()
+        
+        if not existing:
+            pop = IBGEPopulation(**fixture)
+            session.add(pop)
+    
+    await session.commit()
+
+
+def calculate_rate_per_100k(victim_count: int, population: int) -> float:
+    """
+    Calculate the rate per 100,000 population.
+    
+    Args:
+        victim_count: Number of victims
+        population: Total population
+    
+    Returns:
+        Rate per 100,000 population, rounded to 2 decimal places
+    """
+    if population <= 0:
+        return 0.0
+    return round((victim_count / population) * 100000, 2)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     # IBGE data
     "geobr>=2.0.0",
     "sidrapy>=0.2.0",
+    "pandas>=2.0.0",
     # Authentication
     "python-jose[cryptography]>=3.3.0",
     "passlib[bcrypt]>=1.7.4",

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -30,6 +30,9 @@ dependencies = [
     "httpx>=0.28.0",
     "pydantic-settings>=2.6.0",
     "loguru>=0.7.0",
+    # IBGE data
+    "geobr>=2.0.0",
+    "sidrapy>=0.2.0",
     # Authentication
     "python-jose[cryptography]>=3.3.0",
     "passlib[bcrypt]>=1.7.4",

--- a/backend/scripts/load_ibge_population.py
+++ b/backend/scripts/load_ibge_population.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""
+Load IBGE municipality and population data from geobr + SIDRA into the database.
+
+This script should be run once after deployment to populate the ibge_population table.
+
+Usage:
+    python scripts/load_ibge_population.py [--year 2022] [--force]
+
+Options:
+    --year YEAR    Census year (default: 2022)
+    --force        Force reload even if data already exists
+"""
+
+import asyncio
+import sys
+from pathlib import Path
+
+# Add parent directory to path
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from sqlmodel import SQLModel
+from sqlmodel.ext.asyncio.session import AsyncSession
+from loguru import logger
+
+from app.database import get_engine, init_db
+from app.services.ibge_population import load_ibge_data_from_geobr_and_sidra
+
+
+async def main(year: int = 2022, force: bool = False):
+    """Load IBGE data into database."""
+    logger.info("=" * 80)
+    logger.info(f"Loading IBGE population data (year={year}, force={force})")
+    logger.info("=" * 80)
+    
+    # Initialize database tables
+    await init_db()
+    logger.info("Database tables verified")
+    
+    # Get engine
+    engine = get_engine()
+    
+    # Load data
+    async with AsyncSession(engine) as session:
+        try:
+            await load_ibge_data_from_geobr_and_sidra(
+                session=session,
+                year=year,
+                force_reload=force
+            )
+            logger.success("✓ IBGE data loaded successfully")
+            logger.info("=" * 80)
+            logger.info("Next steps:")
+            logger.info("  1. Verify: SELECT COUNT(*) FROM ibge_population;")
+            logger.info("  2. Test: Navigate to /estatisticas and check rates appear")
+            logger.info("=" * 80)
+        except Exception as e:
+            logger.error(f"✗ Failed to load IBGE data: {e}")
+            raise
+
+
+if __name__ == "__main__":
+    import argparse
+    
+    parser = argparse.ArgumentParser(
+        description="Load IBGE population data from geobr + SIDRA"
+    )
+    parser.add_argument(
+        "--year",
+        type=int,
+        default=2022,
+        help="Census year (default: 2022)"
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Force reload even if data exists"
+    )
+    
+    args = parser.parse_args()
+    
+    asyncio.run(main(year=args.year, force=args.force))

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -59,3 +59,11 @@ async def client(app):
     ) as client:
         yield client
 
+
+@pytest.fixture
+async def population_fixture(async_session):
+    """Load IBGE population fixture data for testing."""
+    from app.services.ibge_population import load_ibge_population_fixture
+    await load_ibge_population_fixture(async_session)
+    yield
+

--- a/backend/tests/test_rankings.py
+++ b/backend/tests/test_rankings.py
@@ -2,7 +2,7 @@
 
 import pytest
 from datetime import datetime, timedelta
-from httpx import AsyncClient
+from httpx import AsyncClient, ASGITransport
 from decimal import Decimal
 
 from app.models.unique_event import UniqueEvent
@@ -92,10 +92,10 @@ async def test_rankings_basic_aggregation(app, async_session):
         async_session.add(event)
     await async_session.commit()
     
-    from app.database import get_session
-    app.dependency_overrides[get_session] = lambda: async_session
-    
-    async with AsyncClient(app=app, base_url="http://test") as client:
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test"
+    ) as client:
         response = await client.get("/api/public/stats/rankings?days=365")
         assert response.status_code == 200
         data = response.json()
@@ -158,10 +158,10 @@ async def test_rankings_country_filter_brazil(app, async_session):
         async_session.add(event)
     await async_session.commit()
     
-    from app.database import get_session
-    app.dependency_overrides[get_session] = lambda: async_session
-    
-    async with AsyncClient(app=app, base_url="http://test") as client:
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test"
+    ) as client:
         response = await client.get("/api/public/stats/rankings?days=30&country=BR")
         assert response.status_code == 200
         data = response.json()
@@ -202,10 +202,10 @@ async def test_rankings_country_filter_chile(app, async_session):
         async_session.add(event)
     await async_session.commit()
     
-    from app.database import get_session
-    app.dependency_overrides[get_session] = lambda: async_session
-    
-    async with AsyncClient(app=app, base_url="http://test") as client:
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test"
+    ) as client:
         response = await client.get("/api/public/stats/rankings?days=30&country=CL")
         assert response.status_code == 200
         data = response.json()
@@ -239,7 +239,10 @@ async def test_rankings_empty_chile_data(app, async_session):
     from app.database import get_session
     app.dependency_overrides[get_session] = lambda: async_session
     
-    async with AsyncClient(app=app, base_url="http://test") as client:
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test"
+    ) as client:
         # Request without country filter (should include both)
         response = await client.get("/api/public/stats/rankings?days=30")
         assert response.status_code == 200
@@ -304,10 +307,10 @@ async def test_rankings_delta_calculation(app, async_session):
         async_session.add(event)
     await async_session.commit()
     
-    from app.database import get_session
-    app.dependency_overrides[get_session] = lambda: async_session
-    
-    async with AsyncClient(app=app, base_url="http://test") as client:
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test"
+    ) as client:
         response = await client.get("/api/public/stats/rankings?days=30")
         assert response.status_code == 200
         data = response.json()
@@ -344,10 +347,10 @@ async def test_rankings_different_periods(app, async_session):
         async_session.add(event)
     await async_session.commit()
     
-    from app.database import get_session
-    app.dependency_overrides[get_session] = lambda: async_session
-    
-    async with AsyncClient(app=app, base_url="http://test") as client:
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test"
+    ) as client:
         # Test 7 days
         response = await client.get("/api/public/stats/rankings?days=7")
         assert response.status_code == 200
@@ -399,10 +402,10 @@ async def test_rankings_victim_vs_event_counts(app, async_session):
         async_session.add(event)
     await async_session.commit()
     
-    from app.database import get_session
-    app.dependency_overrides[get_session] = lambda: async_session
-    
-    async with AsyncClient(app=app, base_url="http://test") as client:
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test"
+    ) as client:
         response = await client.get("/api/public/stats/rankings?days=30")
         assert response.status_code == 200
         data = response.json()
@@ -420,3 +423,219 @@ async def test_rankings_victim_vs_event_counts(app, async_session):
         sp = next(c for c in data["cities"] if c["city"] == "São Paulo")
         assert sp["victim_count"] == 2
         assert sp["event_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_rankings_rate_per_100k_matched_br(app, async_session, population_fixture):
+    """Test that matched BR cities include rate_per_100k and population."""
+    now = datetime.utcnow()
+    current_start = now - timedelta(days=30)
+    
+    # Create events in matched BR cities
+    events = [
+        create_ranking_event(
+            event_date=current_start + timedelta(days=1),
+            country="Brasil",
+            city="São Paulo",
+            state="SP",
+            victim_count=100
+        ),
+        create_ranking_event(
+            event_date=current_start + timedelta(days=2),
+            country="Brasil",
+            city="Rio de Janeiro",
+            state="RJ",
+            victim_count=50
+        ),
+    ]
+    
+    for event in events:
+        async_session.add(event)
+    await async_session.commit()
+    
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test"
+    ) as client:
+        response = await client.get("/api/public/stats/rankings?days=30&country=BR")
+        assert response.status_code == 200
+        data = response.json()
+        
+        # Check that population_vintage is included
+        assert "population_vintage" in data
+        assert data["population_vintage"] == 2022
+        
+        # Check São Paulo has rate and population
+        sp = next(c for c in data["cities"] if c["city"] == "São Paulo")
+        assert "population" in sp
+        assert "rate_per_100k" in sp
+        assert sp["population"] == 11451245
+        # rate = 100 / 11451245 * 100000 ≈ 0.87
+        assert sp["rate_per_100k"] is not None
+        assert 0.8 < sp["rate_per_100k"] < 0.9
+        
+        # Check Rio has rate and population
+        rio = next(c for c in data["cities"] if c["city"] == "Rio de Janeiro")
+        assert "population" in rio
+        assert "rate_per_100k" in rio
+        assert rio["population"] == 6211423
+        # rate = 50 / 6211423 * 100000 ≈ 0.80
+        assert rio["rate_per_100k"] is not None
+        assert 0.7 < rio["rate_per_100k"] < 0.9
+
+
+@pytest.mark.asyncio
+async def test_rankings_rate_per_100k_sao_paulo_specific(app, async_session, population_fixture):
+    """Test São Paulo (code_muni 3550308) gets correct rate calculation."""
+    now = datetime.utcnow()
+    current_start = now - timedelta(days=30)
+    
+    # Create event with known victim count
+    event = create_ranking_event(
+        event_date=current_start + timedelta(days=1),
+        country="Brasil",
+        city="São Paulo",
+        state="SP",
+        victim_count=1000
+    )
+    
+    async_session.add(event)
+    await async_session.commit()
+    
+    from app.database import get_session
+    app.dependency_overrides[get_session] = lambda: async_session
+    
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test"
+    ) as client:
+        response = await client.get("/api/public/stats/rankings?days=30&country=BR")
+        assert response.status_code == 200
+        data = response.json()
+        
+        sp = data["cities"][0]
+        assert sp["city"] == "São Paulo"
+        assert sp["population"] == 11451245
+        # rate = 1000 / 11451245 * 100000 = 8.733...
+        expected_rate = 1000 / 11451245 * 100000
+        assert sp["rate_per_100k"] is not None
+        assert abs(sp["rate_per_100k"] - expected_rate) < 0.01
+
+
+@pytest.mark.asyncio
+async def test_rankings_junk_city_no_rate(app, async_session, population_fixture):
+    """Test that junk string 'Joanesburgo' does not get a rate."""
+    now = datetime.utcnow()
+    current_start = now - timedelta(days=30)
+    
+    # Create event with junk city name
+    event = create_ranking_event(
+        event_date=current_start + timedelta(days=1),
+        country="Brasil",
+        city="Joanesburgo",  # Not a BR city
+        state="XX",
+        victim_count=10
+    )
+    
+    async_session.add(event)
+    await async_session.commit()
+    
+    from app.database import get_session
+    app.dependency_overrides[get_session] = lambda: async_session
+    
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test"
+    ) as client:
+        response = await client.get("/api/public/stats/rankings?days=30&country=BR")
+        assert response.status_code == 200
+        data = response.json()
+        
+        joanesburg = data["cities"][0]
+        assert joanesburg["city"] == "Joanesburgo"
+        assert joanesburg["victim_count"] == 10
+        # Should not have rate or population
+        assert joanesburg.get("rate_per_100k") is None
+        assert joanesburg.get("population") is None
+
+
+@pytest.mark.asyncio
+async def test_rankings_chile_no_rate(app, async_session, population_fixture):
+    """Test that Chile events do not get rate_per_100k (not using geobr)."""
+    now = datetime.utcnow()
+    current_start = now - timedelta(days=30)
+    
+    # Create Chile event
+    event = create_ranking_event(
+        event_date=current_start + timedelta(days=1),
+        country="Chile",
+        city="Santiago",
+        state="Metropolitana",
+        victim_count=20
+    )
+    
+    async_session.add(event)
+    await async_session.commit()
+    
+    from app.database import get_session
+    app.dependency_overrides[get_session] = lambda: async_session
+    
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test"
+    ) as client:
+        response = await client.get("/api/public/stats/rankings?days=30&country=CL")
+        assert response.status_code == 200
+        data = response.json()
+        
+        santiago = data["cities"][0]
+        assert santiago["city"] == "Santiago"
+        assert santiago["victim_count"] == 20
+        # Chile should not have rate or population (INE later, not geobr)
+        assert santiago.get("rate_per_100k") is None
+        assert santiago.get("population") is None
+
+
+@pytest.mark.asyncio
+async def test_rankings_default_sort_by_rate(app, async_session, population_fixture):
+    """Test that rankings default sort by rate_per_100k when available."""
+    now = datetime.utcnow()
+    current_start = now - timedelta(days=30)
+    
+    # Create events: São Paulo has more victims but lower rate
+    # Bauru has fewer victims but higher rate
+    events = [
+        create_ranking_event(
+            event_date=current_start + timedelta(days=1),
+            country="Brasil",
+            city="São Paulo",
+            state="SP",
+            victim_count=100  # rate ≈ 0.87 per 100k
+        ),
+        create_ranking_event(
+            event_date=current_start + timedelta(days=2),
+            country="Brasil",
+            city="Bauru",
+            state="SP",
+            victim_count=10  # rate ≈ 2.64 per 100k (higher!)
+        ),
+    ]
+    
+    for event in events:
+        async_session.add(event)
+    await async_session.commit()
+    
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test"
+    ) as client:
+        response = await client.get("/api/public/stats/rankings?days=30&country=BR")
+        assert response.status_code == 200
+        data = response.json()
+        
+        # Bauru should be first (higher rate despite fewer victims)
+        assert data["cities"][0]["city"] == "Bauru"
+        assert data["cities"][0]["rate_per_100k"] > data["cities"][1]["rate_per_100k"]
+        
+        # São Paulo should be second
+        assert data["cities"][1]["city"] == "São Paulo"

--- a/backend/tests/test_rankings.py
+++ b/backend/tests/test_rankings.py
@@ -639,3 +639,44 @@ async def test_rankings_default_sort_by_rate(app, async_session, population_fixt
         
         # São Paulo should be second
         assert data["cities"][1]["city"] == "São Paulo"
+
+
+@pytest.mark.asyncio
+async def test_rankings_campinas_not_hardcoded(app, async_session, population_fixture):
+    """Test that Campinas gets a rate even though it's not in any hardcoded list.
+    
+    This proves the lookup uses the database, not a hardcoded mapping.
+    Campinas (code_muni 3509502) is in the fixture but was never mentioned in code.
+    """
+    now = datetime.utcnow()
+    current_start = now - timedelta(days=30)
+    
+    # Create event in Campinas - NOT in any hardcoded list
+    event = create_ranking_event(
+        event_date=current_start + timedelta(days=1),
+        country="Brasil",
+        city="Campinas",
+        state="SP",
+        victim_count=25
+    )
+    
+    async_session.add(event)
+    await async_session.commit()
+    
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test"
+    ) as client:
+        response = await client.get("/api/public/stats/rankings?days=30&country=BR")
+        assert response.status_code == 200
+        data = response.json()
+        
+        campinas = data["cities"][0]
+        assert campinas["city"] == "Campinas"
+        assert campinas["victim_count"] == 25
+        # Should have rate and population despite not being hardcoded
+        assert campinas["rate_per_100k"] is not None
+        assert campinas["population"] == 1213792  # From fixture
+        # rate = 25 / 1213792 * 100000 ≈ 2.06
+        expected_rate = 25 / 1213792 * 100000
+        assert abs(campinas["rate_per_100k"] - expected_rate) < 0.01

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -321,6 +321,8 @@ export interface RankingRow {
   event_share: number;
   victim_delta: number;
   event_delta: number;
+  population?: number | null;
+  rate_per_100k?: number | null;
 }
 
 export interface RankingsResponse {
@@ -335,6 +337,7 @@ export interface RankingsResponse {
   countries: RankingRow[];
   homicide_types: RankingRow[];
   methods: RankingRow[];
+  population_vintage?: number;
 }
 
 export interface SourcesByHourData {

--- a/frontend/src/pages/public/Rankings.tsx
+++ b/frontend/src/pages/public/Rankings.tsx
@@ -23,6 +23,7 @@ interface RankingTableProps {
   labelField: keyof RankingRow;
   onRowClick?: (value: string) => void;
   emptyMessage?: string;
+  showRateColumns?: boolean;
 }
 
 function DeltaBadge({ delta, label }: { delta: number; label: string }) {
@@ -47,7 +48,7 @@ function DeltaBadge({ delta, label }: { delta: number; label: string }) {
   );
 }
 
-function RankingTable({ title, rows, labelField, onRowClick, emptyMessage }: RankingTableProps) {
+function RankingTable({ title, rows, labelField, onRowClick, emptyMessage, showRateColumns = false }: RankingTableProps) {
   const { t, lang } = useI18n();
   const [expanded, setExpanded] = useState(true);
   
@@ -61,6 +62,7 @@ function RankingTable({ title, rows, labelField, onRowClick, emptyMessage }: Ran
   }
 
   const displayRows = expanded ? rows : rows.slice(0, 10);
+  const hasRateData = showRateColumns && rows.some(r => r.rate_per_100k != null);
 
   return (
     <div className="rounded-xl border border-stone-200 bg-white overflow-hidden">
@@ -98,7 +100,7 @@ function RankingTable({ title, rows, labelField, onRowClick, emptyMessage }: Ran
                 <th className="px-6 py-3 text-right text-xs font-medium text-stone-500 uppercase tracking-wider">
                   {t.rankingsDelta}
                 </th>
-                {labelField === 'city' && rows.some(r => r.rate_per_100k != null) && (
+                {hasRateData && (
                   <>
                     <th className="px-6 py-3 text-right text-xs font-medium text-stone-500 uppercase tracking-wider">
                       Taxa / 100k
@@ -140,7 +142,7 @@ function RankingTable({ title, rows, labelField, onRowClick, emptyMessage }: Ran
                     <td className="px-6 py-4 whitespace-nowrap text-sm text-right">
                       <DeltaBadge delta={row.victim_delta} label={t.rankingsVictimCount} />
                     </td>
-                    {labelField === 'city' && rows.some(r => r.rate_per_100k != null) && (
+                    {hasRateData && (
                       <>
                         <td className="px-6 py-4 whitespace-nowrap text-sm text-right text-stone-900 font-semibold">
                           {row.rate_per_100k != null ? row.rate_per_100k.toFixed(2) : '—'}
@@ -334,6 +336,7 @@ export function Rankings() {
                 labelField="city"
                 onRowClick={handleCityClick}
                 emptyMessage="Nenhuma cidade com eventos no período selecionado."
+                showRateColumns={true}
               />
 
               {/* States/Regions */}
@@ -343,6 +346,7 @@ export function Rankings() {
                 labelField="state"
                 onRowClick={handleStateClick}
                 emptyMessage="Nenhum estado/região com eventos no período selecionado."
+                showRateColumns={true}
               />
 
               {/* Countries */}

--- a/frontend/src/pages/public/Rankings.tsx
+++ b/frontend/src/pages/public/Rankings.tsx
@@ -98,6 +98,16 @@ function RankingTable({ title, rows, labelField, onRowClick, emptyMessage }: Ran
                 <th className="px-6 py-3 text-right text-xs font-medium text-stone-500 uppercase tracking-wider">
                   {t.rankingsDelta}
                 </th>
+                {labelField === 'city' && rows.some(r => r.rate_per_100k != null) && (
+                  <>
+                    <th className="px-6 py-3 text-right text-xs font-medium text-stone-500 uppercase tracking-wider">
+                      Taxa / 100k
+                    </th>
+                    <th className="px-6 py-3 text-right text-xs font-medium text-stone-500 uppercase tracking-wider">
+                      População
+                    </th>
+                  </>
+                )}
               </tr>
             </thead>
             <tbody className="bg-white divide-y divide-stone-200">
@@ -130,6 +140,16 @@ function RankingTable({ title, rows, labelField, onRowClick, emptyMessage }: Ran
                     <td className="px-6 py-4 whitespace-nowrap text-sm text-right">
                       <DeltaBadge delta={row.victim_delta} label={t.rankingsVictimCount} />
                     </td>
+                    {labelField === 'city' && rows.some(r => r.rate_per_100k != null) && (
+                      <>
+                        <td className="px-6 py-4 whitespace-nowrap text-sm text-right text-stone-900 font-semibold">
+                          {row.rate_per_100k != null ? row.rate_per_100k.toFixed(2) : '—'}
+                        </td>
+                        <td className="px-6 py-4 whitespace-nowrap text-sm text-right text-stone-700">
+                          {row.population != null ? row.population.toLocaleString() : '—'}
+                        </td>
+                      </>
+                    )}
                   </tr>
                 );
               })}
@@ -358,6 +378,11 @@ export function Rankings() {
                 <p className="text-sm text-amber-900">
                   <strong className="font-semibold">{t.disclaimerLabel}:</strong> {t.rankingsMethodologyNote}
                 </p>
+                {data.population_vintage && (
+                  <p className="text-sm text-amber-900 mt-2">
+                    <strong className="font-semibold">População:</strong> Dados populacionais do IBGE {data.population_vintage}.
+                  </p>
+                )}
               </div>
             </div>
           )}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements #130

**✅ All spec review feedback addressed**: 
1. ✅ Hardcoded 10-city allowlist → full geobr + SIDRA lookup
2. ✅ Added **CLI script** to actually load data into database
3. ✅ State rates included (aggregated from municipalities)
4. ✅ Documentation for deployment steps

## Changes

### Backend
- **New model**: `IBGEPopulation` table to cache IBGE population data (Censo 2022)
- **New CLI script**: `backend/scripts/load_ibge_population.py` ⭐
  ```bash
  # Run once after deployment:
  python scripts/load_ibge_population.py [--year 2022] [--force]
  ```
- **New service**: `ibge_population` module with:
  - `load_ibge_data_from_geobr_and_sidra()`: **Production load path**
    - Uses `geobr.read_municipal_seat(year=2022)` (not `lookup_muni` which defaults to 2010)
    - Loads ALL ~5,570 BR municipalities from geobr
    - Fetches Censo 2022 population from SIDRA API (table 4714)
    - Joins and caches in `ibge_population` table
  - `lookup_city_codes(session, cities, states)`: Maps (city, state) to IBGE `code_muni` via **database query**
  - `lookup_state_codes(session, states)`: Maps state abbreviation to `code_state`
  - `get_ibge_populations(session, code_munis)`: Fetches cached municipal populations
  - `get_state_populations(session, code_states)`: Aggregates state populations from municipalities
  - `calculate_rate_per_100k()`: Computes rate = victims / population × 100,000
  - `load_ibge_population_fixture()`: Test fixture (São Paulo, Rio, Bauru, **Campinas**)
- **Updated API**: `/api/public/stats/rankings` endpoint returns:
  - `rate_per_100k` and `population` for matched BR **cities and states**
  - `population_vintage` (year of census/estimate data, e.g. 2022)
  - Default sort by rate (when available), otherwise by victim count
  - Chile/unmatched names return `null` (count-only, labelled)
- **Dependencies**: `geobr>=2.0.0`, `sidrapy>=0.2.0`, `pandas>=2.0.0`

### Frontend
- Display **Taxa / 100k** and **População** columns in **city AND state** rankings
- Show population vintage: "Dados populacionais do IBGE 2022"
- Conditional rendering via `showRateColumns` prop

### Database
- Migration `j9k0l1m2n3o4`: Creates `ibge_population` table with indexes

### Documentation (AGENTS.md)
**New section: IBGE Population Data**
```bash
# Local / Docker dev:
docker compose -f docker-compose.dev.yml exec api python scripts/load_ibge_population.py

# Staging / Production (SSH):
ssh hetzner-arv
cd /root/arquivo-da-violencia
docker exec arquivo-api python scripts/load_ibge_population.py --year 2022

# Verify:
SELECT COUNT(*) FROM ibge_population; -- Expect ~5,000+
```

### Tests (TDD: Red → Green)
- ✅ São Paulo (code_muni 3550308) gets correct rate
- ✅ "Joanesburgo" (junk) does not get rate
- ✅ Chile cities do not get rates
- ✅ Default sort by rate when available
- ✅ **Campinas** (code_muni 3509502) gets rate despite never being in code → proves DB lookup

## Deployment Flow

### After merging to develop/master:
1. **Migration runs** (creates empty `ibge_population` table)
2. **Load IBGE data once**:
   ```bash
   docker exec arquivo-api python scripts/load_ibge_population.py
   ```
3. **Verify**:
   ```bash
   docker exec arquivo-api python -c "
   import asyncio
   from sqlalchemy import text
   from sqlmodel.ext.asyncio.session import AsyncSession
   from app.database import get_engine
   
   async def check():
       async with AsyncSession(get_engine()) as s:
           result = await s.execute(text('SELECT COUNT(*) FROM ibge_population'))
           print(f'Records: {result.scalar()}')
   
   asyncio.run(check())
   "
   ```
   Expected: ~5,000+ records
4. **Test**: Navigate to https://staging.arquivodaviolencia.com.br/estatisticas
5. **Verify rates appear** in city and state rankings

### Re-load data (if needed):
```bash
python scripts/load_ibge_population.py --force
```

## Implementation Details

### No Hardcoded Mapping ✅
- ❌ **Before**: `CITY_CODE_MAPPING` dict with ~10 cities
- ✅ **After**: Query `ibge_population` table populated from geobr/SIDRA

### Actual Load Path ✅
- ❌ **Before**: `load_ibge_data_from_geobr_and_sidra()` existed but was never called
- ✅ **After**: CLI script `scripts/load_ibge_population.py` runs the load

### geobr Year Parameter ✅
- Uses `read_municipal_seat(year=2022)` not `lookup_muni()`
- `lookup_muni` defaults to `year=2010` (municipal seats baseline)
- `read_municipal_seat` has 2022 data available

### Unit Tests ✅
- Use `load_ibge_population_fixture()` (4 cities)
- No geobr/SIDRA/network calls in pytest

## Out of Scope
- Official SIM/MVI overlay
- Chile rates (awaiting INE data)
- Calendar-year breakdowns
- Sex/race/age filters

---

**Final review**. All spec issues closed. Closes #130.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ead308a9-6611-4cc3-88d1-bb05bae2140e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ead308a9-6611-4cc3-88d1-bb05bae2140e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

