### PR TITLE
Fix Chilean state filtering with country-specific allowlists (#157)

### DIFF
--- a/backend/app/routers/public.py
+++ b/backend/app/routers/public.py
@@ -495,7 +495,8 @@ async def get_rankings(
                 UniqueEvent.event_date.isnot(None),
                 UniqueEvent.event_date >= start,
                 UniqueEvent.event_date <= end,
-            )
+            ),
+            country=country  # Pass country for state filtering
         )
         if country:
             # Match canonical codes (BR, CL) and legacy "Brasil" for BR

--- a/backend/app/services/public_filters.py
+++ b/backend/app/services/public_filters.py
@@ -4,58 +4,59 @@ from sqlalchemy import ColumnElement, or_
 
 from app.models.unique_event import UniqueEvent
 from app.taxonomy import SUBTYPES_BY_FAMILY, parse_legacy_homicide_type
+from app.geography import BRAZILIAN_STATES, CHILEAN_REGIONS
 
 _HOMICIDIO_SUBTYPES = SUBTYPES_BY_FAMILY["homicidio"]
 
 # Brazilian federative units (27 states + DF).
-BR_UFS = frozenset(
-    {
-        "AC",
-        "AL",
-        "AP",
-        "AM",
-        "BA",
-        "CE",
-        "DF",
-        "ES",
-        "GO",
-        "MA",
-        "MT",
-        "MS",
-        "MG",
-        "PA",
-        "PB",
-        "PR",
-        "PE",
-        "PI",
-        "RJ",
-        "RN",
-        "RS",
-        "RO",
-        "RR",
-        "SC",
-        "SP",
-        "SE",
-        "TO",
-    }
-)
+BR_UFS = frozenset(BRAZILIAN_STATES)
 
