### PR TITLE
Security: Bind Redis to localhost and require password authentication

### DIFF
--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -29,9 +29,15 @@ services:
   redis:
     container_name: staging-arquivo-redis
     ports: !override
-      - "6380:6379"
+      - "127.0.0.1:6380:6379"
     volumes:
       - staging_redis_data:/data
+    command: redis-server --appendonly yes --requirepass ${REDIS_PASSWORD:?REDIS_PASSWORD must be set}
+    healthcheck:
+      test: ["CMD", "redis-cli", "-a", "${REDIS_PASSWORD}", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
 
   # ---------------------------------------------------------------------------
   # API - Staging instance on port 8001
@@ -50,7 +56,7 @@ services:
     ports: !override
       - "8001:8000"
     environment: !override
-      - REDIS_URL=redis://staging-arquivo-redis:6379
+      - REDIS_URL=redis://:${REDIS_PASSWORD}@staging-arquivo-redis:6379
       - DATABASE_URL=postgresql+asyncpg://arquivo:${POSTGRES_PASSWORD}@arquivo-postgres:5432/arquivo_staging
       - DB_POOL_SIZE=5
       - DB_POOL_OVERFLOW=5
@@ -90,7 +96,7 @@ services:
       - default
       - prod
     environment: !override
-      - REDIS_URL=redis://staging-arquivo-redis:6379
+      - REDIS_URL=redis://:${REDIS_PASSWORD}@staging-arquivo-redis:6379
       - DATABASE_URL=postgresql+asyncpg://arquivo:${POSTGRES_PASSWORD}@arquivo-postgres:5432/arquivo_staging
       - DB_POOL_SIZE=15
       - DB_POOL_OVERFLOW=15

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,12 +47,12 @@ services:
     image: redis:7-alpine
     container_name: arquivo-redis
     ports:
-      - "6379:6379"
+      - "127.0.0.1:6379:6379"
     volumes:
       - redis_data:/data
-    command: redis-server --appendonly yes
+    command: redis-server --appendonly yes --requirepass ${REDIS_PASSWORD:?REDIS_PASSWORD must be set}
     healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
+      test: ["CMD", "redis-cli", "-a", "${REDIS_PASSWORD}", "ping"]
       interval: 10s
       timeout: 5s
       retries: 3
@@ -76,7 +76,7 @@ services:
     env_file:
       - .env
     environment:
-      - REDIS_URL=redis://redis:6379
+      - REDIS_URL=redis://:${REDIS_PASSWORD}@redis:6379
       - DATABASE_URL=postgresql+asyncpg://arquivo:${POSTGRES_PASSWORD}@postgres:5432/arquivo_prod
       - DB_POOL_SIZE=5
       - DB_POOL_OVERFLOW=5
@@ -125,7 +125,7 @@ services:
     env_file:
       - .env
     environment:
-      - REDIS_URL=redis://redis:6379
+      - REDIS_URL=redis://:${REDIS_PASSWORD}@redis:6379
       - DATABASE_URL=postgresql+asyncpg://arquivo:${POSTGRES_PASSWORD}@postgres:5432/arquivo_prod
       - DB_POOL_SIZE=15
       - DB_POOL_OVERFLOW=15

--- a/env.example
+++ b/env.example
@@ -22,6 +22,10 @@ ENRICHMENT_MODEL=deepseek/deepseek-v4-flash
 # Get a key at https://console.cloud.google.com (enable the Geocoding API)
 GOOGLE_MAPS_API_KEY=
 
+# Redis Password (required for production and staging)
+# Generate with: openssl rand -hex 32
+REDIS_PASSWORD=
+
 # Enable hourly cron job for city ingestion
 ENABLE_CRON=false
 

--- a/test_redis_security.py
+++ b/test_redis_security.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""
+Test Redis security configuration in docker-compose files.
+
+Validates:
+1. Redis ports are bound to 127.0.0.1 (not exposed to external network)
+2. Redis command includes --requirepass with REDIS_PASSWORD env var
+3. REDIS_URL includes password authentication
+
+Usage:
+    python test_redis_security.py
+"""
+import re
+from pathlib import Path
+
+
+def test_docker_compose_yml():
+    """Test production docker-compose.yml Redis security."""
+    path = Path(__file__).parent / "docker-compose.yml"
+    content = path.read_text()
+    
+    # Check Redis ports bind to 127.0.0.1
+    redis_section = extract_redis_section(content)
+    assert '127.0.0.1:6379:6379' in redis_section, \
+        "Redis ports must bind to 127.0.0.1:6379:6379"
+    
+    # Check Redis command includes requirepass
+    assert '--requirepass' in redis_section, \
+        "Redis command must include --requirepass"
+    assert '${REDIS_PASSWORD:?REDIS_PASSWORD must be set}' in redis_section, \
+        "Redis command must use REDIS_PASSWORD env var with fail-closed check"
+    
+    # Check REDIS_URL includes password for api and worker
+    api_section = extract_service_section(content, 'api')
+    assert 'redis://:${REDIS_PASSWORD}@redis:6379' in api_section, \
+        "API REDIS_URL must include password authentication"
+    
+    worker_section = extract_service_section(content, 'worker')
+    assert 'redis://:${REDIS_PASSWORD}@redis:6379' in worker_section, \
+        "Worker REDIS_URL must include password authentication"
+    
+    # Check healthcheck includes auth
+    assert 'redis-cli' in redis_section and '-a' in redis_section, \
+        "Redis healthcheck must authenticate with -a flag"
+    
+    print("✓ docker-compose.yml Redis security checks passed")
+
+
+def test_docker_compose_staging_yml():
+    """Test staging docker-compose.staging.yml Redis security."""
+    path = Path(__file__).parent / "docker-compose.staging.yml"
+    content = path.read_text()
+    
+    # Check Redis ports bind to 127.0.0.1:6380 (staging uses different host port)
+    redis_section = extract_redis_section(content)
+    assert '127.0.0.1:6380:6379' in redis_section, \
+        "Staging Redis ports must bind to 127.0.0.1:6380:6379"
+    
+    # Check Redis command includes requirepass
+    assert '--requirepass' in redis_section, \
+        "Staging Redis command must include --requirepass"
+    assert '${REDIS_PASSWORD:?REDIS_PASSWORD must be set}' in redis_section, \
+        "Staging Redis command must use REDIS_PASSWORD env var with fail-closed check"
+    
+    # Check REDIS_URL includes password for api and worker (staging uses different hostname)
+    api_section = extract_service_section(content, 'api')
+    assert 'redis://:${REDIS_PASSWORD}@staging-arquivo-redis:6379' in api_section, \
+        "Staging API REDIS_URL must include password authentication"
+    
+    worker_section = extract_service_section(content, 'worker')
+    assert 'redis://:${REDIS_PASSWORD}@staging-arquivo-redis:6379' in worker_section, \
+        "Staging Worker REDIS_URL must include password authentication"
+    
+    # Check healthcheck includes auth
+    assert 'redis-cli' in redis_section and '-a' in redis_section, \
+        "Staging Redis healthcheck must authenticate with -a flag"
+    
+    print("✓ docker-compose.staging.yml Redis security checks passed")
+
+
+def test_env_example():
+    """Test env.example documents REDIS_PASSWORD."""
+    path = Path(__file__).parent / "env.example"
+    content = path.read_text()
+    
+    # Check REDIS_PASSWORD is documented
+    assert 'REDIS_PASSWORD' in content, \
+        "env.example must document REDIS_PASSWORD"
+    
+    # Check it includes openssl hint
+    assert 'openssl' in content.lower(), \
+        "env.example must include openssl generation hint for REDIS_PASSWORD"
+    
+    # Ensure no actual password is committed
+    redis_pass_lines = [line for line in content.split('\n') 
+                        if 'REDIS_PASSWORD=' in line and not line.strip().startswith('#')]
+    for line in redis_pass_lines:
+        value = line.split('=', 1)[1].strip()
+        assert not value or len(value) < 10, \
+            f"env.example must not contain real password (found: {line})"
+    
+    print("✓ env.example REDIS_PASSWORD documentation check passed")
+
+
+def extract_redis_section(content: str) -> str:
+    """Extract Redis service section from docker-compose YAML."""
+    lines = content.split('\n')
+    redis_lines = []
+    in_redis = False
+    indent_level = None
+    
+    for line in lines:
+        if re.match(r'^\s+redis:', line):
+            in_redis = True
+            indent_level = len(line) - len(line.lstrip())
+            redis_lines.append(line)
+        elif in_redis:
+            current_indent = len(line) - len(line.lstrip())
+            # Stop when we hit another top-level service or end of section
+            if line.strip() and current_indent <= indent_level and not line.strip().startswith('-'):
+                break
+            redis_lines.append(line)
+    
+    return '\n'.join(redis_lines)
+
+
+def extract_service_section(content: str, service: str) -> str:
+    """Extract a service section from docker-compose YAML."""
+    lines = content.split('\n')
+    service_lines = []
+    in_service = False
+    indent_level = None
+    
+    for line in lines:
+        if re.match(rf'^\s+{service}:', line):
+            in_service = True
+            indent_level = len(line) - len(line.lstrip())
+            service_lines.append(line)
+        elif in_service:
+            current_indent = len(line) - len(line.lstrip())
+            # Stop when we hit another top-level service
+            if line.strip() and current_indent <= indent_level and not line.strip().startswith('-'):
+                break
+            service_lines.append(line)
+    
+    return '\n'.join(service_lines)
+
+
+if __name__ == '__main__':
+    test_docker_compose_yml()
+    test_docker_compose_staging_yml()
+    test_env_example()
+    print("\n✅ All Redis security tests passed!")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 📝 Descrição

**DO NOT MERGE.** Security fix for Redis configuration.

This PR addresses a security vulnerability where Redis was exposed on all network interfaces (0.0.0.0) without authentication. The changes ensure Redis is only accessible from localhost and requires password authentication.

### Changes
- **Production (`docker-compose.yml`)**: Bind Redis to `127.0.0.1:6379`
- **Staging (`docker-compose.staging.yml`)**: Bind Redis to `127.0.0.1:6380` (different host port)
- **Password authentication**: Require `REDIS_PASSWORD` env var with fail-closed validation (`${REDIS_PASSWORD:?...}`)
- **REDIS_URL updates**: Include password authentication (`redis://:${REDIS_PASSWORD}@...`)
- **Healthcheck**: Authenticate with `-a` flag
- **Documentation**: Add `REDIS_PASSWORD` to `env.example` with `openssl rand -hex 32` hint
- **Tests**: Add `test_redis_security.py` to verify configuration

### Files Changed (git diff --name-only origin/develop..HEAD)
```
docker-compose.staging.yml
docker-compose.yml
env.example
test_redis_security.py
```

✅ **Verified**: Diff includes `docker-compose.yml` and `docker-compose.staging.yml` as required.

Run test:
```bash
python3 test_redis_security.py
```

## 🔗 Issue Relacionada

Security fix - no specific issue

## 🏷️ Tipo de Mudança

- [x] 🐛 Bug fix (security vulnerability)
- [ ] ✨ Nova feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentação
- [x] ✅ Testes (adição de testes)

## 🧪 Como Foi Testado?

- [x] Testes unitários (`test_redis_security.py` - all checks pass)
- [x] Testado em desenvolvimento local (Docker Compose parsing)
- [x] Verified with `git diff --name-only origin/develop..HEAD`

**Ambiente de teste:**
- OS: Linux
- Docker: docker-compose.yml configuration validated
- Test runner: Python 3

## ✅ Checklist

- [x] Meu código segue o guia de estilo do projeto
- [x] Realizei uma auto-revisão do meu código
- [x] Não modifica `docker-compose.dev.yml` (conforme solicitado)
- [x] Adicionei testes que provam que meu fix funciona
- [x] Testes unitários novos passam localmente
- [x] Atualizei a documentação correspondente (env.example)
- [x] No secrets committed to git

## 📚 Documentação

- [x] env.example (documented REDIS_PASSWORD with generation hint)

## 💬 Notas Adicionais

**IMPORTANT**: Before deploying to staging or production:
1. Generate a strong password: `openssl rand -hex 32`
2. Add to `.env`: `REDIS_PASSWORD=<generated-password>`
3. Restart services to apply the configuration

The previous PR #144 was empty (old master merge commits without Redis edits). This is a fresh implementation from current develop.

Target branch: **develop**
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-58833f4e-e2fe-4c91-b86e-77554aa87457?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-58833f4e-e2fe-4c91-b86e-77554aa87457&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

