### PR TITLE
Make REQUESTS_PER_MINUTE configurable via environment variable (clean)

### DIFF
--- a/backend/app/services/cities.py
+++ b/backend/app/services/cities.py
@@ -117,9 +117,12 @@ BRAZILIAN_NEWS_SOURCES = [
 # =============================================================================
 # Google News RSS limit is ~10-20 requests/minute per IP.
 # We use a conservative 12/min to stay safe.
+# Configurable via REQUESTS_PER_MINUTE env var (default: 12).
 
-REQUESTS_PER_MINUTE = 12
-REQUEST_INTERVAL_SECONDS = 60.0 / REQUESTS_PER_MINUTE  # 5 seconds between requests
+import os
+
+REQUESTS_PER_MINUTE = int(os.getenv("REQUESTS_PER_MINUTE", "12"))
+REQUEST_INTERVAL_SECONDS = 60.0 / REQUESTS_PER_MINUTE  # 5 seconds between requests at default
 
 
 # =============================================================================

--- a/backend/tests/test_rate_limit_config.py
+++ b/backend/tests/test_rate_limit_config.py
@@ -1,0 +1,69 @@
+"""Tests for configurable REQUESTS_PER_MINUTE rate limiting."""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+
+def test_requests_per_minute_defaults_to_12():
+    """When REQUESTS_PER_MINUTE env is unset, defaults to 12 req/min."""
+    with patch.dict(os.environ, {}, clear=False):
+        # Remove the env var if it exists
+        os.environ.pop("REQUESTS_PER_MINUTE", None)
+        
+        # Force reimport to pick up env var
+        import importlib
+        from app.services import cities
+        importlib.reload(cities)
+        
+        assert cities.REQUESTS_PER_MINUTE == 12
+        assert cities.REQUEST_INTERVAL_SECONDS == pytest.approx(5.0)
+
+
+def test_requests_per_minute_reads_from_env():
+    """When REQUESTS_PER_MINUTE=60, rate is 60 and interval is 1.0s."""
+    with patch.dict(os.environ, {"REQUESTS_PER_MINUTE": "60"}):
+        # Force reimport to pick up env var
+        import importlib
+        from app.services import cities
+        importlib.reload(cities)
+        
+        assert cities.REQUESTS_PER_MINUTE == 60
+        assert cities.REQUEST_INTERVAL_SECONDS == pytest.approx(1.0)
+
+
+def test_rate_limiter_uses_configured_rate():
+    """AsyncRateLimiter uses the configured REQUESTS_PER_MINUTE."""
+    with patch.dict(os.environ, {"REQUESTS_PER_MINUTE": "60"}):
+        # Force reimport to pick up env var
+        import importlib
+        from app.services import cities
+        from app.services import ingestion
+        importlib.reload(cities)
+        importlib.reload(ingestion)
+        
+        # Reset the global rate limiter so it picks up new config
+        ingestion._rate_limiter = None
+        
+        limiter = ingestion.get_rate_limiter()
+        assert limiter.interval == pytest.approx(1.0)
+
+
+def test_rate_limiter_default_interval():
+    """AsyncRateLimiter defaults to 5s interval when env unset."""
+    with patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("REQUESTS_PER_MINUTE", None)
+        
+        # Force reimport to pick up env var
+        import importlib
+        from app.services import cities
+        from app.services import ingestion
+        importlib.reload(cities)
+        importlib.reload(ingestion)
+        
+        # Reset the global rate limiter so it picks up new config
+        ingestion._rate_limiter = None
+        
+        limiter = ingestion.get_rate_limiter()
+        assert limiter.interval == pytest.approx(5.0)

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -68,6 +68,7 @@ services:
       - ADMIN_USERNAME=${STAGING_ADMIN_USERNAME:-admin}
       - TELEGRAM_BOT_TOKEN=${STAGING_TELEGRAM_BOT_TOKEN:-}
       - TELEGRAM_CHAT_ID=${STAGING_TELEGRAM_CHAT_ID:-}
+      - REQUESTS_PER_MINUTE=${STAGING_REQUESTS_PER_MINUTE:-60}
 
   # ---------------------------------------------------------------------------
   # node_exporter - production-only host metrics (:9100); do not start on staging
@@ -107,6 +108,7 @@ services:
       - ADMIN_USERNAME=${STAGING_ADMIN_USERNAME:-admin}
       - TELEGRAM_BOT_TOKEN=${STAGING_TELEGRAM_BOT_TOKEN:-}
       - TELEGRAM_CHAT_ID=${STAGING_TELEGRAM_CHAT_ID:-}
+      - REQUESTS_PER_MINUTE=${STAGING_REQUESTS_PER_MINUTE:-60}
     # Prod worker publishes :9091 for Prometheus; staging shares the host — no publish.
     ports: !override []
     # Allow worker 120s to finish current job before forced shutdown

--- a/env.staging.example
+++ b/env.staging.example
@@ -29,6 +29,10 @@ STAGING_ADMIN_PASSWORD=
 # Usually disabled on staging to avoid duplicate processing
 STAGING_ENABLE_CRON=false
 
+# Staging rate limiting - higher rate for faster testing
+# Production default is 12 req/min (conservative for Google News RSS)
+STAGING_REQUESTS_PER_MINUTE=60
+
 # -----------------------------------------------------------------------------
 # Staging Telegram Notifications (Optional)
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 📝 Descrição

Implementação limpa do issue #163 para tornar `REQUESTS_PER_MINUTE` configurável via variável de ambiente.

**Mudanças:**
- `REQUESTS_PER_MINUTE` agora é lido da variável de ambiente com padrão de 12 req/min
- `REQUEST_INTERVAL_SECONDS` é calculado automaticamente como `60.0 / REQUESTS_PER_MINUTE`
- Ambiente de staging configurado para usar 60 req/min (via `docker-compose.staging.yml` e `env.staging.example`)
- Produção mantém o comportamento padrão de 12 req/min

## 🔗 Issue Relacionada

Fixes #163

## 🏷️ Tipo de Mudança

- [x] ✨ Nova feature (mudança que adiciona funcionalidade)
- [x] ✅ Testes (adição ou correção de testes)

## 🧪 Como Foi Testado?

- [x] Testes unitários
- [x] Testado em desenvolvimento local

**Testes implementados:**
1. `test_requests_per_minute_defaults_to_12`: Verifica que sem a variável de ambiente, o padrão é 12 req/min (intervalo de 5s)
2. `test_requests_per_minute_reads_from_env`: Verifica que `REQUESTS_PER_MINUTE=60` resulta em intervalo de 1s
3. `test_rate_limiter_uses_configured_rate`: Verifica que o `AsyncRateLimiter` usa a taxa configurada (60 → 1s)
4. `test_rate_limiter_default_interval`: Verifica que o limiter padrão usa intervalo de 5s

**Resultados:**
```
tests/test_rate_limit_config.py::test_requests_per_minute_defaults_to_12 PASSED
tests/test_rate_limit_config.py::test_requests_per_minute_reads_from_env PASSED
tests/test_rate_limit_config.py::test_rate_limiter_uses_configured_rate PASSED
tests/test_rate_limit_config.py::test_rate_limiter_default_interval PASSED
```

## ✅ Checklist

- [x] Meu código segue o guia de estilo do projeto
- [x] Realizei uma auto-revisão do meu código
- [x] Comentei meu código em áreas complexas
- [x] Atualizei a documentação correspondente
- [x] Minhas mudanças não geram novos warnings
- [x] Adicionei testes que provam que meu fix/feature funciona
- [x] Testes unitários novos e existentes passam localmente
- [x] Quaisquer mudanças dependentes foram mergeadas

## 💬 Notas Adicionais

**Critérios de aceitação cumpridos:**
- ✅ Variável de ambiente não definida → 12 req/min (comportamento de produção)
- ✅ `REQUESTS_PER_MINUTE=60` → intervalo de 1s
- ✅ Staging configurado com 60 req/min via `docker-compose.staging.yml` e `env.staging.example`
- ✅ Testes implementados no nível de configuração/limiter (sem chamadas ao Google News)
- ✅ Padrão de produção não foi alterado (continua 12)
- ✅ Nenhum valor hardcoded de 60 no código

**Diff limpo:**
```
 backend/app/services/cities.py        | 7 +++++--
 backend/tests/test_rate_limit_config.py | 69 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 docker-compose.staging.yml            | 2 ++
 env.staging.example                   | 4 ++++
 4 files changed, 80 insertions(+), 2 deletions(-)
```

**Este PR substitui #165**, que foi criado a partir de um develop desatualizado e incluía mudanças não relacionadas (pipeline Chile, extraction.py, rankings tests, etc.).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e8717f77-9bae-45b4-a46b-105b011edd7b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e8717f77-9bae-45b4-a46b-105b011edd7b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