-# Public archive: homicides only (event_family=homicidio), single incidents, BR scope.
+# Chilean regions (regiones)
+CL_REGIONS = frozenset(CHILEAN_REGIONS)
+
+# Public archive: homicides only (event_family=homicidio), single incidents.
 
 
-def public_incident_criteria() -> tuple[ColumnElement, ...]:
-    """SQLAlchemy criteria for public homicide archive rows."""
-    return (
+def public_incident_criteria(country: str | None = None) -> tuple[ColumnElement, ...]:
+    """SQLAlchemy criteria for public homicide archive rows.
+    
+    Args:
+        country: Optional country filter for state allowlist.
+                 - When "BR" or "Brasil": only BR UFs or null
+                 - When "CL": no state filtering (all Chilean regions allowed)
+                 - When None (default): allow both BR UFs and CL regions (for unfiltered queries)
+    """
+    base_criteria = (
         UniqueEvent.event_family == "homicidio",
         UniqueEvent.content_class == "incident",
         UniqueEvent.victim_count <= 10,
-        or_(UniqueEvent.state.in_(BR_UFS), UniqueEvent.state.is_(None)),
     )
+    
+    # Apply country-specific state filtering
+    if country is not None and country.upper() == "CL":
+        # CL: no state filtering (allow all Chilean regions)
+        return base_criteria
+    elif country is not None and country.upper() in ("BR", "BRASIL"):
+        # BR/Brasil explicit: only allow valid Brazilian UFs or null
+        return base_criteria + (
+            or_(UniqueEvent.state.in_(BR_UFS), UniqueEvent.state.is_(None)),
+        )
+    else:
+        # No country filter (None): allow both BR UFs and CL regions or null (default for mixed queries)
+        valid_states = BR_UFS.union(CL_REGIONS)
+        return base_criteria + (
+            or_(UniqueEvent.state.in_(valid_states), UniqueEvent.state.is_(None)),
+        )
 
 
-def apply_public_incident_filter(statement):
-    """Apply public homicide archive filters to a Select statement."""
-    for criterion in public_incident_criteria():
+def apply_public_incident_filter(statement, country: str | None = None):
+    """Apply public homicide archive filters to a Select statement.
+    
+    Args:
+        statement: SQLAlchemy Select statement
+        country: Optional country code for country-specific filtering
+    """
+    for criterion in public_incident_criteria(country):
         statement = statement.where(criterion)
     return statement
 

--- a/backend/tests/test_rankings.py
+++ b/backend/tests/test_rankings.py
@@ -218,6 +218,104 @@ async def test_rankings_country_filter_chile(app, async_session):
 
 
 @pytest.mark.asyncio
+async def test_rankings_chile_includes_metropolitana_region(app, async_session):
+    """Test that Chilean events with Chilean region names (e.g. Metropolitana) are included (issue #157)."""
+    now = datetime.utcnow()
+    current_start = now - timedelta(days=30)
+    
+    # Create Chilean event with Metropolitana region (was previously excluded due to BR UF filter)
+    events = [
+        create_ranking_event(
+            event_date=current_start + timedelta(days=1),
+            country="CL",
+            city="Conchalí",
+            state="Metropolitana",  # Chilean region name
+            victim_count=1
+        ),
+        create_ranking_event(
+            event_date=current_start + timedelta(days=2),
+            country="CL",
+            city="La Serena",
+            state="Coquimbo",  # Another Chilean region
+            victim_count=2
+        ),
+    ]
+    
+    for event in events:
+        async_session.add(event)
+    await async_session.commit()
+    
+    from app.database import get_session
+    app.dependency_overrides[get_session] = lambda: async_session
+    
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test"
+    ) as client:
+        response = await client.get("/api/public/stats/rankings?days=30&country=CL")
+        assert response.status_code == 200
+        data = response.json()
+        
+        # Both Chilean events should be included
+        assert data["total_events"] == 2
+        assert data["total_victims"] == 3
+        assert len(data["cities"]) == 2
+        
+        # Check that Metropolitana region events are counted
+        cities = {c["city"]: c for c in data["cities"]}
+        assert "Conchalí" in cities
+        assert cities["Conchalí"]["victim_count"] == 1
+        assert "La Serena" in cities
+        assert cities["La Serena"]["victim_count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_rankings_brazil_excludes_non_uf_states(app, async_session):
+    """Test that Brazilian events with non-UF states (e.g. Chilean regions) are excluded."""
+    now = datetime.utcnow()
+    current_start = now - timedelta(days=30)
+    
+    # Create Brazilian events: one with valid UF, one with invalid state
+    events = [
+        create_ranking_event(
+            event_date=current_start + timedelta(days=1),
+            country="Brasil",
+            city="São Paulo",
+            state="SP",  # Valid BR UF
+            victim_count=1
+        ),
+        create_ranking_event(
+            event_date=current_start + timedelta(days=2),
+            country="Brasil",
+            city="Rio de Janeiro",
+            state="Metropolitana",  # Invalid for Brazil (Chilean region)
+            victim_count=1
+        ),
+    ]
+    
+    for event in events:
+        async_session.add(event)
+    await async_session.commit()
+    
+    from app.database import get_session
+    app.dependency_overrides[get_session] = lambda: async_session
+    
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test"
+    ) as client:
+        response = await client.get("/api/public/stats/rankings?days=30&country=BR")
+        assert response.status_code == 200
+        data = response.json()
+        
+        # Should only include the valid UF event
+        assert data["total_events"] == 1
+        assert data["total_victims"] == 1
+        assert len(data["cities"]) == 1
+        assert data["cities"][0]["city"] == "São Paulo"
+
+
+@pytest.mark.asyncio
 async def test_rankings_empty_chile_data(app, async_session):
     """Test that empty Chile data doesn't break the page."""
     now = datetime.utcnow()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Cherry-pick of issue #157 onto master (from PR #159 on develop).

## Changes

This PR fixes the Chilean state filtering bug where events in Chilean regions like "Metropolitana" and "Coquimbo" were incorrectly excluded from country=CL queries.

### Implementation

1. **Updated `public_filters.py`**:
   - Added `country` parameter to `public_incident_criteria()` and `apply_public_incident_filter()`
   - For `country=CL`: no state filtering (all Chilean regions allowed)
   - For `country=BR` or `Brasil`: only BR UFs or null
   - For `country=None`: allow BR UFs ∪ CL regions or null (default for mixed queries)

2. **Updated `public.py`**:
   - Modified `GET /api/public/stats/rankings` to pass `country` parameter to `apply_public_incident_filter()`
   - Maintains existing rankings handler from PR #156

3. **Added HTTP tests** in `test_rankings.py`:
   - `test_rankings_chile_includes_metropolitana_region`: Verifies Chilean events with region names are included for `country=CL`
   - `test_rankings_brazil_excludes_non_uf_states`: Verifies Brazilian events with non-UF states are excluded for `country=BR`

## Testing

The changes include two new test cases that verify:
- ✅ Chilean events with state=Metropolitana are counted in `GET /api/public/stats/rankings?country=CL`
- ✅ Brazilian events with state=Metropolitana are excluded from `country=BR` queries

## Notes

- This is a direct port from develop (PR #159, merge commit 2742d55)
- Does NOT include other develop changes like /estatisticas, matrix, IBGE, or city-UF rankings extras
- Keeps master's rankings handler from PR #156 while adding the country parameter fix

Closes #157
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b89962d0-3c13-4559-a5d7-6cb0891e080b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b89962d0-3c13-4559-a5d7-6cb0891e080b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

