### PR TITLE
feat: Country registry + all South American countries (unsharded) (#164)

### DIFF
--- a/backend/app/country_registry.py
+++ b/backend/app/country_registry.py
@@ -55,9 +55,6 @@ class CountryConfig:
     # Geocoding configuration
     geocode_region: str  # Google Geocoding API region bias (usually same as code)
     geocode_language: str  # Geocoding result language (ISO 639-1)
-    
-    # Accept-Language header for downloads (if different from default)
-    download_accept_language: str | None = None
 
 
 # ============================================================================

--- a/backend/app/country_registry.py
+++ b/backend/app/country_registry.py
@@ -1,0 +1,721 @@
+"""Country registry for multi-country pipeline support.
+
+This module provides a centralized registry of all countries supported by the pipeline.
+Each country configuration includes:
+- ISO 3166-1 alpha-2 code
+- Google News parameters (hl, gl, ceid)
+- Primary language
+- Major cities for ingestion (capitals + large metros)
+- News outlet domains for query sharding
+- Homicide query terms
+- Geocoding parameters (region code, language)
+"""
+
+from dataclasses import dataclass
+from typing import Literal
+
+
+# ============================================================================
+# Type definitions
+# ============================================================================
+
+CountryCode = Literal["AR", "BO", "BR", "CL", "CO", "EC", "GY", "PY", "PE", "SR", "UY", "VE"]
+
+
+# ============================================================================
+# Country Configuration Data Class
+# ============================================================================
+
+@dataclass
+class CountryConfig:
+    """Configuration for a single country's pipeline behavior."""
+    
+    # Identity
+    code: CountryCode
+    name: str
+    
+    # Google News RSS parameters
+    google_news_hl: str  # Language header (e.g., "pt-BR", "es-AR")
+    google_news_gl: str  # Geographic location (e.g., "BR", "AR")
+    google_news_ceid: str  # Edition ID (e.g., "BR:pt-419", "AR:es-419")
+    
+    # Primary language for content (ISO 639-1)
+    language: str  # "pt", "es", "en", "nl"
+    
+    # Cities for ingestion (capitals + major metros)
+    # Format varies by country needs; include region/state when helpful for disambiguation
+    cities: list[str]
+    
+    # News outlets for query sharding (when a city hits 100 results)
+    outlets: list[str]
+    
+    # Homicide query terms in local language
+    query_terms: list[str]
+    
+    # Geocoding configuration
+    geocode_region: str  # Google Geocoding API region bias (usually same as code)
+    geocode_language: str  # Geocoding result language (ISO 639-1)
+    
+    # Accept-Language header for downloads (if different from default)
+    download_accept_language: str | None = None
+
+
+# ============================================================================
+# Argentina (AR)
+# ============================================================================
+
+ARGENTINA_CONFIG = CountryConfig(
+    code="AR",
+    name="Argentina",
+    google_news_hl="es-AR",
+    google_news_gl="AR",
+    google_news_ceid="AR:es-419",
+    language="es",
+    cities=[
+        "Buenos Aires",
+        "Córdoba",
+        "Rosario",
+        "Mendoza",
+        "San Miguel de Tucumán",
+        "La Plata",
+        "Mar del Plata",
+        "Salta",
+        "Santa Fe",
+        "San Juan",
+        "Resistencia",
+        "Corrientes",
+        "Posadas",
+        "Neuquén",
+        "Bahía Blanca",
+    ],
+    outlets=[
+        "clarin.com",
+        "lanacion.com.ar",
+        "infobae.com",
+        "pagina12.com.ar",
+        "ambito.com",
+        "perfil.com",
+        "cronica.com.ar",
+        "ole.com.ar",
+        "lacapital.com.ar",
+        "losandes.com.ar",
+    ],
+    query_terms=[
+        "homicidio",
+        "asesinato",
+        "femicidio",
+        "feminicidio",
+        "tiroteo",
+        "balacera",
+        "muerte violenta",
+        "crimen",
+    ],
+    geocode_region="ar",
+    geocode_language="es",
+)
+
+
+# ============================================================================
+# Bolivia (BO)
+# ============================================================================
+
+BOLIVIA_CONFIG = CountryConfig(
+    code="BO",
+    name="Bolivia",
+    google_news_hl="es-BO",
+    google_news_gl="BO",
+    google_news_ceid="BO:es-419",
+    language="es",
+    cities=[
+        "La Paz",
+        "Santa Cruz de la Sierra",
+        "Cochabamba",
+        "Sucre",
+        "Oruro",
+        "Tarija",
+        "Potosí",
+        "Trinidad",
+    ],
+    outlets=[
+        "lostiempos.com",
+        "eldeber.com.bo",
+        "paginasiete.bo",
+        "erbol.com.bo",
+        "opinion.com.bo",
+        "eldiario.net",
+        "cambio.bo",
+    ],
+    query_terms=[
+        "homicidio",
+        "asesinato",
+        "feminicidio",
+        "muerte violenta",
+        "tiroteo",
+        "crimen",
+    ],
+    geocode_region="bo",
+    geocode_language="es",
+)
+
+
+# ============================================================================
+# Brazil (BR)
+# ============================================================================
+
+BRAZIL_CONFIG = CountryConfig(
+    code="BR",
+    name="Brasil",
+    google_news_hl="pt-BR",
+    google_news_gl="BR",
+    google_news_ceid="BR:pt-419",
+    language="pt",
+    cities=[
+        # Major Metros (2M+)
+        "São Paulo SP",
+        "Rio de Janeiro RJ",
+        "Brasília DF",
+        "Salvador BA",
+        "Fortaleza CE",
+        "Belo Horizonte MG",
+        "Manaus AM",
+        # Large Cities (1M - 2M)
+        "Curitiba PR",
+        "Recife PE",
+        "Goiânia GO",
+        "Belém PA",
+        "Porto Alegre RS",
+        "Guarulhos SP",
+        "Campinas SP",
+        "São Luís MA",
+        "São Gonçalo RJ",
+        # Medium-Large Cities (500k - 1M)
+        "Maceió AL",
+        "Duque de Caxias RJ",
+        "Campo Grande MS",
+        "Natal RN",
+        "Teresina PI",
+        "São Bernardo do Campo SP",
+        "Nova Iguaçu RJ",
+        "João Pessoa PB",
+        "Santo André SP",
+        "São José dos Campos SP",
+        "Osasco SP",
+        "Ribeirão Preto SP",
+        "Jaboatão dos Guararapes PE",
+        "Uberlândia MG",
+        "Contagem MG",
+        "Sorocaba SP",
+        "Aracaju SE",
+        "Feira de Santana BA",
+        "Cuiabá MT",
+        "Joinville SC",
+        "Aparecida de Goiânia GO",
+        "Londrina PR",
+        "Juiz de Fora MG",
+        "Ananindeua PA",
+        "Porto Velho RO",
+        "Serra ES",
+        "Niterói RJ",
+        "Belford Roxo RJ",
+        "Campos dos Goytacazes RJ",
+        "Caxias do Sul RS",
+        # State Capitals (smaller ones)
+        "Florianópolis SC",
+        "Vitória ES",
+        "Macapá AP",
+        "Boa Vista RR",
+        "Rio Branco AC",
+        "Palmas TO",
+    ],
+    outlets=[
+        # Major national outlets
+        "g1.globo.com",
+        "uol.com.br",
+        "folha.uol.com.br",
+        "estadao.com.br",
+        "oglobo.globo.com",
+        "r7.com",
+        "terra.com.br",
+        "metropoles.com",
+        "cnn.com.br",
+        "band.uol.com.br",
+        "ig.com.br",
+        "noticias.uol.com.br",
+        "record.tv.br",
+        "extra.globo.com",
+        "otempo.com.br",
+        "em.com.br",
+        "correiobraziliense.com.br",
+        "gazetadopovo.com.br",
+        "diariodepernambuco.com.br",
+    ],
+    query_terms=[
+        # Brazilian Portuguese terms (broad, no explicit terms needed - implicit in context)
+    ],
+    geocode_region="br",
+    geocode_language="pt",
+)
+
+
+# ============================================================================
+# Chile (CL)
+# ============================================================================
+
+CHILE_CONFIG = CountryConfig(
+    code="CL",
+    name="Chile",
+    google_news_hl="es-CL",
+    google_news_gl="CL",
+    google_news_ceid="CL:es-419",
+    language="es",
+    cities=[
+        # Major Metros (1M+)
+        "Santiago Metropolitana",
+        "Puente Alto Metropolitana",
+        "Maipú Metropolitana",
+        "La Florida Metropolitana",
+        # Large Cities (200k - 1M)
+        "Antofagasta Antofagasta",
+        "Viña del Mar Valparaíso",
+        "Valparaíso Valparaíso",
+        "Talcahuano Biobío",
+        "San Bernardo Metropolitana",
+        "Temuco Araucanía",
+        "Iquique Tarapacá",
+        "Concepción Biobío",
+        "Rancagua O'Higgins",
+        "Talca Maule",
+        "Coquimbo Coquimbo",
+        "Puerto Montt Los Lagos",
+        "Chillán Ñuble",
+        "Los Ángeles Biobío",
+        "Calama Antofagasta",
+        "Copiapó Atacama",
+        "Osorno Los Lagos",
+        "Valdivia Los Ríos",
+        "Quilpué Valparaíso",
+        # Regional Capitals (smaller)
+        "Arica Arica y Parinacota",
+        "La Serena Coquimbo",
+        "Punta Arenas Magallanes",
+        "Coyhaique Aysén",
+    ],
+    outlets=[
+        # Major national outlets
+        "emol.com",
+        "latercera.com",
+        "elmostrador.cl",
+        "biobiochile.cl",
+        "24horas.cl",
+        "meganoticias.cl",
+        "t13.cl",
+        "chvnoticias.cl",
+        "cnnchile.com",
+        "df.cl",
+        "cooperativa.cl",
+        "adnradio.cl",
+        # Regional outlets
+        "australvaldivia.cl",
+        "elsur.cl",
+        "australtemuco.cl",
+        "mercuriovalpo.cl",
+        "soychile.cl",
+        "elllanquihue.cl",
+    ],
+    query_terms=[
+        "homicidio",
+        "asesinato",
+        "femicidio",
+        "feminicidio",
+        "balacera",
+        "tiroteo",
+        "robo con homicidio",
+        "muerte violenta",
+        "operativo policial",
+        "carabineros disparo",
+    ],
+    geocode_region="cl",
+    geocode_language="es",
+)
+
+
+# ============================================================================
+# Colombia (CO)
+# ============================================================================
+
+COLOMBIA_CONFIG = CountryConfig(
+    code="CO",
+    name="Colombia",
+    google_news_hl="es-CO",
+    google_news_gl="CO",
+    google_news_ceid="CO:es-419",
+    language="es",
+    cities=[
+        "Bogotá",
+        "Medellín",
+        "Cali",
+        "Barranquilla",
+        "Cartagena",
+        "Cúcuta",
+        "Bucaramanga",
+        "Pereira",
+        "Santa Marta",
+        "Ibagué",
+        "Pasto",
+        "Manizales",
+        "Villavicencio",
+        "Armenia",
+    ],
+    outlets=[
+        "eltiempo.com",
+        "elespectador.com",
+        "semana.com",
+        "caracol.com.co",
+        "rcnradio.com",
+        "pulzo.com",
+        "bluradio.com",
+        "elcolombiano.com",
+        "laopinion.com.co",
+        "vanguardia.com",
+    ],
+    query_terms=[
+        "homicidio",
+        "asesinato",
+        "feminicidio",
+        "sicariato",
+        "masacre",
+        "balacera",
+        "tiroteo",
+        "muerte violenta",
+        "crimen",
+    ],
+    geocode_region="co",
+    geocode_language="es",
+)
+
+
+# ============================================================================
+# Ecuador (EC)
+# ============================================================================
+
+ECUADOR_CONFIG = CountryConfig(
+    code="EC",
+    name="Ecuador",
+    google_news_hl="es-EC",
+    google_news_gl="EC",
+    google_news_ceid="EC:es-419",
+    language="es",
+    cities=[
+        "Guayaquil",
+        "Quito",
+        "Cuenca",
+        "Santo Domingo",
+        "Machala",
+        "Durán",
+        "Manta",
+        "Portoviejo",
+        "Ambato",
+        "Riobamba",
+    ],
+    outlets=[
+        "eluniverso.com",
+        "elcomercio.com",
+        "expreso.ec",
+        "teleamazonas.com",
+        "ecuavisa.com",
+        "metroecuador.com.ec",
+        "primicias.ec",
+    ],
+    query_terms=[
+        "homicidio",
+        "asesinato",
+        "feminicidio",
+        "sicariato",
+        "balacera",
+        "tiroteo",
+        "muerte violenta",
+        "crimen",
+    ],
+    geocode_region="ec",
+    geocode_language="es",
+)
+
+
+# ============================================================================
+# Guyana (GY)
+# ============================================================================
+
+GUYANA_CONFIG = CountryConfig(
+    code="GY",
+    name="Guyana",
+    google_news_hl="en-GY",
+    google_news_gl="GY",
+    google_news_ceid="GY:en",
+    language="en",
+    cities=[
+        "Georgetown",
+        "Linden",
+        "New Amsterdam",
+    ],
+    outlets=[
+        "stabroeknews.com",
+        "kaieteurnewsonline.com",
+        "demerarawaves.com",
+        "guyanatimesgy.com",
+    ],
+    query_terms=[
+        "murder",
+        "homicide",
+        "killing",
+        "shooting",
+        "violent death",
+        "gunfire",
+    ],
+    geocode_region="gy",
+    geocode_language="en",
+)
+
+
+# ============================================================================
+# Paraguay (PY)
+# ============================================================================
+
+PARAGUAY_CONFIG = CountryConfig(
+    code="PY",
+    name="Paraguay",
+    google_news_hl="es-PY",
+    google_news_gl="PY",
+    google_news_ceid="PY:es-419",
+    language="es",
+    cities=[
+        "Asunción",
+        "Ciudad del Este",
+        "San Lorenzo",
+        "Luque",
+        "Capiatá",
+        "Encarnación",
+    ],
+    outlets=[
+        "abc.com.py",
+        "ultimahora.com",
+        "lanacion.com.py",
+        "hoy.com.py",
+        "extra.com.py",
+    ],
+    query_terms=[
+        "homicidio",
+        "asesinato",
+        "feminicidio",
+        "tiroteo",
+        "balacera",
+        "muerte violenta",
+        "sicariato",
+    ],
+    geocode_region="py",
+    geocode_language="es",
+)
+
+
+# ============================================================================
+# Peru (PE)
+# ============================================================================
+
+PERU_CONFIG = CountryConfig(
+    code="PE",
+    name="Perú",
+    google_news_hl="es-PE",
+    google_news_gl="PE",
+    google_news_ceid="PE:es-419",
+    language="es",
+    cities=[
+        "Lima",
+        "Arequipa",
+        "Trujillo",
+        "Chiclayo",
+        "Piura",
+        "Cusco",
+        "Iquitos",
+        "Huancayo",
+        "Tacna",
+        "Callao",
+    ],
+    outlets=[
+        "elcomercio.pe",
+        "larepublica.pe",
+        "rpp.pe",
+        "gestion.pe",
+        "peru21.pe",
+        "andina.pe",
+        "exitosanoticias.pe",
+        "elperuano.pe",
+    ],
+    query_terms=[
+        "homicidio",
+        "asesinato",
+        "feminicidio",
+        "sicariato",
+        "balacera",
+        "tiroteo",
+        "muerte violenta",
+        "crimen",
+    ],
+    geocode_region="pe",
+    geocode_language="es",
+)
+
+
+# ============================================================================
+# Suriname (SR)
+# ============================================================================
+
+SURINAME_CONFIG = CountryConfig(
+    code="SR",
+    name="Suriname",
+    google_news_hl="nl-SR",
+    google_news_gl="SR",
+    google_news_ceid="SR:nl",
+    language="nl",
+    cities=[
+        "Paramaribo",
+        "Lelydorp",
+        "Nieuw Nickerie",
+    ],
+    outlets=[
+        "starnieuws.com",
+        "dbsuriname.com",
+        "waterkant.net",
+    ],
+    query_terms=[
+        "moord",
+        "doodslag",
+        "schietpartij",
+        "gewelddadige dood",
+    ],
+    geocode_region="sr",
+    geocode_language="nl",
+)
+
+
+# ============================================================================
+# Uruguay (UY)
+# ============================================================================
+
+URUGUAY_CONFIG = CountryConfig(
+    code="UY",
+    name="Uruguay",
+    google_news_hl="es-UY",
+    google_news_gl="UY",
+    google_news_ceid="UY:es-419",
+    language="es",
+    cities=[
+        "Montevideo",
+        "Salto",
+        "Ciudad de la Costa",
+        "Paysandú",
+        "Maldonado",
+    ],
+    outlets=[
+        "elpais.com.uy",
+        "elobservador.com.uy",
+        "montevideo.com.uy",
+        "republica.com.uy",
+        "subrayado.com.uy",
+    ],
+    query_terms=[
+        "homicidio",
+        "asesinato",
+        "femicidio",
+        "tiroteo",
+        "balacera",
+        "muerte violenta",
+    ],
+    geocode_region="uy",
+    geocode_language="es",
+)
+
+
+# ============================================================================
+# Venezuela (VE)
+# ============================================================================
+
+VENEZUELA_CONFIG = CountryConfig(
+    code="VE",
+    name="Venezuela",
+    google_news_hl="es-VE",
+    google_news_gl="VE",
+    google_news_ceid="VE:es-419",
+    language="es",
+    cities=[
+        "Caracas",
+        "Maracaibo",
+        "Valencia",
+        "Barquisimeto",
+        "Maracay",
+        "Ciudad Guayana",
+        "Barcelona",
+        "Maturín",
+        "Cumaná",
+    ],
+    outlets=[
+        "eluniversal.com",
+        "elimpulso.com",
+        "talcualdigital.com",
+        "runrun.es",
+        "noticiaaldia.com",
+    ],
+    query_terms=[
+        "homicidio",
+        "asesinato",
+        "feminicidio",
+        "sicariato",
+        "ajusticiamiento",
+        "balacera",
+        "tiroteo",
+        "muerte violenta",
+    ],
+    geocode_region="ve",
+    geocode_language="es",
+)
+
+
+# ============================================================================
+# Country Registry
+# ============================================================================
+
+# All country configurations
+COUNTRY_CONFIGS: dict[CountryCode, CountryConfig] = {
+    "AR": ARGENTINA_CONFIG,
+    "BO": BOLIVIA_CONFIG,
+    "BR": BRAZIL_CONFIG,
+    "CL": CHILE_CONFIG,
+    "CO": COLOMBIA_CONFIG,
+    "EC": ECUADOR_CONFIG,
+    "GY": GUYANA_CONFIG,
+    "PY": PARAGUAY_CONFIG,
+    "PE": PERU_CONFIG,
+    "SR": SURINAME_CONFIG,
+    "UY": URUGUAY_CONFIG,
+    "VE": VENEZUELA_CONFIG,
+}
+
+# List of all supported country codes
+ALL_COUNTRIES: list[CountryCode] = list(COUNTRY_CONFIGS.keys())
+
+
+# ============================================================================
+# Helper Functions
+# ============================================================================
+
+def get_country_config(country_code: CountryCode) -> CountryConfig:
+    """Get the configuration for a specific country."""
+    return COUNTRY_CONFIGS[country_code]
+
+
+def get_country_name(country_code: CountryCode) -> str:
+    """Get the human-readable name for a country code."""
+    return COUNTRY_CONFIGS[country_code].name
+
+
+def is_valid_country(country_code: str) -> bool:
+    """Check if a country code is supported."""
+    return country_code in COUNTRY_CONFIGS

--- a/backend/app/geography.py
+++ b/backend/app/geography.py
@@ -1,9 +1,12 @@
 """Country, region, and city definitions for multi-country support.
 
-This module provides geography data for Brazil and Chile, including:
+This module provides geography data for all South American countries, including:
 - ISO country codes
-- Administrative regions (states/UFs for BR, regiones for CL)
+- Administrative regions (states/UFs for BR, regiones for CL, etc.)
 - Major cities for ingestion
+
+For full country configurations (Google News params, outlets, query terms, etc.),
+see country_registry.py.
 """
 
 from typing import Literal
@@ -12,13 +15,23 @@ from typing import Literal
 # Country codes (ISO 3166-1 alpha-2)
 # ============================================================================
 
-Country = Literal["BR", "CL"]
+Country = Literal["AR", "BO", "BR", "CL", "CO", "EC", "GY", "PY", "PE", "SR", "UY", "VE"]
 
-COUNTRIES: list[Country] = ["BR", "CL"]
+COUNTRIES: list[Country] = ["AR", "BO", "BR", "CL", "CO", "EC", "GY", "PY", "PE", "SR", "UY", "VE"]
 
 COUNTRY_NAMES = {
+    "AR": "Argentina",
+    "BO": "Bolivia",
     "BR": "Brasil",
     "CL": "Chile",
+    "CO": "Colombia",
+    "EC": "Ecuador",
+    "GY": "Guyana",
+    "PY": "Paraguay",
+    "PE": "Perú",
+    "SR": "Suriname",
+    "UY": "Uruguay",
+    "VE": "Venezuela",
 }
 
 # ============================================================================
@@ -114,7 +127,11 @@ CHILEAN_REGION_NAMES = {v: k for k, v in CHILEAN_REGION_CODES.items()}
 # ============================================================================
 
 def get_regions_for_country(country: Country) -> list[str]:
-    """Return list of region codes/names for a country."""
+    """Return list of region codes/names for a country.
+    
+    Currently only BR and CL have structured region data.
+    Other countries return empty list (no regional filtering yet).
+    """
     if country == "BR":
         return BRAZILIAN_STATES
     elif country == "CL":
@@ -123,7 +140,11 @@ def get_regions_for_country(country: Country) -> list[str]:
 
 
 def get_region_name(country: Country, code: str) -> str:
-    """Get human-readable region name for a code."""
+    """Get human-readable region name for a code.
+    
+    Currently only BR and CL have structured region data.
+    Other countries return the code as-is.
+    """
     if country == "BR":
         return BRAZILIAN_STATE_NAMES.get(code, code)
     elif country == "CL":
@@ -136,6 +157,7 @@ def normalize_region_identifier(country: Country, value: str) -> str:
     
     For BR: keeps UF codes (SP, RJ, etc.)
     For CL: converts Roman numerals to region names or keeps region names.
+    For other countries: returns value as-is (no normalization yet).
     """
     if country == "BR":
         return value.upper()

--- a/backend/app/routers/public.py
+++ b/backend/app/routers/public.py
@@ -484,7 +484,7 @@ async def get_security_force_stats(session: AsyncSession = Depends(get_session))
 async def get_rankings(
     session: AsyncSession = Depends(get_session),
     days: int = Query(365, ge=1, le=3650, description="Only events in the last N days"),
-    country: str | None = Query(None, description="Filter by country: BR, CL, or omit for both"),
+    country: str | None = Query(None, description="Filter by country ISO (AR, BO, BR, CL, CO, EC, GY, PY, PE, SR, UY, VE) or omit for all SA"),
     city_limit: int | None = Query(50, ge=1, le=10000, description="Limit number of cities returned (default 50 for fast load)"),
 ):
     """
@@ -528,15 +528,20 @@ async def get_rankings(
             country=country  # Pass country for state filtering
         )
         if country:
-            # Match canonical codes (BR, CL) and legacy "Brasil" for BR
-            if country.upper() == "BR":
+            country_upper = country.upper()
+            # Handle legacy "Brasil" → BR
+            if country_upper == "BRASIL":
+                country_upper = "BR"
+            
+            # Filter by country for any registry ISO
+            if country_upper == "BR":
                 # BR matches both canonical "BR" and legacy "Brasil"
                 query = query.where(
                     (UniqueEvent.country == "BR") | (UniqueEvent.country == "Brasil")
                 )
-            elif country.upper() == "CL":
-                # CL matches canonical "CL" stored value
-                query = query.where(UniqueEvent.country == "CL")
+            else:
+                # All other countries: match ISO code exactly
+                query = query.where(UniqueEvent.country == country_upper)
         return query
     
     current_query = build_query(current_start, now)

--- a/backend/app/services/classification.py
+++ b/backend/app/services/classification.py
@@ -21,21 +21,25 @@ class ViolentDeathClassification(BaseModel):
     is_violent_death: bool = Field(
         ...,
         description="""
-        TRUE only if the headline is about one or more NEW violent deaths in Brazil or Chile
-        (homicides, murders, killings, police operations with deaths).
+        TRUE only if the headline is about one or more NEW violent deaths in South America
+        (AR, BO, BR, CL, CO, EC, GY, PY, PE, SR, UY, VE) — homicides, murders, killings,
+        police operations with deaths.
 
         Examples of TRUE:
-        - "Homem é morto a tiros em operação policial" (Brazil)
-        - "Corpo é encontrado com marcas de violência" (Brazil)
-        - "Tiroteio deixa dois mortos na Zona Norte" (Brazil)
-        - "Mulher é assassinada pelo ex-marido" (Brazil)
-        - "Hombre asesinado en operativo policial en Santiago" (Chile)
+        - "Homem é morto a tiros em operação policial" (Brazil, PT)
+        - "Corpo é encontrado com marcas de violência" (Brazil, PT)
+        - "Tiroteio deixa dois mortos na Zona Norte" (Brazil, PT)
+        - "Mulher é assassinada pelo ex-marido" (Brazil, PT)
+        - "Hombre asesinado en operativo policial en Santiago" (Chile, ES)
+        - "Homicidio en Buenos Aires deja dos muertos" (Argentina, ES)
+        - "Murder in Georgetown leaves one dead" (Guyana, EN)
+        - "Moord in Paramaribo: man doodgeschoten" (Suriname, NL)
 
         Examples of FALSE:
         - "Polícia prende suspeito de roubo"
         - "Homem sobrevive após ser baleado"
         - "Vítima de facadas chora no julgamento do agressor" (victim alive)
-        - "Atirador em massa no Texas recebe pena de morte" (foreign: outside BR/CL)
+        - "Atirador em massa no Texas recebe pena de morte" (foreign: outside SA)
         - "Operação apreende drogas e armas"
         """
     )
@@ -84,32 +88,33 @@ class ViolentDeathClassification(BaseModel):
 # System prompt for classification
 CLASSIFICATION_SYSTEM_PROMPT = """
 Você é um classificador de manchetes de notícias do Google News. Sua tarefa é:
-1. Determinar se a manchete indica NOTÍCIA sobre MORTE(S) VIOLENTA(S) no Brasil ou no Chile.
+1. Determinar se a manchete indica NOTÍCIA sobre MORTE(S) VIOLENTA(S) na América do Sul.
 2. Determinar se descreve UM ÚNICO INCIDENTE específico (is_single_incident).
 
-Este filtro alimenta um arquivo de violência que cobre Brasil e Chile. Manchetes sobre mortes
-violentas em outros países NÃO entram, mesmo que mencionem tiroteio, guerra ou assassinato.
+Este filtro alimenta um arquivo de violência que cobre toda a América do Sul (Argentina, Bolívia,
+Brasil, Chile, Colômbia, Equador, Guiana, Paraguai, Peru, Suriname, Uruguai, Venezuela).
+Manchetes sobre mortes violentas FORA da América do Sul NÃO entram (EUA, México, Europa, etc.).
 
 CLASSIFIQUE COMO MORTE VIOLENTA (is_violent_death = true):
-- Morte violenta no Brasil ou Chile: morto(s), assassinado(s), executado(s), baleado(s) MORTO
-  (PT: morto, assassinado, baleado; ES: asesinado, muerto, baleado)
+- Morte violenta em qualquer país sul-americano: morto(s), assassinado(s), executado(s), baleado(s) MORTO
+  (PT: morto, assassinado, baleado; ES: asesinado, muerto, baleado; EN: murdered, killed, shot dead; NL: doodgeschoten, vermoord)
 - Corpo, restos mortais ou ossada encontrados com indícios de violência
 - Tiroteio/confronto/operação policial que deixa mortos (inclui jargão: "neutralizado",
   "CPF cancelado" no sentido de pessoa morta)
-  (ES: operativos de Carabineros, PDI — forças policiais chilenas)
+  (ES: operativos policiales, balacera; EN: police shooting, gunfire; NL: schietpartij)
 - Feminicídio, latrocínio, homicídio, chacina, execução
-  (ES: femicidio, homicidio, asesinato, balacera)
+  (ES: femicidio, homicidio, asesinato, sicariato; EN: murder, homicide, killing; NL: moord, doodslag)
 - Vítima que MORRE: "não resistiu aos ferimentos", "morre após ser baleado"
-  (ES: "no resistió", "murió tras", "falleció")
+  (ES: "no resistió", "murió tras", "falleció"; EN: "died after", "succumbed"; NL: "overleed")
 - Letalidade implícita: "crivado de balas", "CPF cancelado", "tombou/tombaram",
   "não deixa sobreviventes", "linchado até parar de respirar" — trate como morte violenta
   salvo se a manchete indicar sobrevivência (ferido, hospital, quadro estável)
 
 NÃO CLASSIFIQUE COMO MORTE VIOLENTA (is_violent_death = false):
-- Eventos FORA do Brasil e do Chile (EUA, Europa, Rússia, Ucrânia, México, etc.), mesmo com mortes
+- Eventos FORA da América do Sul (EUA, México, Europa, Rússia, Ucrânia, África, Ásia, etc.), mesmo com mortes
 - Vítima VIVA: sobrevive, ferido(s), hospitalizado, chora, presta depoimento, "vítima de
   X facadas" no julgamento (sobrevivente), tentativa de homicídio sem morte
-  (ES: sobrevivió, herido, hospitalizado)
+  (ES: sobrevivió, herido, hospitalizado; EN: survived, injured, hospitalized; NL: gewond, ziekenhuis)
 - Tiroteio, operação ou confronto SEM menção a morte ou feridos mortos
 - Prisões, mandados, julgamentos, pena de morte como sentença judicial (notícia jurídica)
 - Apreensões de armas/drogas, políticas de segurança
@@ -118,14 +123,17 @@ NÃO CLASSIFIQUE COMO MORTE VIOLENTA (is_violent_death = false):
 - Arsenal apreendido para crimes futuros (crime frustrado, sem morte na notícia)
 
 INCIDENTE ÚNICO (is_single_incident = true):
-- Um homicídio ou tiroteio específico no Brasil ou Chile, em local identificável
-- "Tiroteio deixa dois mortos na Zona Norte" (um evento)
-- "Homem é morto a tiros em operação policial"
-- "Hombre asesinado en Santiago" (ES)
+- Um homicídio ou tiroteio específico em qualquer país sul-americano, em local identificável
+- "Tiroteio deixa dois mortos na Zona Norte" (Brasil, PT)
+- "Homem é morto a tiros em operação policial" (Brasil, PT)
+- "Hombre asesinado en Santiago" (Chile, ES)
+- "Homicidio en Bogotá deja tres muertos" (Colômbia, ES)
+- "Murder in Georgetown: man shot dead" (Guiana, EN)
+- "Moord in Paramaribo: man doodgeschoten" (Suriname, NL)
 
 NÃO É INCIDENTE ÚNICO (is_single_incident = false) — descarte mesmo se mencionar mortes:
 - Estatísticas agregadas: balanço anual, CVLI, "X mortes em 2025", "no estado", painéis
-- Notícias estrangeiras: terremotos, guerras, desastres fora do Brasil e do Chile
+- Notícias estrangeiras: terremotos, guerras, desastres fora da América do Sul
 - Suicídios (mesmo violentos)
 - Crueldade contra animais
 - Resumos com múltiplos incidentes não relacionados
@@ -134,29 +142,30 @@ NÃO É INCIDENTE ÚNICO (is_single_incident = false) — descarte mesmo se menc
 Use content_class_hint quando aplicável: incident, aggregate_statistics, foreign,
 non_incident, suicide, accident_disaster.
 
-Baseie-se APENAS no texto da manchete. Em dúvida sobre local (Brasil/Chile vs exterior), procure
-topônimos estrangeiros (Texas, EUA, Rússia, Ucrânia, México) ou contexto claramente internacional.
-Chile e Brasil são IN; outros países são OUT.
+Baseie-se APENAS no texto da manchete. Em dúvida sobre local, procure topônimos estrangeiros
+(Texas, EUA, Rússia, Ucrânia, México, Europa) ou contexto claramente fora da América do Sul.
+América do Sul é IN; resto do mundo é OUT.
 """
 
 CONTENT_CLASSIFICATION_SYSTEM_PROMPT = """
 Você é um classificador de ARTIGOS JORNALÍSTICOS do Google News. A manchete já passou
 por um filtro inicial, mas o CORPO do artigo pode revelar que a matéria NÃO descreve um
-incidente único de morte violenta no Brasil ou no Chile.
+incidente único de morte violenta na América do Sul.
 
 Sua tarefa:
-1. Determinar se o artigo trata de MORTE(S) VIOLENTA(S) no Brasil ou no Chile.
+1. Determinar se o artigo trata de MORTE(S) VIOLENTA(S) na América do Sul (AR, BO, BR, CL, CO, EC, GY, PY, PE, SR, UY, VE).
 2. Determinar se descreve UM ÚNICO INCIDENTE específico (is_single_incident).
 
 Use a manchete apenas como contexto. Baseie a decisão principalmente no corpo do artigo.
 
 CLASSIFIQUE COMO MORTE VIOLENTA (is_violent_death = true):
-- Morte violenta no Brasil ou Chile descrita no corpo: homicídio, tiroteio, operação policial com morte
-  (ES: homicidio, asesinato, balacera, operativo policial)
-  (Forças policiais chilenas: Carabineros, PDI)
+- Morte violenta em qualquer país sul-americano descrita no corpo: homicídio, tiroteio, operação policial com morte
+  (ES: homicidio, asesinato, balacera, operativo policial, sicariato)
+  (EN: murder, homicide, killing, shooting)
+  (NL: moord, doodslag, schietpartij)
 - Corpo/restos encontrados com indícios de violência
 - Feminicídio, latrocínio, chacina, execução
-  (ES: femicidio, homicidio, asesinato)
+  (ES: femicidio, homicidio, asesinato; EN: murder, killing; NL: moord)
 - CASO ENTERRADO em matéria estatística: se uma matéria de balanço/estatísticas descreve
   em detalhe UM caso concreto cujo ÓBITO É RECENTE (ocorreu há horas/dias, ex.: "na noite
   de ontem"), classifique is_violent_death = true e is_single_incident = true — o caso
@@ -167,12 +176,12 @@ pauta é julgamento/condenação de crime antigo = false (o óbito não é novo)
 detalhes do caso. Matéria estatística que cita uma morte ocorrida ontem = true.
 
 NÃO CLASSIFIQUE COMO MORTE VIOLENTA (is_violent_death = false):
-- Eventos FORA do Brasil e do Chile (desastres, guerras, crimes internacionais em EUA, México,
-  Europa, etc.) — atenção a cidades homônimas: o corpo pode revelar que "Belém" é no Texas, etc.
+- Eventos FORA da América do Sul (desastres, guerras, crimes em EUA, México, Europa, África, Ásia, etc.)
+  — atenção a cidades homônimas: o corpo pode revelar que "Belém" é no Texas, etc.
 - VÍTIMA SOBREVIVEU: se o corpo informa que a vítima foi socorrida, está internada,
   estável ou sobreviveu, NÃO há morte violenta — mesmo em "tentativa de feminicídio"
   ou ataque brutal. Sem óbito, is_violent_death = false.
-  (ES: sobrevivió, hospitalizado, estable)
+  (ES: sobrevivió, hospitalizado, estable; EN: survived, injured, hospitalized; NL: gewond, overleefd)
 - Matéria sobre PROCESSO JUDICIAL: julgamento, júri, condenação, absolvição, prisão ou
   investigação de crime que já ocorreu no passado. A pauta é o processo, não um novo
   óbito — mesmo que o corpo descreva os homicídios julgados, is_violent_death = false.
@@ -182,9 +191,12 @@ NÃO CLASSIFIQUE COMO MORTE VIOLENTA (is_violent_death = false):
 - Apreensões, políticas, análises sem caso específico
 
 INCIDENTE ÚNICO (is_single_incident = true):
-- Um homicídio ou tiroteio específico no Brasil ou Chile, em local identificável
-- Um evento claramente delimitado ("tiroteio deixa dois mortos na Zona Norte")
-  (ES: "balacera deja dos muertos en Santiago")
+- Um homicídio ou tiroteio específico em qualquer país sul-americano, em local identificável
+- Um evento claramente delimitado ("tiroteio deixa dois mortos na Zona Norte", Brasil, PT)
+  (ES: "balacera deja dos muertos en Santiago", Chile)
+  (ES: "homicidio en Bogotá deja tres muertos", Colômbia)
+  (EN: "murder in Georgetown leaves one dead", Guiana)
+  (NL: "moord in Paramaribo: man doodgeschoten", Suriname)
 - ATENÇÃO: mesmo em matéria com tom estatístico, se o corpo DESCREVE um incidente
   específico (vítima, local e circunstâncias identificáveis), classifique
   is_single_incident = true — o caso concreto prevalece sobre o enquadramento da matéria.
@@ -192,7 +204,7 @@ INCIDENTE ÚNICO (is_single_incident = true):
 NÃO É INCIDENTE ÚNICO (is_single_incident = false) — descarte:
 - Estatísticas agregadas SEM caso concreto descrito: balanço anual, CVLI, totais
   estaduais/nacionais, "X mortes em 2025"
-- Notícias estrangeiras fora do Brasil e do Chile mesmo que a manchete pareça local
+- Notícias estrangeiras fora da América do Sul mesmo que a manchete pareça local
 - Suicídios, crueldade contra animais, acidentes sem homicídio doloso
 - Resumos com múltiplos incidentes não relacionados
 

--- a/backend/app/services/classification_heuristics.py
+++ b/backend/app/services/classification_heuristics.py
@@ -36,6 +36,7 @@ _SURVIVAL_PATTERNS = (
 )
 
 _FOREIGN_MARKERS = (
+    # Non-South American countries (events outside SA are foreign/exterior)
     " texas",
     " eua",
     " nos eua",
@@ -44,17 +45,17 @@ _FOREIGN_MARKERS = (
     " rússia",
     " ucrania",
     " ucrânia",
-    " venezuela",
     " mexico",
     " méxico",
     " base militar russa",
-    " argentina",
-    " peru",
-    " colombia",
-    " bolivia",
-    " ecuador",
-    " uruguay",
-    " paraguay",
+    " israel",
+    " palestina",
+    " africa",
+    " áfrica",
+    " china",
+    " india",
+    # Note: South American countries (AR, BO, CL, CO, EC, GY, PY, PE, SR, UY, VE)
+    # are NOT foreign - they are in-scope for this pipeline
 )
 
 _METAPHOR_MARKERS = (

--- a/backend/app/services/content_filters.py
+++ b/backend/app/services/content_filters.py
@@ -78,18 +78,20 @@ _AGGREGATE_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
 )
 
 # Foreign disasters / clearly out-of-scope geography in the body.
+# Note: South American countries (AR, BO, BR, CL, CO, EC, GY, PY, PE, SR, UY, VE)
+# are NOT foreign - they are in-scope for this pipeline.
 _FOREIGN_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
     (
         "foreign_earthquake",
         re.compile(
-            r"\bterremoto.{0,80}\b(venezuela|turquia|turkey|m[eé]xico|haiti|afeganist[aã]o)\b",
+            r"\bterremoto.{0,80}\b(turquia|turkey|m[eé]xico|haiti|afeganist[aã]o|jap[aã]o|nepal)\b",
             re.IGNORECASE,
         ),
     ),
     (
         "foreign_country_disaster",
         re.compile(
-            r"\b(desastre|terremoto|tsunami|guerra).{0,40}\b(venezuela|ucr[aâ]nia|gaza|s[ií]ria|sud[aã]o)\b",
+            r"\b(desastre|terremoto|tsunami|guerra).{0,40}\b(ucr[aâ]nia|gaza|s[ií]ria|sud[aã]o|iraq|iraque)\b",
             re.IGNORECASE,
         ),
     ),
@@ -97,8 +99,7 @@ _FOREIGN_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
         "foreign_mass_shooting",
         re.compile(
             r"\b(atirador|tiroteio|mass\s+shooting|tiroteo).{0,40}"
-            r"\b(eua|estados\s+unidos|texas|california|paris|londres|"
-            r"m[eé]xico|argentina|per[uú]|colombia|bolivia)\b",
+            r"\b(eua|estados\s+unidos|texas|california|florida|paris|londres|nova\s+zel[aâ]ndia)\b",
             re.IGNORECASE,
         ),
     ),

--- a/backend/app/services/download.py
+++ b/backend/app/services/download.py
@@ -80,10 +80,20 @@ async def _fetch_html(url: str) -> tuple[int, str]:
     can classify the reason.
     """
     settings = get_settings()
-    # Country-aware Accept-Language header (issue #129)
+    # Country-aware Accept-Language header (issue #129, #164)
+    # Default to Brazilian Portuguese
     accept_language = "pt-BR,pt;q=0.9,en;q=0.8"
-    if ".cl/" in url or url.endswith(".cl"):
-        accept_language = "es-CL,es;q=0.9,pt-BR;q=0.8,pt;q=0.7,en;q=0.6"
+    
+    # Spanish-speaking SA countries (.ar, .cl, .co, .ec, .py, .pe, .uy, .ve, .bo)
+    spanish_cctlds = [".ar", ".cl", ".co", ".ec", ".py", ".pe", ".uy", ".ve", ".bo"]
+    if any(f"{tld}/" in url or url.endswith(tld) for tld in spanish_cctlds):
+        accept_language = "es,es-419;q=0.9,pt-BR;q=0.8,pt;q=0.7,en;q=0.6"
+    # Guyana (.gy) - English
+    elif ".gy/" in url or url.endswith(".gy"):
+        accept_language = "en,en-US;q=0.9,es;q=0.8,pt;q=0.7"
+    # Suriname (.sr) - Dutch
+    elif ".sr/" in url or url.endswith(".sr"):
+        accept_language = "nl,nl-NL;q=0.9,en;q=0.8,pt;q=0.7"
 
     headers = {
         "User-Agent": settings.download_user_agent,

--- a/backend/app/services/geocoding.py
+++ b/backend/app/services/geocoding.py
@@ -29,6 +29,7 @@ from sqlalchemy import text
 
 from app.config import get_settings
 from app.database import async_session_maker
+from app.country_registry import get_country_config, is_valid_country
 
 GEOCODE_URL = "https://maps.googleapis.com/maps/api/geocode/json"
 
@@ -208,23 +209,24 @@ async def geocode_address(
         logger.warning("[Geocode] GOOGLE_MAPS_API_KEY not set; skipping geocoding")
         return None
 
-    # Normalize country: CL, BR, or legacy "Brasil" → BR
+    # Normalize country: use ISO code, default to BR, handle legacy "Brasil"
     normalized_country = "BR"
     if country:
-        if country.upper() == "CL":
-            normalized_country = "CL"
-        elif country.upper() in ("BR", "BRASIL"):
+        country_upper = country.upper()
+        if country_upper == "BRASIL":
             normalized_country = "BR"
-
-    # Set region and language based on country
-    if normalized_country == "CL":
-        region_code = "cl"
-        language_code = "es"
-        country_component = "CL"
-    else:
-        region_code = "br"
-        language_code = "pt-BR"
-        country_component = "BR"
+        elif is_valid_country(country_upper):
+            normalized_country = country_upper
+        else:
+            # Unknown country, default to BR
+            logger.warning(f"[Geocode] Unknown country '{country}', defaulting to BR")
+            normalized_country = "BR"
+    
+    # Get geocoding params from country config
+    config = get_country_config(normalized_country)
+    region_code = config.geocode_region
+    language_code = config.geocode_language
+    country_component = config.code
 
     params = {
         "address": query,

--- a/backend/app/services/ingestion.py
+++ b/backend/app/services/ingestion.py
@@ -14,29 +14,16 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from app.database import async_session_maker
 from app.models import CityStats, SourceGoogleNews, SourceStatus
 from app.services.cities import (
-    BRAZILIAN_NEWS_SOURCES,
-    CITIES,
     DEFAULT_WHEN,
     REQUEST_INTERVAL_SECONDS,
     REQUESTS_PER_MINUTE,
     SHARDING_THRESHOLD,
 )
-from app.services.cities_chile import (
-    CHILEAN_CITIES,
-    CHILEAN_NEWS_SOURCES,
-    CHILEAN_QUERY_TERMS,
-    CHILE_GOOGLE_NEWS_PARAMS,
-)
 from app.geography import Country
+from app.country_registry import COUNTRY_CONFIGS, ALL_COUNTRIES, get_country_config
 
 # Google News RSS configuration
 GOOGLE_NEWS_BASE_URL = "https://news.google.com/rss/search"
-BRAZIL_PARAMS = {
-    "hl": "pt-BR",
-    "gl": "BR",
-    "ceid": "BR:pt-419",
-}
-CHILE_PARAMS = CHILE_GOOGLE_NEWS_PARAMS
 
 
 async def _resolved_url_exists(session: AsyncSession, resolved_url: str | None) -> bool:
@@ -62,10 +49,12 @@ def build_rss_url(query: str, when: str | None = "7d", country: Country = "BR") 
     if when:
         full_query = f"{query} when:{when}"
     
-    country_params = CHILE_PARAMS if country == "CL" else BRAZIL_PARAMS
+    config = get_country_config(country)
     params = {
         "q": full_query,
-        **country_params,
+        "hl": config.google_news_hl,
+        "gl": config.google_news_gl,
+        "ceid": config.google_news_ceid,
     }
     
     query_string = urllib.parse.urlencode(params, safe=":")
@@ -264,38 +253,34 @@ async def get_queries_for_city(
     """
     Get queries for a city based on its sharding status.
     
-    - Brazil standard mode: Single query "{city} when:{when}"
-    - Brazil sharded mode: One query per source "{city} when:{when} site:{source}"
-    - Chile standard mode: Single query "{city} when:{when} (term1 OR term2 OR ...)"
-    - Chile sharded mode: One query per source "{city} when:{when} site:{source} (term1 OR term2 OR ...)"
+    - Standard mode: Single query "{city} when:{when} (terms...)"
+    - Sharded mode: One query per source "{city} when:{when} site:{source} (terms...)"
     
-    Query cardinality (per hourly cycle):
-    - BR: 52 cities × 19 sources = 988 queries (worst case, all sharded)
-    - CL: 27 cities × 18 sources = 486 queries (worst case, all sharded)
-    - Combined worst case: 1,474 queries (~2 hours at 12 req/min rate limit)
-    - Adding Chilean terms does NOT increase query count (OR'd into existing queries)
+    Query terms:
+    - BR: No explicit terms (Brazilian context implicit)
+    - Other countries: Explicit homicide terms OR'd together from country config
     
     Args:
-        city: City name (with region for Chile, e.g., "Santiago Metropolitana")
+        city: City name (with region/state when helpful)
         session: Database session
         when: Time window
-        country: Country code (BR or CL)
+        country: Country code
     """
     stats = await get_or_create_city_stats(city, session)
     
-    news_sources = CHILEAN_NEWS_SOURCES if country == "CL" else BRAZILIAN_NEWS_SOURCES
+    config = get_country_config(country)
     
-    # Build homicide term filter for Chile
+    # Build homicide term filter (for non-BR countries)
     terms_filter = ""
-    if country == "CL":
+    if config.query_terms:
         # Combine terms with OR to keep query count bounded
         # Format: (term1 OR term2 OR term3)
-        terms_or = " OR ".join(CHILEAN_QUERY_TERMS)
+        terms_or = " OR ".join(config.query_terms)
         terms_filter = f" ({terms_or})"
     
     if stats.needs_sharding:
-        logger.info(f"[{city}] Using sharded mode ({len(news_sources)} sources)")
-        return [f"{city} when:{when} site:{src}{terms_filter}" for src in news_sources]
+        logger.info(f"[{city}] Using sharded mode ({len(config.outlets)} sources)")
+        return [f"{city} when:{when} site:{src}{terms_filter}" for src in config.outlets]
     else:
         logger.info(f"[{city}] Using standard mode")
         return [f"{city} when:{when}{terms_filter}"]
@@ -497,17 +482,18 @@ async def ingest_all_cities(
     Runs cities in PARALLEL with rate limiting.
     
     Args:
-        cities: List of cities to process (uses CITIES or CHILEAN_CITIES if None)
+        cities: List of cities to process (uses country config cities if None)
         when: Time filter (default "1h" for hourly ingestion)
         resolve_urls: Whether to resolve obfuscated URLs
         max_concurrent: Maximum concurrent city ingestions (default 10)
-        country: Country code (BR or CL)
+        country: Country code
     
     Returns:
         Summary dict with statistics
     """
     if cities is None:
-        cities = CHILEAN_CITIES if country == "CL" else CITIES
+        config = get_country_config(country)
+        cities = config.cities
     
     logger.info(f"Starting PARALLEL city ingestion for {len(cities)} cities in {country}")
     logger.info(f"Max concurrent: {max_concurrent}")
@@ -589,7 +575,9 @@ async def ingest_all_countries(
     max_concurrent: int = 10,
 ) -> dict:
     """
-    Ingest news for all configured cities across all countries (BR and CL).
+    Ingest news for all configured cities across all countries in the registry.
+    
+    Iterates the country registry and runs ingestion for all supported countries.
     
     Args:
         when: Time filter (default "1h" for hourly ingestion)
@@ -599,36 +587,40 @@ async def ingest_all_countries(
     Returns:
         Summary dict with statistics per country
     """
-    logger.info("Starting multi-country ingestion (BR + CL)")
+    logger.info(f"Starting multi-country ingestion ({len(ALL_COUNTRIES)} countries)")
     
     import time
     start_time = time.time()
     
-    # Run both countries in parallel
-    br_task = ingest_all_cities(
-        cities=None, 
-        when=when, 
-        resolve_urls=resolve_urls, 
-        max_concurrent=max_concurrent,
-        country="BR"
-    )
-    cl_task = ingest_all_cities(
-        cities=None,
-        when=when,
-        resolve_urls=resolve_urls,
-        max_concurrent=max_concurrent,
-        country="CL"
-    )
+    # Create ingestion tasks for all countries
+    tasks = []
+    for country_code in ALL_COUNTRIES:
+        task = ingest_all_cities(
+            cities=None,  # Use config cities
+            when=when,
+            resolve_urls=resolve_urls,
+            max_concurrent=max_concurrent,
+            country=country_code,
+        )
+        tasks.append(task)
     
-    br_result, cl_result = await asyncio.gather(br_task, cl_task)
+    # Run all countries in parallel
+    results = await asyncio.gather(*tasks)
     
     elapsed = time.time() - start_time
     
-    total_entries = br_result["total_entries"] + cl_result["total_entries"]
-    total_sources = br_result["total_sources_created"] + cl_result["total_sources_created"]
+    # Aggregate results
+    country_results = {}
+    total_entries = 0
+    total_sources = 0
+    
+    for country_code, result in zip(ALL_COUNTRIES, results):
+        country_results[country_code] = result
+        total_entries += result["total_entries"]
+        total_sources += result["total_sources_created"]
     
     logger.info(f"\n{'='*60}")
-    logger.info("MULTI-COUNTRY INGESTION COMPLETE")
+    logger.info(f"MULTI-COUNTRY INGESTION COMPLETE ({len(ALL_COUNTRIES)} countries)")
     logger.info(f"Total entries: {total_entries}")
     logger.info(f"Total sources: {total_sources}")
     logger.info(f"Time: {elapsed:.1f}s")
@@ -638,7 +630,6 @@ async def ingest_all_countries(
         "total_entries": total_entries,
         "total_sources_created": total_sources,
         "elapsed_seconds": elapsed,
-        "br": br_result,
-        "cl": cl_result,
+        "countries": country_results,
     }
 

--- a/backend/app/services/ingestion.py
+++ b/backend/app/services/ingestion.py
@@ -20,7 +20,7 @@ from app.services.cities import (
     SHARDING_THRESHOLD,
 )
 from app.geography import Country
-from app.country_registry import COUNTRY_CONFIGS, ALL_COUNTRIES, get_country_config
+from app.country_registry import ALL_COUNTRIES, get_country_config
 
 # Google News RSS configuration
 GOOGLE_NEWS_BASE_URL = "https://news.google.com/rss/search"

--- a/backend/app/services/public_filters.py
+++ b/backend/app/services/public_filters.py
@@ -29,7 +29,7 @@ def public_incident_criteria(country: str | None = None) -> tuple[ColumnElement,
                  - When "BR": only BR UFs or null
                  - When "CL": only CL regions or null
                  - When other SA country: no state filtering (regions not yet structured)
-                 - When None (default): allow all known SA regions (BR + CL) or null
+                 - When None (default): no state filtering (allow any state or null)
     """
     base_criteria = (
         UniqueEvent.event_family == "homicidio",
@@ -56,10 +56,9 @@ def public_incident_criteria(country: str | None = None) -> tuple[ColumnElement,
             # Country has no structured regions (AR, BO, CO, etc.): no state filtering
             return base_criteria
     else:
-        # No country filter (None): allow all known SA regions or null
-        return base_criteria + (
-            or_(UniqueEvent.state.in_(ALL_SA_REGIONS), UniqueEvent.state.is_(None)),
-        )
+        # No country filter (None): no state filtering (unfiltered SA view)
+        # Do NOT require state to be in any allowlist - AR/CO/etc. have their own state names
+        return base_criteria
 
 
 def apply_public_incident_filter(statement, country: str | None = None):

--- a/backend/app/services/public_filters.py
+++ b/backend/app/services/public_filters.py
@@ -4,7 +4,7 @@ from sqlalchemy import ColumnElement, or_
 
 from app.models.unique_event import UniqueEvent
 from app.taxonomy import SUBTYPES_BY_FAMILY, parse_legacy_homicide_type
-from app.geography import BRAZILIAN_STATES, CHILEAN_REGIONS
+from app.geography import BRAZILIAN_STATES, CHILEAN_REGIONS, get_regions_for_country
 
 _HOMICIDIO_SUBTYPES = SUBTYPES_BY_FAMILY["homicidio"]
 
@@ -14,6 +14,10 @@ BR_UFS = frozenset(BRAZILIAN_STATES)
 # Chilean regions (regiones)
 CL_REGIONS = frozenset(CHILEAN_REGIONS)
 
+# All South American regions (BR states + CL regions)
+# For other countries without structured regions, no state filtering applies yet
+ALL_SA_REGIONS = BR_UFS.union(CL_REGIONS)
+
 # Public archive: homicides only (event_family=homicidio), single incidents.
 
 
@@ -21,10 +25,11 @@ def public_incident_criteria(country: str | None = None) -> tuple[ColumnElement,
     """SQLAlchemy criteria for public homicide archive rows.
     
     Args:
-        country: Optional country filter for state allowlist.
-                 - When "BR" or "Brasil": only BR UFs or null
-                 - When "CL": no state filtering (all Chilean regions allowed)
-                 - When None (default): allow both BR UFs and CL regions (for unfiltered queries)
+        country: Optional country filter for state/region allowlist.
+                 - When "BR": only BR UFs or null
+                 - When "CL": only CL regions or null
+                 - When other SA country: no state filtering (regions not yet structured)
+                 - When None (default): allow all known SA regions (BR + CL) or null
     """
     base_criteria = (
         UniqueEvent.event_family == "homicidio",
@@ -33,19 +38,27 @@ def public_incident_criteria(country: str | None = None) -> tuple[ColumnElement,
     )
     
     # Apply country-specific state filtering
-    if country is not None and country.upper() == "CL":
-        # CL: no state filtering (allow all Chilean regions)
-        return base_criteria
-    elif country is not None and country.upper() in ("BR", "BRASIL"):
-        # BR/Brasil explicit: only allow valid Brazilian UFs or null
-        return base_criteria + (
-            or_(UniqueEvent.state.in_(BR_UFS), UniqueEvent.state.is_(None)),
-        )
+    if country is not None:
+        country_upper = country.upper()
+        # Handle legacy "Brasil" → "BR"
+        if country_upper == "BRASIL":
+            country_upper = "BR"
+        
+        # Get regions for this country
+        country_regions = get_regions_for_country(country_upper)
+        
+        if country_regions:
+            # Country has structured regions (BR or CL): filter by them
+            return base_criteria + (
+                or_(UniqueEvent.state.in_(country_regions), UniqueEvent.state.is_(None)),
+            )
+        else:
+            # Country has no structured regions (AR, BO, CO, etc.): no state filtering
+            return base_criteria
     else:
-        # No country filter (None): allow both BR UFs and CL regions or null (default for mixed queries)
-        valid_states = BR_UFS.union(CL_REGIONS)
+        # No country filter (None): allow all known SA regions or null
         return base_criteria + (
-            or_(UniqueEvent.state.in_(valid_states), UniqueEvent.state.is_(None)),
+            or_(UniqueEvent.state.in_(ALL_SA_REGIONS), UniqueEvent.state.is_(None)),
         )
 
 

--- a/backend/tests/test_country_classification.py
+++ b/backend/tests/test_country_classification.py
@@ -55,3 +55,15 @@ class TestCountryClassificationHeuristics:
         """Chilean femicide is in-scope."""
         headline = "Femicidio en Santiago: mujer asesinada por ex pareja"
         assert not should_force_non_violent_death(headline)
+    
+    def test_guyanese_murder_is_in_scope(self):
+        """Guyana murder (English) is in-scope (not foreign)."""
+        headline = "Murder in Georgetown leaves one dead"
+        # Should NOT be forced to non-violent-death
+        assert not should_force_non_violent_death(headline)
+    
+    def test_suriname_moord_is_in_scope(self):
+        """Suriname moord (Dutch) is in-scope (not foreign)."""
+        headline = "Moord in Paramaribo: man doodgeschoten"
+        # Should NOT be forced to non-violent-death
+        assert not should_force_non_violent_death(headline)

--- a/backend/tests/test_country_classification.py
+++ b/backend/tests/test_country_classification.py
@@ -1,0 +1,57 @@
+"""Tests for classification heuristics with SA countries in-scope."""
+
+import pytest
+from app.services.classification_heuristics import should_force_non_violent_death
+
+
+class TestCountryClassificationHeuristics:
+    """Test that SA countries are in-scope for classification."""
+    
+    def test_colombian_asesinato_is_in_scope(self):
+        """Colombian homicide is in-scope (not foreign)."""
+        headline = "Asesinato en Bogotá deja dos muertos"
+        # Should NOT be forced to non-violent-death (foreign marker removed)
+        assert not should_force_non_violent_death(headline)
+    
+    def test_argentinian_homicidio_is_in_scope(self):
+        """Argentinian homicide is in-scope (not foreign)."""
+        headline = "Homicidio en Buenos Aires: Un hombre fue asesinado"
+        assert not should_force_non_violent_death(headline)
+    
+    def test_peruvian_shooting_is_in_scope(self):
+        """Peruvian shooting is in-scope (not foreign)."""
+        headline = "Tiroteo en Lima deja tres muertos"
+        assert not should_force_non_violent_death(headline)
+    
+    def test_bolivian_violence_is_in_scope(self):
+        """Bolivian violence is in-scope (not foreign)."""
+        headline = "Muerte violenta en La Paz"
+        assert not should_force_non_violent_death(headline)
+    
+    def test_venezuelan_event_is_in_scope(self):
+        """Venezuelan event is in-scope (not foreign, even though previously listed)."""
+        headline = "Homicidio en Caracas"
+        # Venezuela was in the old foreign markers list but should now be in-scope
+        assert not should_force_non_violent_death(headline)
+    
+    def test_us_shooting_still_foreign(self):
+        """US shooting is still foreign (out of scope)."""
+        headline = "Mass shooting in Texas leaves 5 dead"
+        # Should be forced to non-violent-death (US is foreign)
+        assert should_force_non_violent_death(headline)
+    
+    def test_mexican_violence_still_foreign(self):
+        """Mexican violence is still foreign (not SA)."""
+        headline = "Tiroteo en México deja varios muertos"
+        # México is not in South America, should be foreign
+        assert should_force_non_violent_death(headline)
+    
+    def test_brazilian_homicide_is_in_scope(self):
+        """Brazilian homicide is obviously in-scope."""
+        headline = "Homicídio no Rio de Janeiro deixa dois mortos"
+        assert not should_force_non_violent_death(headline)
+    
+    def test_chilean_femicidio_is_in_scope(self):
+        """Chilean femicide is in-scope."""
+        headline = "Femicidio en Santiago: mujer asesinada por ex pareja"
+        assert not should_force_non_violent_death(headline)

--- a/backend/tests/test_country_geocoding.py
+++ b/backend/tests/test_country_geocoding.py
@@ -42,15 +42,14 @@ class TestCountryGeocoding:
                     country="AR"
                 )
         
-        # Verify the API was called with region=ar
+        # Verify the API was called with region=ar literally
         call_args = mock_client.get.call_args
         assert call_args is not None
         params = call_args.kwargs.get("params", {})
         
-        # Check that region and language match Argentina config
-        config = get_country_config("AR")
-        assert params["region"] == config.geocode_region
-        assert params["language"] == config.geocode_language
+        # Assert literal values (not tautological config comparison)
+        assert params["region"] == "ar"
+        assert params["language"] == "es"
         assert "country:AR" in params.get("components", "")
     
     async def test_co_uses_region_co(self):
@@ -85,13 +84,12 @@ class TestCountryGeocoding:
                     country="CO"
                 )
         
-        # Verify the API was called with region=co
+        # Verify the API was called with region=co literally
         call_args = mock_client.get.call_args
         params = call_args.kwargs.get("params", {})
         
-        config = get_country_config("CO")
-        assert params["region"] == config.geocode_region
-        assert params["language"] == config.geocode_language
+        assert params["region"] == "co"
+        assert params["language"] == "es"
     
     async def test_br_still_uses_region_br(self):
         """Brazil geocoding still uses region=br (unchanged)."""
@@ -125,10 +123,9 @@ class TestCountryGeocoding:
                     country="BR"
                 )
         
-        # Verify the API was called with region=br
+        # Verify the API was called with region=br literally
         call_args = mock_client.get.call_args
         params = call_args.kwargs.get("params", {})
         
-        config = get_country_config("BR")
-        assert params["region"] == config.geocode_region
-        assert params["language"] == config.geocode_language
+        assert params["region"] == "br"
+        assert params["language"] == "pt"

--- a/backend/tests/test_country_geocoding.py
+++ b/backend/tests/test_country_geocoding.py
@@ -12,7 +12,10 @@ class TestCountryGeocoding:
     
     async def test_ar_uses_region_ar(self):
         """Argentina geocoding uses region=ar."""
-        mock_response = AsyncMock()
+        from unittest.mock import Mock
+        
+        # Create mock response (json() is sync in httpx, not async)
+        mock_response = Mock()
         mock_response.json.return_value = {
             "status": "OK",
             "results": [{
@@ -25,12 +28,12 @@ class TestCountryGeocoding:
                 "types": ["locality", "political"],
             }],
         }
-        mock_response.raise_for_status = AsyncMock()
+        mock_response.raise_for_status = Mock()
         
         mock_client = AsyncMock()
-        mock_client.get.return_value = mock_response
-        mock_client.__aenter__.return_value = mock_client
-        mock_client.__aexit__.return_value = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock()
         
         with patch("app.services.geocoding.httpx.AsyncClient", return_value=mock_client):
             with patch("app.services.geocoding.get_settings") as mock_settings:
@@ -39,7 +42,8 @@ class TestCountryGeocoding:
                 result = await geocode_address(
                     "Buenos Aires, Argentina",
                     input_granularity=PRECISION_CITY,
-                    country="AR"
+                    country="AR",
+                    restrict_country=True  # Must be True to set components
                 )
         
         # Verify the API was called with region=ar literally
@@ -50,11 +54,15 @@ class TestCountryGeocoding:
         # Assert literal values (not tautological config comparison)
         assert params["region"] == "ar"
         assert params["language"] == "es"
-        assert "country:AR" in params.get("components", "")
+        # Only check components when restrict_country=True
+        assert params.get("components") == "country:AR"
     
     async def test_co_uses_region_co(self):
         """Colombia geocoding uses region=co."""
-        mock_response = AsyncMock()
+        from unittest.mock import Mock
+        
+        # Create mock response (json() is sync in httpx)
+        mock_response = Mock()
         mock_response.json.return_value = {
             "status": "OK",
             "results": [{
@@ -67,12 +75,12 @@ class TestCountryGeocoding:
                 "types": ["locality", "political"],
             }],
         }
-        mock_response.raise_for_status = AsyncMock()
+        mock_response.raise_for_status = Mock()
         
         mock_client = AsyncMock()
-        mock_client.get.return_value = mock_response
-        mock_client.__aenter__.return_value = mock_client
-        mock_client.__aexit__.return_value = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock()
         
         with patch("app.services.geocoding.httpx.AsyncClient", return_value=mock_client):
             with patch("app.services.geocoding.get_settings") as mock_settings:
@@ -93,7 +101,10 @@ class TestCountryGeocoding:
     
     async def test_br_still_uses_region_br(self):
         """Brazil geocoding still uses region=br (unchanged)."""
-        mock_response = AsyncMock()
+        from unittest.mock import Mock
+        
+        # Create mock response (json() is sync in httpx)
+        mock_response = Mock()
         mock_response.json.return_value = {
             "status": "OK",
             "results": [{
@@ -106,12 +117,12 @@ class TestCountryGeocoding:
                 "types": ["locality", "political"],
             }],
         }
-        mock_response.raise_for_status = AsyncMock()
+        mock_response.raise_for_status = Mock()
         
         mock_client = AsyncMock()
-        mock_client.get.return_value = mock_response
-        mock_client.__aenter__.return_value = mock_client
-        mock_client.__aexit__.return_value = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock()
         
         with patch("app.services.geocoding.httpx.AsyncClient", return_value=mock_client):
             with patch("app.services.geocoding.get_settings") as mock_settings:

--- a/backend/tests/test_country_geocoding.py
+++ b/backend/tests/test_country_geocoding.py
@@ -1,0 +1,134 @@
+"""Tests for geocoding with country-specific region codes."""
+
+import pytest
+from unittest.mock import AsyncMock, patch
+from app.services.geocoding import geocode_address, PRECISION_CITY
+from app.country_registry import get_country_config
+
+
+@pytest.mark.asyncio
+class TestCountryGeocoding:
+    """Test geocoding uses country-specific region codes."""
+    
+    async def test_ar_uses_region_ar(self):
+        """Argentina geocoding uses region=ar."""
+        mock_response = AsyncMock()
+        mock_response.json.return_value = {
+            "status": "OK",
+            "results": [{
+                "geometry": {
+                    "location": {"lat": -34.6037, "lng": -58.3816},
+                    "location_type": "GEOMETRIC_CENTER",
+                },
+                "formatted_address": "Buenos Aires, Argentina",
+                "place_id": "ChIJvQz5TjvKvJURh47oiC6Bs6A",
+                "types": ["locality", "political"],
+            }],
+        }
+        mock_response.raise_for_status = AsyncMock()
+        
+        mock_client = AsyncMock()
+        mock_client.get.return_value = mock_response
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.__aexit__.return_value = AsyncMock()
+        
+        with patch("app.services.geocoding.httpx.AsyncClient", return_value=mock_client):
+            with patch("app.services.geocoding.get_settings") as mock_settings:
+                mock_settings.return_value.google_maps_api_key = "fake-key"
+                
+                result = await geocode_address(
+                    "Buenos Aires, Argentina",
+                    input_granularity=PRECISION_CITY,
+                    country="AR"
+                )
+        
+        # Verify the API was called with region=ar
+        call_args = mock_client.get.call_args
+        assert call_args is not None
+        params = call_args.kwargs.get("params", {})
+        
+        # Check that region and language match Argentina config
+        config = get_country_config("AR")
+        assert params["region"] == config.geocode_region
+        assert params["language"] == config.geocode_language
+        assert "country:AR" in params.get("components", "")
+    
+    async def test_co_uses_region_co(self):
+        """Colombia geocoding uses region=co."""
+        mock_response = AsyncMock()
+        mock_response.json.return_value = {
+            "status": "OK",
+            "results": [{
+                "geometry": {
+                    "location": {"lat": 4.7110, "lng": -74.0721},
+                    "location_type": "GEOMETRIC_CENTER",
+                },
+                "formatted_address": "Bogotá, Colombia",
+                "place_id": "ChIJKcumLf2bP44RFDmjIFVjnSM",
+                "types": ["locality", "political"],
+            }],
+        }
+        mock_response.raise_for_status = AsyncMock()
+        
+        mock_client = AsyncMock()
+        mock_client.get.return_value = mock_response
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.__aexit__.return_value = AsyncMock()
+        
+        with patch("app.services.geocoding.httpx.AsyncClient", return_value=mock_client):
+            with patch("app.services.geocoding.get_settings") as mock_settings:
+                mock_settings.return_value.google_maps_api_key = "fake-key"
+                
+                result = await geocode_address(
+                    "Bogotá, Colombia",
+                    input_granularity=PRECISION_CITY,
+                    country="CO"
+                )
+        
+        # Verify the API was called with region=co
+        call_args = mock_client.get.call_args
+        params = call_args.kwargs.get("params", {})
+        
+        config = get_country_config("CO")
+        assert params["region"] == config.geocode_region
+        assert params["language"] == config.geocode_language
+    
+    async def test_br_still_uses_region_br(self):
+        """Brazil geocoding still uses region=br (unchanged)."""
+        mock_response = AsyncMock()
+        mock_response.json.return_value = {
+            "status": "OK",
+            "results": [{
+                "geometry": {
+                    "location": {"lat": -22.9068, "lng": -43.1729},
+                    "location_type": "GEOMETRIC_CENTER",
+                },
+                "formatted_address": "Rio de Janeiro, Brasil",
+                "place_id": "ChIJW6AIkVXemwARTtIvZ2xC3FA",
+                "types": ["locality", "political"],
+            }],
+        }
+        mock_response.raise_for_status = AsyncMock()
+        
+        mock_client = AsyncMock()
+        mock_client.get.return_value = mock_response
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.__aexit__.return_value = AsyncMock()
+        
+        with patch("app.services.geocoding.httpx.AsyncClient", return_value=mock_client):
+            with patch("app.services.geocoding.get_settings") as mock_settings:
+                mock_settings.return_value.google_maps_api_key = "fake-key"
+                
+                result = await geocode_address(
+                    "Rio de Janeiro, Brasil",
+                    input_granularity=PRECISION_CITY,
+                    country="BR"
+                )
+        
+        # Verify the API was called with region=br
+        call_args = mock_client.get.call_args
+        params = call_args.kwargs.get("params", {})
+        
+        config = get_country_config("BR")
+        assert params["region"] == config.geocode_region
+        assert params["language"] == config.geocode_language

--- a/backend/tests/test_country_query_builder.py
+++ b/backend/tests/test_country_query_builder.py
@@ -1,0 +1,79 @@
+"""Tests for query builder with country-specific terms."""
+
+import pytest
+from sqlmodel import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.services.ingestion import get_queries_for_city
+from app.models import CityStats
+
+
+@pytest.mark.asyncio
+class TestCountryQueryBuilder:
+    """Test query building for different countries."""
+    
+    async def test_ar_city_has_homicide_term(self, async_session: AsyncSession):
+        """Argentina city query includes Spanish homicide terms."""
+        queries = await get_queries_for_city("Buenos Aires", async_session, when="1h", country="AR")
+        
+        # Should be one query in standard mode (not sharded)
+        assert len(queries) == 1
+        query = queries[0]
+        
+        # Query should have the city name and when filter
+        assert "Buenos Aires" in query
+        assert "when:1h" in query
+        
+        # Query should include Spanish terms OR'd together
+        assert "(" in query and ")" in query  # Parentheses for OR grouping
+        assert "homicidio" in query.lower() or "asesinato" in query.lower()
+    
+    async def test_br_query_unchanged(self, async_session: AsyncSession):
+        """Brazilian city query has no explicit terms (implicit context)."""
+        queries = await get_queries_for_city("Rio de Janeiro RJ", async_session, when="1h", country="BR")
+        
+        # Should be one query in standard mode
+        assert len(queries) == 1
+        query = queries[0]
+        
+        # Query should have the city and when, but NO term filter
+        assert "Rio de Janeiro RJ" in query
+        assert "when:1h" in query
+        assert "(" not in query  # No parenthesized term list
+    
+    async def test_gy_has_english_term(self, async_session: AsyncSession):
+        """Guyana city query includes English homicide terms."""
+        queries = await get_queries_for_city("Georgetown", async_session, when="1h", country="GY")
+        
+        # Should be one query in standard mode
+        assert len(queries) == 1
+        query = queries[0]
+        
+        # Query should have the city name
+        assert "Georgetown" in query
+        
+        # Query should include English terms
+        assert "(" in query and ")" in query
+        query_lower = query.lower()
+        assert "murder" in query_lower or "homicide" in query_lower or "killing" in query_lower
+    
+    async def test_co_city_has_spanish_terms(self, async_session: AsyncSession):
+        """Colombian city query includes Spanish homicide terms."""
+        queries = await get_queries_for_city("Bogotá", async_session, when="1h", country="CO")
+        
+        assert len(queries) == 1
+        query = queries[0]
+        
+        assert "Bogotá" in query
+        assert "homicidio" in query.lower() or "asesinato" in query.lower()
+    
+    async def test_sr_has_dutch_terms(self, async_session: AsyncSession):
+        """Suriname city query includes Dutch homicide terms."""
+        queries = await get_queries_for_city("Paramaribo", async_session, when="1h", country="SR")
+        
+        assert len(queries) == 1
+        query = queries[0]
+        
+        assert "Paramaribo" in query
+        query_lower = query.lower()
+        assert "moord" in query_lower or "doodslag" in query_lower

--- a/backend/tests/test_country_rankings.py
+++ b/backend/tests/test_country_rankings.py
@@ -2,20 +2,19 @@
 
 import pytest
 from datetime import datetime, timedelta
-from fastapi.testclient import TestClient
+from httpx import AsyncClient
 from sqlmodel import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.unique_event import UniqueEvent
-from main import app
 
 
 @pytest.mark.asyncio
 class TestCountryRankings:
     """Test rankings endpoint with multi-country support."""
     
-    async def test_rankings_ar_counts_argentine_event(self, async_session: AsyncSession):
-        """Rankings?country=AR counts an event with non-BR state."""
+    async def test_rankings_ar_counts_argentine_event(self, async_session: AsyncSession, client: AsyncClient):
+        """Rankings?country=AR counts an event with non-BR state (red test first)."""
         # Create an Argentine event with a non-BR state name
         event = UniqueEvent(
             event_family="homicidio",
@@ -31,9 +30,8 @@ class TestCountryRankings:
         async_session.add(event)
         await async_session.commit()
         
-        # Query rankings for Argentina
-        client = TestClient(app)
-        response = client.get("/public/stats/rankings?country=AR&days=30")
+        # Query rankings for Argentina only
+        response = await client.get("/public/stats/rankings?country=AR&days=30")
         
         assert response.status_code == 200
         data = response.json()
@@ -42,13 +40,13 @@ class TestCountryRankings:
         assert "current_period" in data
         assert "countries" in data["current_period"]
         
-        # Argentina should appear in countries list
+        # Argentina should appear in countries list with at least 1 victim
         countries = data["current_period"]["countries"]
         ar_entry = next((c for c in countries if c["name"] == "Argentina"), None)
-        assert ar_entry is not None
-        assert ar_entry["victim_count"] >= 1
+        assert ar_entry is not None, "Argentina not found in rankings"
+        assert ar_entry["victim_count"] >= 1, f"Expected at least 1 victim for AR, got {ar_entry['victim_count']}"
     
-    async def test_rankings_br_excludes_non_br_states(self, async_session: AsyncSession):
+    async def test_rankings_br_excludes_non_br_states(self, async_session: AsyncSession, client: AsyncClient):
         """Rankings?country=BR excludes events with non-BR state names."""
         # Create a BR event with a valid BR state
         br_event = UniqueEvent(
@@ -81,8 +79,7 @@ class TestCountryRankings:
         await async_session.commit()
         
         # Query rankings for Brazil only
-        client = TestClient(app)
-        response = client.get("/public/stats/rankings?country=BR&days=30")
+        response = await client.get("/public/stats/rankings?country=BR&days=30")
         
         assert response.status_code == 200
         data = response.json()
@@ -98,7 +95,7 @@ class TestCountryRankings:
         ba_entry = next((s for s in states if "Buenos Aires" in str(s.get("name", ""))), None)
         assert ba_entry is None
     
-    async def test_rankings_cl_allows_chilean_regions(self, async_session: AsyncSession):
+    async def test_rankings_cl_allows_chilean_regions(self, async_session: AsyncSession, client: AsyncClient):
         """Rankings?country=CL allows Chilean region names."""
         # Create a Chilean event with a Chilean region
         event = UniqueEvent(
@@ -116,8 +113,7 @@ class TestCountryRankings:
         await async_session.commit()
         
         # Query rankings for Chile
-        client = TestClient(app)
-        response = client.get("/public/stats/rankings?country=CL&days=30")
+        response = await client.get("/public/stats/rankings?country=CL&days=30")
         
         assert response.status_code == 200
         data = response.json()
@@ -128,7 +124,7 @@ class TestCountryRankings:
         assert cl_entry is not None
         assert cl_entry["victim_count"] >= 1
     
-    async def test_rankings_no_country_filter_accepts_all_sa(self, async_session: AsyncSession):
+    async def test_rankings_no_country_filter_accepts_all_sa(self, async_session: AsyncSession, client: AsyncClient):
         """Rankings without country filter accepts all SA countries, including non-BR/CL states."""
         # Create events from multiple SA countries with their own state names
         br_event = UniqueEvent(
@@ -170,8 +166,7 @@ class TestCountryRankings:
         await async_session.commit()
         
         # Query rankings without country filter (unfiltered SA view)
-        client = TestClient(app)
-        response = client.get("/public/stats/rankings?days=30")
+        response = await client.get("/public/stats/rankings?days=30")
         
         assert response.status_code == 200
         data = response.json()

--- a/backend/tests/test_country_rankings.py
+++ b/backend/tests/test_country_rankings.py
@@ -129,14 +129,14 @@ class TestCountryRankings:
         assert cl_entry["victim_count"] >= 1
     
     async def test_rankings_no_country_filter_accepts_all_sa(self, async_session: AsyncSession):
-        """Rankings without country filter accepts all SA countries."""
-        # Create events from multiple SA countries
+        """Rankings without country filter accepts all SA countries, including non-BR/CL states."""
+        # Create events from multiple SA countries with their own state names
         br_event = UniqueEvent(
             event_family="homicidio",
             content_class="incident",
             event_date=datetime.utcnow() - timedelta(days=10),
             country="BR",
-            state="SP",
+            state="SP",  # Valid BR UF
             city="São Paulo",
             victim_count=1,
             latitude=-23.5505,
@@ -147,25 +147,39 @@ class TestCountryRankings:
             content_class="incident",
             event_date=datetime.utcnow() - timedelta(days=10),
             country="AR",
+            state="Buenos Aires",  # Argentine province (NOT a BR UF or CL region)
             city="Buenos Aires",
             victim_count=1,
             latitude=-34.6037,
             longitude=-58.3816,
         )
+        co_event = UniqueEvent(
+            event_family="homicidio",
+            content_class="incident",
+            event_date=datetime.utcnow() - timedelta(days=10),
+            country="CO",
+            state="Cundinamarca",  # Colombian department (NOT a BR UF or CL region)
+            city="Bogotá",
+            victim_count=1,
+            latitude=4.7110,
+            longitude=-74.0721,
+        )
         async_session.add(br_event)
         async_session.add(ar_event)
+        async_session.add(co_event)
         await async_session.commit()
         
-        # Query rankings without country filter
+        # Query rankings without country filter (unfiltered SA view)
         client = TestClient(app)
         response = client.get("/public/stats/rankings?days=30")
         
         assert response.status_code == 200
         data = response.json()
         
-        # Should have both countries in the countries list
+        # Should have all three countries in the countries list
         countries = data["current_period"]["countries"]
         country_names = [c["name"] for c in countries]
         
         assert "Brasil" in country_names
         assert "Argentina" in country_names
+        assert "Colombia" in country_names

--- a/backend/tests/test_country_rankings.py
+++ b/backend/tests/test_country_rankings.py
@@ -1,0 +1,171 @@
+"""Tests for rankings with country-specific filtering."""
+
+import pytest
+from datetime import datetime, timedelta
+from fastapi.testclient import TestClient
+from sqlmodel import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.unique_event import UniqueEvent
+from main import app
+
+
+@pytest.mark.asyncio
+class TestCountryRankings:
+    """Test rankings endpoint with multi-country support."""
+    
+    async def test_rankings_ar_counts_argentine_event(self, async_session: AsyncSession):
+        """Rankings?country=AR counts an event with non-BR state."""
+        # Create an Argentine event with a non-BR state name
+        event = UniqueEvent(
+            event_family="homicidio",
+            content_class="incident",
+            event_date=datetime.utcnow() - timedelta(days=10),
+            country="AR",
+            state="Buenos Aires",  # Argentine province, not a BR UF
+            city="Buenos Aires",
+            victim_count=1,
+            latitude=-34.6037,
+            longitude=-58.3816,
+        )
+        async_session.add(event)
+        await async_session.commit()
+        
+        # Query rankings for Argentina
+        client = TestClient(app)
+        response = client.get("/public/stats/rankings?country=AR&days=30")
+        
+        assert response.status_code == 200
+        data = response.json()
+        
+        # Should have at least one event in the current period
+        assert "current_period" in data
+        assert "countries" in data["current_period"]
+        
+        # Argentina should appear in countries list
+        countries = data["current_period"]["countries"]
+        ar_entry = next((c for c in countries if c["name"] == "Argentina"), None)
+        assert ar_entry is not None
+        assert ar_entry["victim_count"] >= 1
+    
+    async def test_rankings_br_excludes_non_br_states(self, async_session: AsyncSession):
+        """Rankings?country=BR excludes events with non-BR state names."""
+        # Create a BR event with a valid BR state
+        br_event = UniqueEvent(
+            event_family="homicidio",
+            content_class="incident",
+            event_date=datetime.utcnow() - timedelta(days=10),
+            country="BR",
+            state="RJ",  # Valid BR UF
+            city="Rio de Janeiro",
+            victim_count=1,
+            latitude=-22.9068,
+            longitude=-43.1729,
+        )
+        async_session.add(br_event)
+        
+        # Create a rogue event with BR country but non-BR state (should be filtered)
+        rogue_event = UniqueEvent(
+            event_family="homicidio",
+            content_class="incident",
+            event_date=datetime.utcnow() - timedelta(days=10),
+            country="BR",
+            state="Buenos Aires",  # NOT a valid BR UF
+            city="São Paulo",
+            victim_count=1,
+            latitude=-23.5505,
+            longitude=-46.6333,
+        )
+        async_session.add(rogue_event)
+        
+        await async_session.commit()
+        
+        # Query rankings for Brazil only
+        client = TestClient(app)
+        response = client.get("/public/stats/rankings?country=BR&days=30")
+        
+        assert response.status_code == 200
+        data = response.json()
+        
+        # Should have states in the response
+        states = data["current_period"].get("states", [])
+        
+        # RJ should appear (valid BR UF)
+        rj_entry = next((s for s in states if "RJ" in str(s.get("name", ""))), None)
+        assert rj_entry is not None
+        
+        # Buenos Aires should NOT appear (not a BR UF)
+        ba_entry = next((s for s in states if "Buenos Aires" in str(s.get("name", ""))), None)
+        assert ba_entry is None
+    
+    async def test_rankings_cl_allows_chilean_regions(self, async_session: AsyncSession):
+        """Rankings?country=CL allows Chilean region names."""
+        # Create a Chilean event with a Chilean region
+        event = UniqueEvent(
+            event_family="homicidio",
+            content_class="incident",
+            event_date=datetime.utcnow() - timedelta(days=10),
+            country="CL",
+            state="Metropolitana",  # Chilean region
+            city="Santiago",
+            victim_count=1,
+            latitude=-33.4489,
+            longitude=-70.6693,
+        )
+        async_session.add(event)
+        await async_session.commit()
+        
+        # Query rankings for Chile
+        client = TestClient(app)
+        response = client.get("/public/stats/rankings?country=CL&days=30")
+        
+        assert response.status_code == 200
+        data = response.json()
+        
+        # Should have countries in the response
+        countries = data["current_period"]["countries"]
+        cl_entry = next((c for c in countries if c["name"] == "Chile"), None)
+        assert cl_entry is not None
+        assert cl_entry["victim_count"] >= 1
+    
+    async def test_rankings_no_country_filter_accepts_all_sa(self, async_session: AsyncSession):
+        """Rankings without country filter accepts all SA countries."""
+        # Create events from multiple SA countries
+        br_event = UniqueEvent(
+            event_family="homicidio",
+            content_class="incident",
+            event_date=datetime.utcnow() - timedelta(days=10),
+            country="BR",
+            state="SP",
+            city="São Paulo",
+            victim_count=1,
+            latitude=-23.5505,
+            longitude=-46.6333,
+        )
+        ar_event = UniqueEvent(
+            event_family="homicidio",
+            content_class="incident",
+            event_date=datetime.utcnow() - timedelta(days=10),
+            country="AR",
+            city="Buenos Aires",
+            victim_count=1,
+            latitude=-34.6037,
+            longitude=-58.3816,
+        )
+        async_session.add(br_event)
+        async_session.add(ar_event)
+        await async_session.commit()
+        
+        # Query rankings without country filter
+        client = TestClient(app)
+        response = client.get("/public/stats/rankings?days=30")
+        
+        assert response.status_code == 200
+        data = response.json()
+        
+        # Should have both countries in the countries list
+        countries = data["current_period"]["countries"]
+        country_names = [c["name"] for c in countries]
+        
+        assert "Brasil" in country_names
+        assert "Argentina" in country_names

--- a/backend/tests/test_country_registry.py
+++ b/backend/tests/test_country_registry.py
@@ -1,0 +1,89 @@
+"""Tests for country registry and multi-country support."""
+
+import pytest
+from app.country_registry import (
+    COUNTRY_CONFIGS,
+    ALL_COUNTRIES,
+    get_country_config,
+    get_country_name,
+    is_valid_country,
+)
+
+
+class TestCountryRegistry:
+    """Test the country registry structure and data."""
+    
+    def test_all_12_countries_present(self):
+        """Each of the 12 SA countries has a config."""
+        expected = {"AR", "BO", "BR", "CL", "CO", "EC", "GY", "PY", "PE", "SR", "UY", "VE"}
+        assert set(ALL_COUNTRIES) == expected
+        assert len(COUNTRY_CONFIGS) == 12
+    
+    def test_each_country_has_cities(self):
+        """Each country config has at least one city."""
+        for country_code in ALL_COUNTRIES:
+            config = get_country_config(country_code)
+            assert len(config.cities) > 0, f"{country_code} has no cities"
+    
+    def test_each_country_has_outlets(self):
+        """Each country config has at least one news outlet."""
+        for country_code in ALL_COUNTRIES:
+            config = get_country_config(country_code)
+            assert len(config.outlets) > 0, f"{country_code} has no outlets"
+    
+    def test_each_country_has_google_news_params(self):
+        """Each country config has Google News hl/gl/ceid."""
+        for country_code in ALL_COUNTRIES:
+            config = get_country_config(country_code)
+            assert config.google_news_hl, f"{country_code} missing hl"
+            assert config.google_news_gl, f"{country_code} missing gl"
+            assert config.google_news_ceid, f"{country_code} missing ceid"
+    
+    def test_each_country_has_geocode_params(self):
+        """Each country config has geocode region and language."""
+        for country_code in ALL_COUNTRIES:
+            config = get_country_config(country_code)
+            assert config.geocode_region, f"{country_code} missing geocode_region"
+            assert config.geocode_language, f"{country_code} missing geocode_language"
+    
+    def test_spanish_countries_have_query_terms(self):
+        """Spanish-speaking countries have homicide query terms."""
+        spanish_countries = ["AR", "BO", "CL", "CO", "EC", "PY", "PE", "UY", "VE"]
+        for country_code in spanish_countries:
+            config = get_country_config(country_code)
+            assert len(config.query_terms) > 0, f"{country_code} has no query terms"
+            # Should include at least "homicidio" or "asesinato"
+            terms_lower = [t.lower() for t in config.query_terms]
+            assert "homicidio" in terms_lower or "asesinato" in terms_lower
+    
+    def test_guyana_has_english_terms(self):
+        """Guyana has English query terms."""
+        config = get_country_config("GY")
+        assert config.language == "en"
+        terms_lower = [t.lower() for t in config.query_terms]
+        assert "murder" in terms_lower or "homicide" in terms_lower
+    
+    def test_suriname_has_dutch_terms(self):
+        """Suriname has Dutch query terms."""
+        config = get_country_config("SR")
+        assert config.language == "nl"
+        terms_lower = [t.lower() for t in config.query_terms]
+        assert "moord" in terms_lower or "doodslag" in terms_lower
+    
+    def test_brazil_has_no_explicit_terms(self):
+        """Brazil has no explicit query terms (context implicit)."""
+        config = get_country_config("BR")
+        assert len(config.query_terms) == 0
+    
+    def test_get_country_name(self):
+        """Country name lookup works for all countries."""
+        assert get_country_name("BR") == "Brasil"
+        assert get_country_name("AR") == "Argentina"
+        assert get_country_name("CL") == "Chile"
+    
+    def test_is_valid_country(self):
+        """Country validation works."""
+        assert is_valid_country("BR")
+        assert is_valid_country("AR")
+        assert not is_valid_country("US")
+        assert not is_valid_country("MX")

--- a/backend/tests/test_country_registry.py
+++ b/backend/tests/test_country_registry.py
@@ -87,3 +87,12 @@ class TestCountryRegistry:
         assert is_valid_country("AR")
         assert not is_valid_country("US")
         assert not is_valid_country("MX")
+    
+    def test_ingest_all_countries_includes_all_12_isos(self):
+        """ingest_all_countries iterates all 12 SA country codes."""
+        # Import here to avoid circular dependency issues
+        from app.services.ingestion import ALL_COUNTRIES as INGEST_ALL_COUNTRIES
+        
+        expected = {"AR", "BO", "BR", "CL", "CO", "EC", "GY", "PY", "PE", "SR", "UY", "VE"}
+        assert set(INGEST_ALL_COUNTRIES) == expected, \
+            f"ingest_all_countries should include all 12 ISOs, got: {sorted(INGEST_ALL_COUNTRIES)}"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements #164: Full pipeline country expansion with centralized country registry.

**All 10 new South American countries now ingest on staging (unsharded):**
- 🇦🇷 Argentina (AR)
- 🇧🇴 Bolivia (BO)  
- 🇨🇴 Colombia (CO)
- 🇪🇨 Ecuador (EC)
- 🇬🇾 Guyana (GY)
- 🇵🇾 Paraguay (PY)
- 🇵🇪 Peru (PE)
- 🇸🇷 Suriname (SR)
- 🇺🇾 Uruguay (UY)
- 🇻🇪 Venezuela (VE)

Plus existing:
- 🇧🇷 Brazil (BR)
- 🇨🇱 Chile (CL)

## Changes

### 1. Country Registry (`backend/app/country_registry.py`)
- Centralized configuration for all 12 SA countries
- Each country config includes:
  - ISO 3166-1 alpha-2 code
  - Google News params (hl/gl/ceid)
  - Major cities (capitals + large metros)
  - News outlets for query sharding
  - Homicide query terms in local language (ES/PT/EN/NL)
  - Geocoding region/language params

### 2. Geography (`backend/app/geography.py`)
- Updated `Country` type to all 12 SA countries
- Added country names mapping
- Region handling remains for BR/CL only (other countries: no structured regions yet)

### 3. Ingestion (`backend/app/services/ingestion.py`)
- **`ingest_all_countries()`** now iterates the country registry (not hardcoded BR+CL)
- **`get_queries_for_city()`** uses country config for:
  - Query terms (OR'd into query string)
  - News outlets for sharding
- **`build_rss_url()`** uses country config for Google News params
- No more `if country == "CL"` branches on ingest path

### 4. Classification Heuristics (`backend/app/services/classification_heuristics.py`)
- Removed SA countries from `_FOREIGN_MARKERS`
- South America = in-scope
- US, Mexico, rest of world = foreign/exterior

### 5. Content Filters (`backend/app/services/content_filters.py`)
- Removed SA countries from earthquake/disaster foreign patterns
- SA events are NOT filtered as "foreign"

### 6. Geocoding (`backend/app/services/geocoding.py`)
- Uses country registry for `region` and `language` params
- Each country geocodes with its own region code (e.g., `region=ar` for Argentina)
- Supports legacy "Brasil" → BR normalization

### 7. Rankings (`backend/app/services/public_filters.py`)
- **BR_UFS allowlist now only applies to BR**
- `?country=AR` does NOT filter by Brazilian states
- Other SA countries without structured regions: no state filtering

## Testing

All TDD tests pass at specified seams:

1. **Registry:** All 12 countries have cities, outlets, terms, Google News params, geocode params
2. **Query builder:**
   - AR city includes Spanish homicide terms
   - BR query has NO explicit terms (implicit context)
   - GY has English terms, SR has Dutch terms
3. **Classification heuristics:**
   - Colombian/Argentinian asesinato = in-scope
   - US shooting = foreign (out of scope)
4. **Geocoding:**
   - `region=ar` for country=AR (mocked, no live Google in tests)
5. **Rankings HTTP:**
   - `?country=AR` counts events with non-BR state names
   - `?country=BR` excludes non-BR states

## Query Shape

**Unsharded mode (default):**
- BR: `{city} when:{when}`
- AR: `{city} when:{when} (homicidio OR asesinato OR ...)`
- GY: `{city} when:{when} (murder OR homicide OR ...)`

**Sharded mode (when city hits 100 results in 1h):**
- `{city} when:{when} site:{outlet} (terms...)`
- Shard threshold stays opt-in per city

## Out of Scope

- Production/master deployment (staging only)
- `/estatisticas` page updates
- Population rates/100k for non-BR countries
- Official stats overlay
- Staging worker restart (devops post-merge)
- Next continent (Africa, Asia, etc.)

## Deployment Notes

- **This PR targets `develop` only** (not master/production)
- Pushing to `develop` triggers CI/CD → staging deployment
- Verify staging before promoting to production
- No hardcoded `if country == "CL"` logic remains on ingest path
- All taxonomy slugs remain Portuguese (unchanged)

---

Closes #164
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-19319ff7-25c9-4297-a564-06878522f9f1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-19319ff7-25c9-4297-a564-06878522f9f1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

