### PR TITLE
fix: resolve download filter excluding ready_for_download with NULL resolved_url (#171)

### DIFF
--- a/backend/app/routers/pipeline.py
+++ b/backend/app/routers/pipeline.py
@@ -374,6 +374,39 @@ async def run_batch_geocoding(
     }
 
 
+@router.post("/backfill-null-resolved-urls")
+async def run_backfill_null_resolved_urls(
+    limit: int | None = Query(None, description="Maximum sources to process (default: all)"),
+    dry_run: bool = Query(False, description="Only report counts without updating database"),
+):
+    """
+    Backfill resolved_url for sources stuck at ready_for_download with NULL resolved_url.
+    
+    Issue #171: After ingest decoder failures, ~500 sources on staging have:
+    - status = ready_for_download
+    - resolved_url = NULL
+    - google_news_url present
+    
+    Before the fix, download_classified_sources filtered WHERE resolved_url IS NOT NULL,
+    so these rows were never processed. After the fix, new sources are handled automatically,
+    but this backfill clears the existing stuck rows.
+    
+    Use dry_run=true to see how many rows would be affected without making changes.
+    """
+    from app.services.maintenance import backfill_null_resolved_urls
+    
+    result = await backfill_null_resolved_urls(limit=limit, dry_run=dry_run)
+    
+    return {
+        "status": "completed" if not dry_run else "dry_run",
+        "message": (
+            f"Backfill {'completed' if not dry_run else 'dry run'}: "
+            f"{result['resolved']} resolved, {result['failed']} failed (out of {result['total']} total)"
+        ),
+        **result,
+    }
+
+
 # =============================================================================
 # Job Status & Queue Monitoring
 # =============================================================================

--- a/backend/app/services/download.py
+++ b/backend/app/services/download.py
@@ -267,10 +267,58 @@ async def download_source_content(source_id: int) -> DownloadOutcome:
             logger.warning(f"Source {source_id} not found")
             return DownloadOutcome.failed
 
-        # Use resolved URL if available, otherwise the Google News URL
-        target_url = row[0] or row[1]
+        resolved_url = row[0]
+        google_news_url = row[1]
         headline = row[2]
+    
+    # Issue #171: If resolved_url is NULL but google_news_url exists,
+    # try to resolve it now (handles decoder failures during ingest)
+    if not resolved_url and google_news_url:
+        logger.info(f"Source {source_id}: resolved_url is NULL, attempting late resolution")
+        from app.services.ingestion import resolve_google_news_url
+        resolved_url = await asyncio.to_thread(resolve_google_news_url, google_news_url)
+        
+        if resolved_url:
+            logger.info(f"Source {source_id}: late resolution succeeded -> {resolved_url[:60]}...")
+            # Persist the resolved URL so we don't re-resolve next time
+            async with async_session_maker() as session:
+                await session.execute(
+                    text("UPDATE source_google_news SET resolved_url = :url WHERE id = :id"),
+                    {"id": source_id, "url": resolved_url},
+                )
+                await session.commit()
+        else:
+            logger.warning(f"Source {source_id}: late resolution failed, will use google_news_url")
+    
+    # Use resolved URL if available, otherwise fall back to Google News URL
+    target_url = resolved_url or google_news_url
+    
+    if not target_url:
+        async with async_session_maker() as session:
+            await session.execute(
+                text("""
+                    UPDATE source_google_news 
+                    SET status = 'failed_in_download', updated_at = CURRENT_TIMESTAMP
+                    WHERE id = :id
+                """),
+                {"id": source_id}
+            )
+            await session.commit()
+        await diagnostics.record_attempt(
+            stage=diagnostics.STAGE_DOWNLOAD,
+            outcome=diagnostics.OUTCOME_FAILURE,
+            source_google_news_id=source_id,
+            failure_reason=diagnostics.NO_URL,
+            failure_detail="Source has no resolved_url or google_news_url",
+            http_status=None,
+            url_domain=None,
+            duration_ms=0,
+            attempt_number=await diagnostics.count_attempts(source_id, diagnostics.STAGE_DOWNLOAD) + 1,
+        )
+        return DownloadOutcome.failed
 
+    logger.info(f"Downloading content from: {target_url[:80]}...")
+    
     attempt_number = await diagnostics.count_attempts(source_id, diagnostics.STAGE_DOWNLOAD) + 1
     url_domain = diagnostics.domain_of(target_url)
 
@@ -296,12 +344,6 @@ async def download_source_content(source_id: int) -> DownloadOutcome:
             duration_ms=duration_ms,
             attempt_number=attempt_number,
         )
