### PR TITLE
Clip police_operation_force to 100 chars (cherry-pick #147)

### DIFF
--- a/backend/app/services/extraction_derived.py
+++ b/backend/app/services/extraction_derived.py
@@ -67,6 +67,11 @@ def derive_public_fields(event: ViolentDeathEvent) -> dict[str, Any]:
         if victim.political_role is not None and victim.political_role.is_politician_or_candidate
     ]
 
+    police_operation_force = None
+    if po and po.responsible_force:
+        force_stripped = po.responsible_force.strip()
+        police_operation_force = force_stripped[:100] if force_stripped else None
+
     return {
         "security_force_involved": derive_security_force_involved(event),
         "security_force_victim": derive_security_force_victim(event),
@@ -76,7 +81,7 @@ def derive_public_fields(event: ViolentDeathEvent) -> dict[str, Any]:
         "criminal_groups": _join_nonempty(cg.groups) if cg and cg.groups else None,
         "criminal_group_attacked": cg.group_attacked if cg else None,
         "police_operation_connected": po.connected if po else None,
-        "police_operation_force": po.responsible_force if po else None,
+        "police_operation_force": police_operation_force,
         "police_operation_targeted_armed_groups": po.targeted_armed_groups if po else None,
         "off_duty_police_perpetrator": dynamic.off_duty_police_perpetrator,
         "off_duty_police_context": dynamic.off_duty_police_context,

--- a/backend/tests/test_extraction_derived.py
+++ b/backend/tests/test_extraction_derived.py
@@ -115,3 +115,23 @@ def test_derive_security_force_victim_public_field():
     fields = derive_public_fields(event)
     assert fields["security_force_victim"] is True
     assert fields["security_force_involved"] is True
+
+
+def test_police_operation_force_truncates_long_responsible_force():
+    """police_operation_force must be truncated to 100 chars to fit DB column."""
+    long_force = "Polícia Militar do Estado do Rio de Janeiro - Batalhão de Operações Especiais (BOPE) em conjunto com Comando de Operações Táticas"
+    assert len(long_force) > 100
+    
+    event = _base_event(
+        police_operation_context=PoliceOperationContext(
+            connected=True,
+            responsible_force=long_force,
+            targeted_armed_groups=True,
+        ),
+    )
+    fields = derive_public_fields(event)
+    
+    assert fields["police_operation_force"] is not None
+    assert len(fields["police_operation_force"]) <= 100
+    assert fields["police_operation_force"] == long_force[:100]
+    assert long_force.startswith(fields["police_operation_force"])


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Cherry-pick of commit 35ae81a from PR #147 to hotfix master.

This change truncates the `police_operation_force` field to 100 characters to prevent database truncation errors when the `responsible_force` value from the police operation context exceeds the column width.

## Changes

The commit modifies:
- `backend/app/services/extraction_derived.py`: Strips and truncates `responsible_force` to 100 chars (empty → None)
- `backend/tests/test_extraction_derived.py`: Adds test verifying 129-char input gets truncated to 100 chars

## Files changed (verification)

```
backend/app/services/extraction_derived.py
backend/tests/test_extraction_derived.py
```

Verified via `git diff master...HEAD --name-only` - only these two files changed as expected.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-88d2a786-179a-4844-b793-d9d683c762db?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-88d2a786-179a-4844-b793-d9d683c762db&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

