### PR TITLE
🐛 Fix: Truncate police_operation_force to 100 chars to prevent DB truncation error

### DIFF
--- a/backend/app/services/extraction_derived.py
+++ b/backend/app/services/extraction_derived.py
@@ -67,6 +67,11 @@ def derive_public_fields(event: ViolentDeathEvent) -> dict[str, Any]:
         if victim.political_role is not None and victim.political_role.is_politician_or_candidate
     ]
 
+    police_operation_force = None
+    if po and po.responsible_force:
+        force_stripped = po.responsible_force.strip()
+        police_operation_force = force_stripped[:100] if force_stripped else None
+
     return {
         "security_force_involved": derive_security_force_involved(event),
         "security_force_victim": derive_security_force_victim(event),
@@ -76,7 +81,7 @@ def derive_public_fields(event: ViolentDeathEvent) -> dict[str, Any]:
         "criminal_groups": _join_nonempty(cg.groups) if cg and cg.groups else None,
         "criminal_group_attacked": cg.group_attacked if cg else None,
         "police_operation_connected": po.connected if po else None,
-        "police_operation_force": po.responsible_force if po else None,
+        "police_operation_force": police_operation_force,
         "police_operation_targeted_armed_groups": po.targeted_armed_groups if po else None,
         "off_duty_police_perpetrator": dynamic.off_duty_police_perpetrator,
         "off_duty_police_context": dynamic.off_duty_police_context,

--- a/backend/tests/test_extraction_derived.py
+++ b/backend/tests/test_extraction_derived.py
@@ -115,3 +115,23 @@ def test_derive_security_force_victim_public_field():
     fields = derive_public_fields(event)
     assert fields["security_force_victim"] is True
     assert fields["security_force_involved"] is True
+
+
+def test_police_operation_force_truncates_long_responsible_force():
+    """police_operation_force must be truncated to 100 chars to fit DB column."""
+    long_force = "Polícia Militar do Estado do Rio de Janeiro - Batalhão de Operações Especiais (BOPE) em conjunto com Comando de Operações Táticas"
+    assert len(long_force) > 100
+    
+    event = _base_event(
+        police_operation_context=PoliceOperationContext(
+            connected=True,
+            responsible_force=long_force,
+            targeted_armed_groups=True,
+        ),
+    )
+    fields = derive_public_fields(event)
+    
+    assert fields["police_operation_force"] is not None
+    assert len(fields["police_operation_force"]) <= 100
+    assert fields["police_operation_force"] == long_force[:100]
+    assert long_force.startswith(fields["police_operation_force"])


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 📝 Descrição

Este PR corrige um bug de produção onde `process_cities_backlog` / `batch_dedup` falhava ao fazer INSERT em `unique_event` com erro `StringDataRightTruncationError` no campo `varchar(100)`.

**Problema:**
- `backend/app/services/extraction_derived.py` configurava `police_operation_force = po.responsible_force` sem limitação de tamanho
- Modelo `UniqueEvent.police_operation_force` tem `max_length=100`
- O LLM pode gerar valores de `responsible_force` maiores que 100 caracteres
- Erro ocorreu em produção em 2026-08-20 às 15:25 e 15:57 UTC

**Solução (TDD - Red/Green):**
1. **RED:** Adicionado teste com `responsible_force` de 129 caracteres
2. **GREEN:** Implementado clipping para 100 caracteres (strip + [:100], vazio → None)
3. Testes existentes (incluindo `assert fields["police_operation_force"] == "PM"`) continuam passando

**Notas importantes:**
- ⚠️ **NÃO fazer merge** - PR apenas para correção do bug de produção
- Sem alterações no schema do banco de dados (sem Alembic neste PR)
- Não toca em Redis, rankings, matrix ou classifier
- ✅ **Branch limpa:** rebased em `origin/develop`, apenas 2 arquivos alterados

## 🔗 Issue Relacionada

Bug de produção reportado em 2026-08-20

## 🏷️ Tipo de Mudança

- [x] 🐛 Bug fix (mudança que corrige um problema)
- [ ] ✨ Nova feature (mudança que adiciona funcionalidade)
- [ ] 💥 Breaking change (fix ou feature que causaria quebra de funcionalidade existente)
- [ ] 📚 Documentação (mudança apenas em documentação)
- [ ] 🎨 Estilo (formatação, ponto e vírgula, etc - sem mudança de código)
- [ ] ♻️ Refatoração (mudança de código sem alterar funcionalidade)
- [ ] ⚡ Performance (mudança que melhora performance)
- [x] ✅ Testes (adição ou correção de testes)
- [ ] 🔧 Chore (atualizações de build, CI, etc)

## 🧪 Como Foi Testado?

- [x] Testes unitários
- [ ] Testes de integração
- [ ] Testes manuais
- [x] Testado em desenvolvimento local
- [ ] Testado com Docker

**Ambiente de teste:**
- OS: Linux 6.12.94+ (Cloud Agent VM)
- Python: 3.12.3
- pytest: 9.1.1

**Resultados:**
```
tests/test_extraction_derived.py::test_police_operation_force_truncates_long_responsible_force PASSED
tests/test_extraction_derived.py::test_derive_police_operation_and_off_duty PASSED
All 6 tests in test_extraction_derived.py PASSED
```

## ✅ Checklist

- [x] Meu código segue o guia de estilo do projeto
- [x] Realizei uma auto-revisão do meu código
- [x] Comentei meu código em áreas complexas
- [ ] Atualizei a documentação correspondente
- [x] Minhas mudanças não geram novos warnings
- [x] Adicionei testes que provam que meu fix/feature funciona
- [x] Testes unitários novos e existentes passam localmente
- [x] Quaisquer mudanças dependentes foram mergeadas
- [ ] Atualizei o CHANGELOG (se aplicável)

## 📚 Documentação

- [ ] README.md
- [ ] CONTRIBUTING.md
- [x] Docstrings/comentários no código
- [ ] API documentation
- [ ] Outro: 

## 💬 Notas Adicionais

### Alterações no código:

1. **`backend/app/services/extraction_derived.py`:**
   - Adiciona lógica de truncamento em `derive_public_fields()`
   - `police_operation_force = force_stripped[:100] if force_stripped else None`

2. **`backend/tests/test_extraction_derived.py`:**
   - Novo teste: `test_police_operation_force_truncates_long_responsible_force()`
   - Valida truncamento com string de 129 caracteres
   - Garante que o resultado é prefixo da entrada original

### Diff limpo contra develop:
```
$ git diff origin/develop HEAD --name-only
backend/app/services/extraction_derived.py
backend/tests/test_extraction_derived.py
```

✅ **Confirmado:** Nenhum arquivo estranho (extraction.py, test_extraction_module.py) no diff.

### Próximos passos (fora deste PR):
- Considerar aplicar a mesma lógica para outros campos com limites (se necessário)
- Monitorar logs de produção para verificar se o erro foi resolvido

---

**⚠️ IMPORTANTE: Este PR não deve ser mergeado automaticamente. Target: develop.**
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fb0fd937-4a4c-485b-a32e-bf1157e5536a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fb0fd937-4a4c-485b-a32e-bf1157e5536a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