-
-    if not target_url:
-        await _mark_failed(diagnostics.NO_URL, "Source has no resolved or google_news URL", None, 0)
-        return DownloadOutcome.failed
-
-    logger.info(f"Downloading content from: {target_url[:80]}...")
 
     # Step 2: fetch over the network, then extract off the event loop. Neither
     # step holds a DB connection.
@@ -395,11 +437,13 @@ async def download_classified_sources(limit: int = 50, concurrency: int = 10) ->
     async with async_session_maker() as session:
         # Get sources ready for download (passed classification)
         # Use raw SQL to avoid SQLAlchemy enum caching issues
+        # Issue #171: Include sources with NULL resolved_url (decoder failures)
+        # as long as google_news_url is present - we'll try to resolve at download time
         result = await session.execute(
             text("""
                 SELECT id FROM source_google_news 
                 WHERE status = 'ready_for_download' 
-                AND resolved_url IS NOT NULL 
+                AND google_news_url IS NOT NULL 
                 LIMIT :limit
             """),
             {"limit": limit}

--- a/backend/app/services/maintenance.py
+++ b/backend/app/services/maintenance.py
@@ -1,5 +1,6 @@
 """Maintenance helpers for recovering the pipeline from stuck states."""
 
+import asyncio
 from datetime import date, datetime, timedelta
 from typing import Any
 
@@ -627,3 +628,98 @@ async def auto_merge_near_duplicates_in_bucket(
         )
 
     return audit
+
+
+async def backfill_null_resolved_urls(
+    *,
+    limit: int | None = None,
+    dry_run: bool = False,
+) -> dict:
+    """Backfill resolved_url for sources stuck at ready_for_download with NULL resolved_url.
+    
+    Issue #171: After ingest decoder failures, sources with resolved_url=NULL but
+    google_news_url present got classified and marked ready_for_download, but the
+    download service filtered them out with WHERE resolved_url IS NOT NULL.
+    
+    This function retries URL resolution for those stuck sources. After the download
+    service fix (#171), newly ingested sources will be handled automatically, but
+    this backfill clears the existing ~500 stuck rows on staging.
+    
+    Args:
+        limit: Max sources to process (default: all stuck sources)
+        dry_run: If True, only report counts without updating the database
+    
+    Returns:
+        Dict with statistics: total, resolved, failed, skipped
+    """
+    from app.services.ingestion import resolve_google_news_url
+    
+    async with async_session_maker() as session:
+        query = """
+            SELECT id, google_news_url 
+            FROM source_google_news 
+            WHERE status = 'ready_for_download' 
+            AND resolved_url IS NULL 
+            AND google_news_url IS NOT NULL
+        """
+        if limit:
+            query += f" LIMIT {limit}"
+        
+        result = await session.execute(text(query))
+        rows = result.fetchall()
+    
+    total = len(rows)
+    logger.info(f"[BACKFILL] Found {total} sources with NULL resolved_url to process")
+    
+    if dry_run:
+        logger.info("[BACKFILL] DRY RUN - no changes will be made")
+        return {
+            "dry_run": True,
+            "total": total,
+            "resolved": 0,
+            "failed": 0,
+            "skipped": 0,
+        }
+    
+    resolved = 0
+    failed = 0
+    
+    for source_id, google_news_url in rows:
+        try:
+            # Try to resolve the URL (blocking call, run off event loop)
+            resolved_url = await asyncio.to_thread(resolve_google_news_url, google_news_url)
+            
+            if resolved_url:
+                # Update the database with the resolved URL
+                async with async_session_maker() as session:
+                    await session.execute(
+                        text("""
+                            UPDATE source_google_news 
+                            SET resolved_url = :resolved_url, updated_at = CURRENT_TIMESTAMP
+                            WHERE id = :id
+                        """),
+                        {"id": source_id, "resolved_url": resolved_url},
+                    )
+                    await session.commit()
+                
+                logger.debug(f"[BACKFILL] Source {source_id}: resolved -> {resolved_url[:60]}...")
+                resolved += 1
+            else:
+                logger.debug(f"[BACKFILL] Source {source_id}: resolution failed (decoder returned None)")
+                failed += 1
+        
+        except Exception as e:
+            logger.error(f"[BACKFILL] Source {source_id}: error during resolution: {e}")
+            failed += 1
+    
+    logger.info(
+        f"[BACKFILL] Complete: {resolved} resolved, {failed} failed (out of {total} total)"
+    )
+    
+    return {
+        "dry_run": False,
+        "total": total,
+        "resolved": resolved,
+        "failed": failed,
+        "skipped": 0,
+    }

--- a/backend/tests/test_download_null_resolved_url.py
+++ b/backend/tests/test_download_null_resolved_url.py
@@ -1,0 +1,145 @@
+"""Test download behavior when resolved_url is NULL.
+
+Issue #171: download_classified_sources skips ready_for_download rows
+that have resolved_url=NULL but google_news_url present.
+
+Root cause: resolve_google_news_url can return None (decoder failure),
+ingest still inserts the source, classify marks ready_for_download,
+but download filters WHERE resolved_url IS NOT NULL.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlmodel import SQLModel
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.models.source_google_news import SourceGoogleNews, SourceStatus
+from app.services.download import download_classified_sources
+
+
+class _TestSessionMaker:
+    """Test session maker for mocking."""
+    
+    def __init__(self, session):
+        self._session = session
+    
+    def __call__(self):
+        return self
+    
+    async def __aenter__(self):
+        return self._session
+    
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+@pytest.fixture
+async def test_db():
+    """Create an in-memory test database."""
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        echo=False,
+        future=True,
+    )
+    
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    
+    async with AsyncSession(engine) as session:
+        yield session
+    
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_download_skips_null_resolved_url(test_db):
+    """
+    RED TEST: Verify the bug exists.
+    
+    When a source has:
+    - status = ready_for_download
+    - resolved_url = NULL
+    - google_news_url present
+    
+    download_classified_sources should process it, but currently skips it
+    due to the WHERE resolved_url IS NOT NULL filter.
+    """
+    # Create a source that simulates decoder failure:
+    # resolved_url is NULL but google_news_url is present
+    source = SourceGoogleNews(
+        google_news_id="test-null-resolved",
+        google_news_url="https://news.google.com/articles/test123",
+        resolved_url=None,  # Decoder returned None
+        headline="Homem é morto a tiros em operação policial",
+        status=SourceStatus.ready_for_download,
+        is_violent_death=True,
+    )
+    
+    test_db.add(source)
+    await test_db.commit()
+    await test_db.refresh(source)
+    
+    # Mock the download flow to prevent actual HTTP calls
+    maker = _TestSessionMaker(test_db)
+    html = "<html><body>Homem foi morto durante operação policial.</body></html>"
+    content = "Homem foi morto durante operação policial."
+    
+    with (
+        patch("app.services.download.async_session_maker", maker),
+        patch("app.services.diagnostics.async_session_maker", maker),
+        patch("app.services.download._fetch_html", new=AsyncMock(return_value=(200, html))),
+        patch("app.services.download.extract_content_and_metadata", return_value=(content, None)),
+        patch("app.services.download.classify_article_content", new=AsyncMock()),
+        patch("app.services.download.passes_content_gate", return_value=True),
+        patch("app.services.diagnostics.record_attempt", new=AsyncMock()),
+    ):
+        result = await download_classified_sources(limit=10)
+    
+    # THE BUG: This should process 1 source, but currently processes 0
+    # because the SQL filter excludes rows with resolved_url IS NULL
+    assert result["processed"] == 1, (
+        f"Expected to process 1 source with NULL resolved_url, "
+        f"but got {result['processed']}. This is the bug from issue #171."
+    )
+
+
+@pytest.mark.asyncio
+async def test_download_with_resolved_url_works(test_db):
+    """
+    CONTROL: Verify normal case still works.
+    
+    When a source has resolved_url set, it should be processed normally.
+    """
+    source = SourceGoogleNews(
+        google_news_id="test-with-resolved",
+        google_news_url="https://news.google.com/articles/test456",
+        resolved_url="https://example.com/article",  # Decoder succeeded
+        headline="Tiroteio deixa dois mortos na Zona Norte",
+        status=SourceStatus.ready_for_download,
+        is_violent_death=True,
+    )
+    
+    test_db.add(source)
+    await test_db.commit()
+    await test_db.refresh(source)
+    
+    maker = _TestSessionMaker(test_db)
+    html = "<html><body>Dois mortos em tiroteio.</body></html>"
+    content = "Dois mortos em tiroteio."
+    
+    with (
+        patch("app.services.download.async_session_maker", maker),
+        patch("app.services.diagnostics.async_session_maker", maker),
+        patch("app.services.download._fetch_html", new=AsyncMock(return_value=(200, html))),
+        patch("app.services.download.extract_content_and_metadata", return_value=(content, None)),
+        patch("app.services.download.classify_article_content", new=AsyncMock()),
+        patch("app.services.download.passes_content_gate", return_value=True),
+        patch("app.services.diagnostics.record_attempt", new=AsyncMock()),
+    ):
+        result = await download_classified_sources(limit=10)
+    
+    # This should work (and does work currently)
+    assert result["processed"] == 1
+    assert result["successful"] == 1

--- a/backend/tests/test_download_null_resolved_url.py
+++ b/backend/tests/test_download_null_resolved_url.py
@@ -54,24 +54,24 @@ async def test_db():
 
 
 @pytest.mark.asyncio
-async def test_download_skips_null_resolved_url(test_db):
+async def test_download_processes_null_resolved_url_with_late_resolution_success(test_db):
     """
-    RED TEST: Verify the bug exists.
+    Test that sources with NULL resolved_url are processed when late resolution succeeds.
     
     When a source has:
     - status = ready_for_download
-    - resolved_url = NULL
+    - resolved_url = NULL (initial decoder failure)
     - google_news_url present
     
-    download_classified_sources should process it, but currently skips it
-    due to the WHERE resolved_url IS NOT NULL filter.
+    And late resolution succeeds, the source should be:
+    - Processed (processed==1)
+    - resolved_url persisted to database
+    - Downloaded from the resolved URL
     """
-    # Create a source that simulates decoder failure:
-    # resolved_url is NULL but google_news_url is present
     source = SourceGoogleNews(
-        google_news_id="test-null-resolved",
+        google_news_id="test-null-resolved-success",
         google_news_url="https://news.google.com/articles/test123",
-        resolved_url=None,  # Decoder returned None
+        resolved_url=None,  # Initial decoder failure
         headline="Homem é morto a tiros em operação policial",
         status=SourceStatus.ready_for_download,
         is_violent_death=True,
@@ -81,14 +81,15 @@ async def test_download_skips_null_resolved_url(test_db):
     await test_db.commit()
     await test_db.refresh(source)
     
-    # Mock the download flow to prevent actual HTTP calls
     maker = _TestSessionMaker(test_db)
     html = "<html><body>Homem foi morto durante operação policial.</body></html>"
     content = "Homem foi morto durante operação policial."
+    resolved_url_result = "https://example.com/article-resolved"
     
     with (
         patch("app.services.download.async_session_maker", maker),
         patch("app.services.diagnostics.async_session_maker", maker),
+        patch("app.services.ingestion.resolve_google_news_url", return_value=resolved_url_result) as mock_resolve,
         patch("app.services.download._fetch_html", new=AsyncMock(return_value=(200, html))),
         patch("app.services.download.extract_content_and_metadata", return_value=(content, None)),
         patch("app.services.download.classify_article_content", new=AsyncMock()),
@@ -97,11 +98,72 @@ async def test_download_skips_null_resolved_url(test_db):
     ):
         result = await download_classified_sources(limit=10)
     
-    # THE BUG: This should process 1 source, but currently processes 0
-    # because the SQL filter excludes rows with resolved_url IS NULL
+    # Should process 1 source
+    assert result["processed"] == 1, f"Expected 1 processed, got {result['processed']}"
+    assert result["successful"] == 1, f"Expected 1 successful, got {result['successful']}"
+    
+    # Verify resolved_url was persisted
+    await test_db.refresh(source)
+    assert source.resolved_url == resolved_url_result, (
+        f"Expected resolved_url to be persisted as {resolved_url_result}, "
+        f"but got {source.resolved_url}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_download_processes_null_resolved_url_with_late_resolution_failure(test_db):
+    """
+    Test that sources with NULL resolved_url are still processed when late resolution fails.
+    
+    When a source has:
+    - status = ready_for_download
+    - resolved_url = NULL (initial decoder failure)
+    - google_news_url present
+    
+    And late resolution ALSO fails (returns None), the source should:
+    - Still be processed (processed==1) via fallback to google_news_url
+    - NOT skip the source
+    """
+    source = SourceGoogleNews(
+        google_news_id="test-null-resolved-failure",
+        google_news_url="https://news.google.com/articles/test456",
+        resolved_url=None,  # Initial decoder failure
+        headline="Tiroteio deixa dois mortos na Zona Norte",
+        status=SourceStatus.ready_for_download,
+        is_violent_death=True,
+    )
+    
+    test_db.add(source)
+    await test_db.commit()
+    await test_db.refresh(source)
+    
+    maker = _TestSessionMaker(test_db)
+    html = "<html><body>Dois mortos em tiroteio.</body></html>"
+    content = "Dois mortos em tiroteio."
+    
+    with (
+        patch("app.services.download.async_session_maker", maker),
+        patch("app.services.diagnostics.async_session_maker", maker),
+        patch("app.services.ingestion.resolve_google_news_url", return_value=None) as mock_resolve,  # Late resolution also fails
+        patch("app.services.download._fetch_html", new=AsyncMock(return_value=(200, html))),
+        patch("app.services.download.extract_content_and_metadata", return_value=(content, None)),
+        patch("app.services.download.classify_article_content", new=AsyncMock()),
+        patch("app.services.download.passes_content_gate", return_value=True),
+        patch("app.services.diagnostics.record_attempt", new=AsyncMock()),
+    ):
+        result = await download_classified_sources(limit=10)
+    
+    # Should still process 1 source (fallback to google_news_url)
     assert result["processed"] == 1, (
-        f"Expected to process 1 source with NULL resolved_url, "
-        f"but got {result['processed']}. This is the bug from issue #171."
+        f"Expected 1 processed via fallback to google_news_url, got {result['processed']}"
+    )
+    assert result["successful"] == 1, f"Expected 1 successful, got {result['successful']}"
+    
+    # Verify resolved_url is still NULL (late resolution failed)
+    await test_db.refresh(source)
+    assert source.resolved_url is None, (
+        f"Expected resolved_url to remain NULL when late resolution fails, "
+        f"but got {source.resolved_url}"
     )
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 📝 Descrição

Corrige o bug onde `download_classified_sources` ignora fontes `ready_for_download` que têm `resolved_url=NULL` mas `google_news_url` presente. Aproximadamente 500 registros estavam presos neste estado no ambiente de staging.

### Causa Raiz
- `resolve_google_news_url` pode retornar `None` quando o `googlenewsdecoder` falha
- Ingest ainda insere a fonte com `resolved_url=NULL`
- Classify marca como `ready_for_download`
- Download filtra com `WHERE resolved_url IS NOT NULL`, pulando esses registros

### Solução Implementada (Opção A)
**Resolver no momento do download usando fallback para google_news_url:**
- Alterado filtro SQL de `resolved_url IS NOT NULL` para `google_news_url IS NOT NULL`
- Adicionada resolução tardia em `download_source_content` quando `resolved_url` é NULL
- Persiste URL resolvida para evitar re-resolução
- Usa `google_news_url` como fallback se resolução tardia também falhar

### Caminho de Backfill
- Adicionada função `backfill_null_resolved_urls()` no serviço de manutenção
- Endpoint `/api/pipeline/backfill-null-resolved-urls` para executar o backfill
- Use `dry_run=true` para visualizar contagem antes de executar
- Necessário para limpar os ~500 registros presos no staging

## 🔗 Issue Relacionada

Fixes #171

## 🏷️ Tipo de Mudança

- [x] 🐛 Bug fix (mudança que corrige um problema)
- [ ] ✨ Nova feature (mudança que adiciona funcionalidade)
- [ ] 💥 Breaking change (fix ou feature que causaria quebra de funcionalidade existente)
- [ ] 📚 Documentação (mudança apenas em documentação)
- [ ] 🎨 Estilo (formatação, ponto e vírgula, etc - sem mudança de código)
- [ ] ♻️ Refatoração (mudança de código sem alterar funcionalidade)
- [ ] ⚡ Performance (mudança que melhora performance)
- [x] ✅ Testes (adição ou correção de testes)
- [ ] 🔧 Chore (atualizações de build, CI, etc)

## 🧪 Como Foi Testado?

- [x] Testes unitários
- [ ] Testes de integração
- [ ] Testes manuais
- [x] Testado em desenvolvimento local
- [x] Testado com Docker

**Testes adicionados (TDD):**

1. **`test_download_processes_null_resolved_url_with_late_resolution_success`**
   - Mock: `resolve_google_news_url` retorna URL resolvida
   - Verifica: `processed==1`, `resolved_url` persistida no banco

2. **`test_download_processes_null_resolved_url_with_late_resolution_failure`**
   - Mock: `resolve_google_news_url` retorna `None` (falha também na resolução tardia)
   - Verifica: `processed==1` via fallback para `google_news_url`, `resolved_url` permanece NULL

3. **`test_download_with_resolved_url_works`**
   - Teste de controle: caso normal com `resolved_url` definida

**Comando de teste executado:**
```bash
cd /workspace/backend
source .venv/bin/activate
python -m pytest tests/test_download_null_resolved_url.py -v --tb=short
```

**Resultado:**
```
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-9.1.1, pluggy-1.6.0
tests/test_download_null_resolved_url.py::test_download_processes_null_resolved_url_with_late_resolution_success PASSED [ 33%]
tests/test_download_null_resolved_url.py::test_download_processes_null_resolved_url_with_late_resolution_failure PASSED [ 66%]
tests/test_download_null_resolved_url.py::test_download_with_resolved_url_works PASSED [100%]

========================= 3 passed in 0.44s =========================
```

✅ **Todos os testes passam** - Nenhuma chamada ao `googlenewsdecoder` real (HTTP totalmente mockado)

## 📸 Screenshots (se aplicável)

N/A - Mudança no backend sem impacto visual

## ✅ Checklist

- [x] Meu código segue o guia de estilo do projeto
- [x] Realizei uma auto-revisão do meu código
- [x] Comentei meu código em áreas complexas
- [ ] Atualizei a documentação correspondente
- [x] Minhas mudanças não geram novos warnings
- [x] Adicionei testes que provam que meu fix/feature funciona
- [x] Testes unitários novos e existentes passam localmente
- [x] Quaisquer mudanças dependentes foram mergeadas
- [ ] Atualizei o CHANGELOG (se aplicável)

## 📚 Documentação

- [x] Docstrings/comentários no código
- [ ] README.md
- [ ] CONTRIBUTING.md
- [ ] API documentation
- [ ] Outro:

## 🔍 Arquivos Modificados

```
backend/app/routers/pipeline.py
backend/app/services/download.py
backend/app/services/maintenance.py
backend/tests/test_download_null_resolved_url.py
```

**Total:** 4 arquivos (3 de produção, 1 de testes)

## 💬 Notas Adicionais

### Após Deploy para Staging:
1. Execute o backfill com dry_run primeiro:
   ```bash
   curl -X POST "https://staging.arquivodaviolencia.com.br/api/pipeline/backfill-null-resolved-urls?dry_run=true" \
     -H "Authorization: Bearer $TOKEN"
   ```

2. Execute o backfill real:
   ```bash
   curl -X POST "https://staging.arquivodaviolencia.com.br/api/pipeline/backfill-null-resolved-urls" \
     -H "Authorization: Bearer $TOKEN"
   ```

3. Verifique que:
   - Registros com `ready_for_download` + NULL `resolved_url` diminuem
   - `download.processed > 0` em backlog subsequente
   - `QueuePool_errors` permanecem em 0

### Decisão de Design (Por que Opção A?)
Escolhi a **opção (a) - resolver no momento do download** porque:
- ✅ Menos invasiva - não altera lógica de classificação
- ✅ Trata automaticamente registros existentes presos
- ✅ Download já tinha lógica para usar `resolved_url` OR `google_news_url`
- ✅ Não requer mudanças no ingest ou classify
- ❌ Alternativas (b) e (c) exigiriam mais mudanças e retry complexo

---

**⚠️ PR pronto para revisão. Não fazer merge para master - apenas para develop conforme workflow especificado.**
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-12bdc1a6-3547-4d3c-acc2-3f44c19629e1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-12bdc1a6-3547-4d3c-acc2-3f44c19629e1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

