### PR TITLE
feat: Add Chilean homicide query terms to Chile city ingestion

### DIFF
--- a/backend/app/services/ingestion.py
+++ b/backend/app/services/ingestion.py
@@ -24,6 +24,7 @@ from app.services.cities import (
 from app.services.cities_chile import (
     CHILEAN_CITIES,
     CHILEAN_NEWS_SOURCES,
+    CHILEAN_QUERY_TERMS,
     CHILE_GOOGLE_NEWS_PARAMS,
 )
 from app.geography import Country
@@ -263,8 +264,16 @@ async def get_queries_for_city(
     """
     Get queries for a city based on its sharding status.
     
-    - Standard mode: Single query "{city} when:{when}"
-    - Sharded mode: One query per source "{city} when:{when} site:{source}"
+    - Brazil standard mode: Single query "{city} when:{when}"
+    - Brazil sharded mode: One query per source "{city} when:{when} site:{source}"
+    - Chile standard mode: Single query "{city} when:{when} (term1 OR term2 OR ...)"
+    - Chile sharded mode: One query per source "{city} when:{when} site:{source} (term1 OR term2 OR ...)"
+    
+    Query cardinality (per hourly cycle):
+    - BR: 52 cities × 19 sources = 988 queries (worst case, all sharded)
+    - CL: 27 cities × 18 sources = 486 queries (worst case, all sharded)
+    - Combined worst case: 1,474 queries (~2 hours at 12 req/min rate limit)
+    - Adding Chilean terms does NOT increase query count (OR'd into existing queries)
     
     Args:
         city: City name (with region for Chile, e.g., "Santiago Metropolitana")
@@ -276,12 +285,20 @@ async def get_queries_for_city(
     
     news_sources = CHILEAN_NEWS_SOURCES if country == "CL" else BRAZILIAN_NEWS_SOURCES
     
+    # Build homicide term filter for Chile
+    terms_filter = ""
+    if country == "CL":
+        # Combine terms with OR to keep query count bounded
+        # Format: (term1 OR term2 OR term3)
+        terms_or = " OR ".join(CHILEAN_QUERY_TERMS)
+        terms_filter = f" ({terms_or})"
+    
     if stats.needs_sharding:
         logger.info(f"[{city}] Using sharded mode ({len(news_sources)} sources)")
-        return [f"{city} when:{when} site:{src}" for src in news_sources]
+        return [f"{city} when:{when} site:{src}{terms_filter}" for src in news_sources]
     else:
         logger.info(f"[{city}] Using standard mode")
-        return [f"{city} when:{when}"]
+        return [f"{city} when:{when}{terms_filter}"]
 
 
 async def update_city_stats(

--- a/backend/tests/test_query_builder.py
+++ b/backend/tests/test_query_builder.py
@@ -1,0 +1,92 @@
+"""Tests for query building at the get_queries_for_city seam.
+
+Tests that Chilean queries include homicide terms while Brazilian queries remain unchanged.
+"""
+
+import pytest
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.services.ingestion import get_queries_for_city
+
+
+@pytest.mark.asyncio
+async def test_chile_city_queries_include_homicide_term(async_session: AsyncSession):
+    """Chile city queries must include at least one homicide vocabulary term."""
+    # Given a Chilean city
+    city = "Santiago Metropolitana"
+    
+    # When getting queries for that city
+    queries = await get_queries_for_city(city, async_session, when="1h", country="CL")
+    
+    # Then at least one query should contain a homicide term
+    homicide_terms = [
+        "homicidio",
+        "asesinato", 
+        "femicidio",
+        "feminicidio",
+        "balacera",
+        "tiroteo",
+        "robo con homicidio",
+        "muerte violenta",
+        "operativo policial",
+        "carabineros disparo",
+    ]
+    
+    assert len(queries) > 0, "Should generate at least one query"
+    
+    # Check that at least one query contains at least one homicide term
+    has_homicide_term = False
+    for query in queries:
+        if any(term in query.lower() for term in homicide_terms):
+            has_homicide_term = True
+            break
+    
+    assert has_homicide_term, (
+        f"At least one Chile query must include a homicide term. Got: {queries}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_brazil_city_queries_unchanged(async_session: AsyncSession):
+    """Brazilian city queries should remain unchanged (city + when only, no homicide terms)."""
+    # Given a Brazilian city
+    city = "Rio de Janeiro RJ"
+    
+    # When getting queries for that city in standard (non-sharded) mode
+    queries = await get_queries_for_city(city, async_session, when="1h", country="BR")
+    
+    # Then the query should be exactly city + when (no additional terms)
+    assert queries == ["Rio de Janeiro RJ when:1h"], (
+        f"Brazil standard query should be unchanged. Got: {queries}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_brazil_city_sharded_queries_unchanged(async_session: AsyncSession):
+    """Brazilian city sharded queries should remain unchanged (city + when + site only)."""
+    # Given a Brazilian city that needs sharding
+    city = "São Paulo SP"
+    
+    # First, set up the city to need sharding
+    from app.models import CityStats
+    stats = CityStats(city_name=city, needs_sharding=True)
+    async_session.add(stats)
+    await async_session.commit()
+    
+    # When getting queries for that city
+    queries = await get_queries_for_city(city, async_session, when="1h", country="BR")
+    
+    # Then queries should be city + when + site (no homicide terms)
+    assert len(queries) > 1, "Sharded mode should generate multiple queries"
+    
+    # All queries should match the pattern: "{city} when:{when} site:{source}"
+    for query in queries:
+        assert city in query, f"Query should contain city name: {query}"
+        assert "when:1h" in query, f"Query should contain time filter: {query}"
+        assert "site:" in query, f"Sharded query should contain site: {query}"
+        
+        # No homicide terms should be present
+        homicide_terms = ["homicídio", "assassinato", "tiroteio"]
+        assert not any(term in query.lower() for term in homicide_terms), (
+            f"Brazil sharded queries should not have homicide terms: {query}"
+        )


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 📝 Descrição

Implementa termos de violência chilenos nas consultas de ingestão do Chile conforme especificado na issue #151. As consultas do Chile agora incluem vocabulário de homicídio relevante (homicidio, asesinato, femicidio, balacera, etc.) usando operador OR, enquanto as consultas do Brasil permanecem inalteradas.

**Implementação:**
- Importa `CHILEAN_QUERY_TERMS` do módulo `cities_chile.py`
- Modifica `get_queries_for_city` para adicionar termos OR'd apenas para país="CL"
- Brasil: queries mantém formato original `"{city} when:{when}"` ou `"{city} when:{when} site:{source}"`
- Chile: queries agora incluem `"(term1 OR term2 OR ... OR term10)"` ao final

**Cardinalidade de Queries (limitada):**
- BR: 52 cidades × 19 fontes = 988 queries (pior caso, todas sharded)
- CL: 27 cidades × 18 fontes = 486 queries (pior caso, todas sharded)
- **Pior caso combinado: 1.474 queries (~2 horas a 12 req/min)**
- Adicionar termos chilenos **NÃO** aumenta contagem de queries (OR'd nas queries existentes)

## 🔗 Issue Relacionada

Fixes #151

## 🏷️ Tipo de Mudança

- [ ] 🐛 Bug fix (mudança que corrige um problema)
- [x] ✨ Nova feature (mudança que adiciona funcionalidade)
- [ ] 💥 Breaking change (fix ou feature que causaria quebra de funcionalidade existente)
- [ ] 📚 Documentação (mudança apenas em documentação)
- [ ] 🎨 Estilo (formatação, ponto e vírgula, etc - sem mudança de código)
- [ ] ♻️ Refatoração (mudança de código sem alterar funcionalidade)
- [ ] ⚡ Performance (mudança que melhora performance)
- [x] ✅ Testes (adição ou correção de testes)
- [ ] 🔧 Chore (atualizações de build, CI, etc)

## 🧪 Como Foi Testado?

- [x] Testes unitários
- [ ] Testes de integração
- [x] Testes manuais
- [x] Testado em desenvolvimento local
- [ ] Testado com Docker

**Testes Adicionados:**
1. `test_chile_city_queries_include_homicide_term` - Verifica que queries do Chile incluem pelo menos um termo de homicídio
2. `test_brazil_city_queries_unchanged` - Verifica que queries do Brasil em modo padrão permanecem inalteradas
3. `test_brazil_city_sharded_queries_unchanged` - Verifica que queries do Brasil em modo sharded permanecem inalteradas

**Verificação Manual:**
Executei script de verificação mostrando queries reais geradas:
- Chile standard: `"Santiago Metropolitana when:1h (homicidio OR asesinato OR femicidio OR feminicidio OR balacera OR tiroteo OR robo con homicidio OR muerte violenta OR operativo policial OR carabineros disparo)"`
- Brasil standard: `"Rio de Janeiro RJ when:1h"` (inalterado)
- Chile sharded: `"Concepción Biobío when:1h site:emol.com (homicidio OR ...)"`
- Brasil sharded: `"São Paulo SP when:1h site:g1.globo.com"` (inalterado)

**Ambiente de teste:**
- OS: Linux (Ubuntu 24.04)
- Python: 3.12.3
- Pytest: 9.1.1
- SQLite in-memory database para testes

**Resultados dos Testes:**
```
tests/test_query_builder.py::test_chile_city_queries_include_homicide_term PASSED
tests/test_query_builder.py::test_brazil_city_queries_unchanged PASSED
tests/test_query_builder.py::test_brazil_city_sharded_queries_unchanged PASSED
tests/test_ingestion_dedup.py::test_ingest_city_skips_existing_google_news_id PASSED
tests/test_ingestion_dedup.py::test_ingest_city_continues_after_integrity_error_on_flush PASSED

5 passed in 0.17s
```

## ✅ Checklist

- [x] Meu código segue o guia de estilo do projeto
- [x] Realizei uma auto-revisão do meu código
- [x] Comentei meu código em áreas complexas
- [ ] Atualizei a documentação correspondente
- [x] Minhas mudanças não geram novos warnings
- [x] Adicionei testes que provam que meu fix/feature funciona
- [x] Testes unitários novos e existentes passam localmente
- [x] Quaisquer mudanças dependentes foram mergeadas
- [ ] Atualizei o CHANGELOG (se aplicável)

## 📚 Documentação

- [ ] README.md
- [ ] CONTRIBUTING.md
- [x] Docstrings/comentários no código
- [ ] API documentation
- [ ] Outro: 

**Documentação Atualizada:**
- Docstring de `get_queries_for_city` com exemplos de queries e limites de cardinalidade

## 💬 Notas Adicionais

**Abordagem TDD:**
Seguiu processo TDD conforme solicitado:
1. Escreveu testes falhando primeiro (red)
2. Implementou código mínimo para passar os testes (green)
3. Verificou que testes existentes continuam passando

**Compatibilidade com Brasil:**
Todas as queries do Brasil permanecem 100% inalteradas. A feature é opt-in apenas para país="CL" através de condicional simples.

**Cardinalidade Mantida:**
Usar operador OR garante que:
- Modo standard: 1 query por cidade (independente do país)
- Modo sharded: N queries por cidade (N = número de fontes de notícias)
- Chile não explode contagem de queries

**Próximos Passos:**
Após merge em `develop`, testar em staging antes de promover para production conforme fluxo descrito em AGENTS.md.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-96a111f2-7cd5-492b-ae0c-af7980f13598?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-96a111f2-7cd5-492b-ae0c-af7980f13598&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

