### PR TITLE
Fix HTTP 500 in /api/public/stats/rankings - import COUNTRY_NAMES

### DIFF
--- a/backend/app/routers/public.py
+++ b/backend/app/routers/public.py
@@ -19,6 +19,7 @@ from app.services.public_filters import (
     homicide_type_filter,
     homicide_types_filter,
 )
+from app.geography import COUNTRY_NAMES
 
 router = APIRouter(prefix="/public", tags=["public"])
 

--- a/backend/tests/test_rankings.py
+++ b/backend/tests/test_rankings.py
@@ -425,6 +425,99 @@ async def test_rankings_victim_vs_event_counts(app, async_session):
 
 
 @pytest.mark.asyncio
+async def test_rankings_http_200_with_br_fixture(app, async_session):
+    """
+    Test that GET /api/public/stats/rankings returns HTTP 200 with BR fixture.
+    
+    Regression test for issue #161: COUNTRY_NAMES import missing caused HTTP 500.
+    """
+    now = datetime.utcnow()
+    
+    br_event = UniqueEvent(
+        title="Evento no Brasil",
+        event_date=now - timedelta(days=10),
+        country="BR",
+        state="SP",
+        city="São Paulo",
+        event_family="homicidio",
+        event_subtype="simples",
+        content_class="incident",
+        homicide_type="Homicídio simples",
+        method_of_death="Arma de fogo",
+        victim_count=1,
+        latitude=Decimal("-23.5505"),
+        longitude=Decimal("-46.6333"),
+        source_count=1,
+    )
+    
+    async_session.add(br_event)
+    await async_session.commit()
+    
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test"
+    ) as client:
+        response = await client.get("/api/public/stats/rankings?days=30")
+        assert response.status_code == 200, f"Expected 200, got {response.status_code}"
+        
+        data = response.json()
+        assert data["total_events"] >= 1
+        assert len(data["countries"]) >= 1
+        # Verify BR is normalized to "Brasil" display name
+        br_country = next((c for c in data["countries"] if c["country"] == "Brasil"), None)
+        assert br_country is not None, "BR should be normalized to 'Brasil' in display"
+
+
+@pytest.mark.asyncio
+async def test_rankings_http_200_with_cl_fixture(app, async_session):
+    """
+    Test that GET /api/public/stats/rankings returns HTTP 200 with CL fixture.
+    
+    Regression test for issue #161: COUNTRY_NAMES import missing caused HTTP 500.
+    Tests that state=Metropolitana is still counted for CL (issue #157).
+    """
+    now = datetime.utcnow()
+    
+    cl_event = UniqueEvent(
+        title="Evento en Chile",
+        event_date=now - timedelta(days=10),
+        country="CL",
+        state="Metropolitana",
+        city="Santiago",
+        event_family="homicidio",
+        event_subtype="simples",
+        content_class="incident",
+        homicide_type="Homicídio simples",
+        method_of_death="Arma de fogo",
+        victim_count=1,
+        latitude=Decimal("-33.4489"),
+        longitude=Decimal("-70.6693"),
+        source_count=1,
+    )
+    
+    async_session.add(cl_event)
+    await async_session.commit()
+    
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test"
+    ) as client:
+        response = await client.get("/api/public/stats/rankings?days=30")
+        assert response.status_code == 200, f"Expected 200, got {response.status_code}"
+        
+        data = response.json()
+        assert data["total_events"] >= 1
+        assert len(data["countries"]) >= 1
+        # Verify CL is normalized to "Chile" display name
+        cl_country = next((c for c in data["countries"] if c["country"] == "Chile"), None)
+        assert cl_country is not None, "CL should be normalized to 'Chile' in display"
+        # Verify state=Metropolitana is counted
+        assert len(data["states"]) >= 1
+        metropolitana_state = next((s for s in data["states"] if s["state"] == "Metropolitana"), None)
+        assert metropolitana_state is not None, "state=Metropolitana should be counted for CL"
+
+
+@pytest.mark.asyncio
 async def test_rankings_country_filter_iso_codes_issue_152(app, async_session):
     """
     Test rankings country filter with ISO codes (issue #152).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem
GET `/api/public/stats/rankings` returns HTTP 500 for BR and CL requests.

**Traceback:** `backend/app/routers/public.py` line 531
```python
return COUNTRY_NAMES.get(country_code.upper(), country_code)
```
**Error:** `NameError: name 'COUNTRY_NAMES' is not defined`

## Root Cause
`COUNTRY_NAMES` is defined in `app.geography` but was not imported in `public.py` on master. The develop branch already has the correct import. This was missed during the Chile cherry-picks (#156, #160).

## Solution
- Import `COUNTRY_NAMES` from `app.geography` in `backend/app/routers/public.py` (same as develop)
- Add HTTP 200 regression tests for BR and CL fixtures in `backend/tests/test_rankings.py`

## Testing
Added two new regression tests:
- `test_rankings_http_200_with_br_fixture` - verifies BR events return 200 and normalize to "Brasil"
- `test_rankings_http_200_with_cl_fixture` - verifies CL events return 200 and normalize to "Chile", including state=Metropolitana (issue #157)

## Changes
- `backend/app/routers/public.py`: Added missing import
- `backend/tests/test_rankings.py`: Added 2 regression tests

**Fixes #161**
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-718ef501-c540-49d5-bbd7-1d71d4aa2453?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-718ef501-c540-49d5-bbd7-1d71d4aa2453&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

