### PR TITLE
Add IBGE municipality codes to UniqueEvent (issue #174)

### DIFF
--- a/backend/alembic/versions/k0l1m2n3o4p5_add_municipality_code_to_unique_event.py
+++ b/backend/alembic/versions/k0l1m2n3o4p5_add_municipality_code_to_unique_event.py
@@ -1,0 +1,32 @@
+"""add_municipality_code_to_unique_event
+
+Revision ID: k0l1m2n3o4p5
+Revises: j9k0l1m2n3o4
+Create Date: 2026-08-25 12:30:00.000000
+
+Add municipality_code field to unique_event table to store 7-digit IBGE
+municipal codes for Brazilian municipalities (issue #174).
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'k0l1m2n3o4p5'
+down_revision: Union[str, Sequence[str], None] = 'j9k0l1m2n3o4'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add municipality_code field to unique_event."""
+    op.add_column('unique_event', sa.Column('municipality_code', sa.Integer(), nullable=True))
+    op.create_index(op.f('ix_unique_event_municipality_code'), 'unique_event', ['municipality_code'], unique=False)
+
+
+def downgrade() -> None:
+    """Remove municipality_code field from unique_event."""
+    op.drop_index(op.f('ix_unique_event_municipality_code'), table_name='unique_event')
+    op.drop_column('unique_event', 'municipality_code')

--- a/backend/app/models/unique_event.py
+++ b/backend/app/models/unique_event.py
@@ -28,6 +28,7 @@ class UniqueEventBase(SQLModel):
     country: str | None = Field(default="BR", max_length=100)
     state: str | None = Field(default=None, max_length=50, index=True)
     city: str | None = Field(default=None, max_length=100, index=True)
+    municipality_code: int | None = Field(default=None, index=True, description="7-digit IBGE municipal code for Brazilian municipalities")
     neighborhood: str | None = Field(default=None, max_length=100)
     street: str | None = Field(default=None, max_length=256)
     establishment: str | None = Field(default=None, max_length=256)

--- a/backend/app/services/geocoding.py
+++ b/backend/app/services/geocoding.py
@@ -502,6 +502,23 @@ async def geocode_unique_event(
 
 async def _persist_geocode(unique_event_id: int, fields: dict) -> None:
     async with async_session_maker() as session:
+        # First get the event's city, state, and country for municipality code lookup
+        result = await session.execute(
+            text("SELECT city, state, country FROM unique_event WHERE id = :id"),
+            {"id": unique_event_id},
+        )
+        event_data = result.fetchone()
+        
+        # Look up municipality code for Brazilian cities
+        municipality_code = None
+        if event_data and event_data[2] in ("BR", "Brasil", None):  # country is BR, Brasil, or NULL (default BR)
+            city = event_data[0]
+            state = event_data[1]
+            if city and state:
+                from app.services.ibge_population import lookup_city_codes
+                codes = await lookup_city_codes(session, cities=[city], states=[state])
+                municipality_code = codes.get((city, state))
+        
         await session.execute(
             text("""
                 UPDATE unique_event
@@ -513,6 +530,7 @@ async def _persist_geocode(unique_event_id: int, fields: dict) -> None:
                     location_precision = :location_precision,
                     geocoding_confidence = :geocoding_confidence,
                     geocoding_source = :geocoding_source,
+                    municipality_code = :municipality_code,
                     updated_at = CURRENT_TIMESTAMP
                 WHERE id = :id
             """),
@@ -526,6 +544,7 @@ async def _persist_geocode(unique_event_id: int, fields: dict) -> None:
                 "location_precision": fields.get("location_precision"),
                 "geocoding_confidence": fields.get("geocoding_confidence"),
                 "geocoding_source": fields.get("geocoding_source"),
+                "municipality_code": municipality_code,
             },
         )
         await session.commit()

--- a/backend/app/services/municipality_codes.py
+++ b/backend/app/services/municipality_codes.py
@@ -52,7 +52,7 @@ async def backfill_municipality_codes(
         SELECT id, city, state, country
         FROM unique_event
         WHERE municipality_code IS NULL
-          AND country IN ('BR', 'Brasil') OR country IS NULL
+          AND (country IN ('BR', 'Brasil') OR country IS NULL)
           AND city IS NOT NULL
           AND state IS NOT NULL
         ORDER BY id
@@ -148,8 +148,8 @@ async def backfill_municipality_codes(
         text("""
             SELECT COUNT(*) FROM unique_event
             WHERE municipality_code IS NULL
-              AND country NOT IN ('BR', 'Brasil')
               AND country IS NOT NULL
+              AND country NOT IN ('BR', 'Brasil')
         """)
     )
     skipped_non_brazil = result.scalar()

--- a/backend/app/services/municipality_codes.py
+++ b/backend/app/services/municipality_codes.py
@@ -1,0 +1,163 @@
+"""
+Municipality code backfill service for existing UniqueEvents (issue #174).
+
+This module provides functions to backfill IBGE municipality codes for existing
+UniqueEvents that were geocoded before the municipality_code field existed.
+
+Only Brazilian municipalities get codes. Ambiguous city names (no state) are
+skipped - we do not guess.
+"""
+
+from typing import Dict
+from sqlmodel.ext.asyncio.session import AsyncSession
+from sqlalchemy import text
+from loguru import logger
+
+from app.services.ibge_population import lookup_city_codes
+
+
+async def backfill_municipality_codes(
+    session: AsyncSession,
+    limit: int | None = None
+) -> Dict[str, int]:
+    """
+    Backfill municipality_code for existing UniqueEvents that lack it.
+    
+    Only updates events where:
+    - municipality_code IS NULL
+    - country is BR, Brasil, or NULL (default BR)
+    - city AND state are both present (unambiguous)
+    - city+state uniquely resolve to an IBGE code
+    
+    Does NOT guess codes for:
+    - Events with city but no state (ambiguous)
+    - Non-Brazilian events (Chile, etc.)
+    - Events where the city name is not in the IBGE database
+    
+    Args:
+        session: Database session
+        limit: Maximum number of events to backfill (for batching)
+    
+    Returns:
+        Dictionary with counts: {
+            "updated": int,
+            "skipped_no_city": int,
+            "skipped_no_state": int,
+            "skipped_non_brazil": int,
+            "skipped_not_found": int,
+        }
+    """
+    # Find events that need codes: Brazilian events with city+state but no code
+    query = text("""
+        SELECT id, city, state, country
+        FROM unique_event
+        WHERE municipality_code IS NULL
+          AND country IN ('BR', 'Brasil') OR country IS NULL
+          AND city IS NOT NULL
+          AND state IS NOT NULL
+        ORDER BY id
+    """)
+    
+    if limit:
+        query = text(str(query) + f" LIMIT {limit}")
+    
+    result = await session.execute(query)
+    events = result.fetchall()
+    
+    if not events:
+        logger.info("[Backfill] No events to backfill")
+        return {
+            "updated": 0,
+            "skipped_no_city": 0,
+            "skipped_no_state": 0,
+            "skipped_non_brazil": 0,
+            "skipped_not_found": 0,
+        }
+    
+    logger.info(f"[Backfill] Found {len(events)} events to process")
+    
+    # Build unique list of (city, state) pairs to lookup
+    city_state_pairs = set()
+    for event in events:
+        city = event[1]
+        state = event[2]
+        if city and state:
+            city_state_pairs.add((city, state))
+    
+    # Batch lookup all codes
+    cities = [pair[0] for pair in city_state_pairs]
+    states = [pair[1] for pair in city_state_pairs]
+    code_map = await lookup_city_codes(session, cities=cities, states=states)
+    
+    logger.info(f"[Backfill] Resolved {len(code_map)} municipality codes")
+    
+    # Update events
+    updated = 0
+    not_found = 0
+    
+    for event in events:
+        event_id = event[0]
+        city = event[1]
+        state = event[2]
+        
+        code = code_map.get((city, state))
+        if code:
+            await session.execute(
+                text("""
+                    UPDATE unique_event
+                    SET municipality_code = :code,
+                        updated_at = CURRENT_TIMESTAMP
+                    WHERE id = :id
+                """),
+                {"id": event_id, "code": code}
+            )
+            updated += 1
+        else:
+            not_found += 1
+    
+    await session.commit()
+    
+    logger.info(f"[Backfill] ✅ Updated {updated} events, {not_found} not found in IBGE database")
+    
+    # Now count the skipped categories
+    # Events with no city
+    result = await session.execute(
+        text("""
+            SELECT COUNT(*) FROM unique_event
+            WHERE municipality_code IS NULL
+              AND (country IN ('BR', 'Brasil') OR country IS NULL)
+              AND city IS NULL
+        """)
+    )
+    skipped_no_city = result.scalar()
+    
+    # Events with no state
+    result = await session.execute(
+        text("""
+            SELECT COUNT(*) FROM unique_event
+            WHERE municipality_code IS NULL
+              AND (country IN ('BR', 'Brasil') OR country IS NULL)
+              AND city IS NOT NULL
+              AND state IS NULL
+        """)
+    )
+    skipped_no_state = result.scalar()
+    
+    # Non-Brazilian events
+    result = await session.execute(
+        text("""
+            SELECT COUNT(*) FROM unique_event
+            WHERE municipality_code IS NULL
+              AND country NOT IN ('BR', 'Brasil')
+              AND country IS NOT NULL
+        """)
+    )
+    skipped_non_brazil = result.scalar()
+    
+    return {
+        "updated": updated,
+        "skipped_no_city": skipped_no_city or 0,
+        "skipped_no_state": skipped_no_state or 0,
+        "skipped_non_brazil": skipped_non_brazil or 0,
+        "skipped_not_found": not_found,
+    }

--- a/backend/tests/test_municipality_codes.py
+++ b/backend/tests/test_municipality_codes.py
@@ -11,6 +11,22 @@ from app.services.ibge_population import load_ibge_population_fixture, lookup_ci
 from app.services.geocoding import geocode_unique_event
 
 
+class _TestSessionMaker:
+    """Test session maker wrapper for patching async_session_maker."""
+    
+    def __init__(self, session):
+        self._session = session
+    
+    def __call__(self):
+        return self
+    
+    async def __aenter__(self):
+        return self._session
+    
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
 @pytest.mark.asyncio
 async def test_lookup_city_codes_returns_official_code(async_session):
     """
@@ -129,8 +145,14 @@ async def test_geocode_stores_municipality_code_for_brazilian_city(async_session
     mock_client = AsyncMock()
     mock_client.get = AsyncMock(return_value=mock_response)
     
+    # Patch async_session_maker to use test session
+    maker = _TestSessionMaker(async_session)
+    
     # Geocode the event
-    with patch("app.services.geocoding.get_settings") as mock_settings:
+    with (
+        patch("app.services.geocoding.async_session_maker", maker),
+        patch("app.services.geocoding.get_settings") as mock_settings,
+    ):
         mock_settings.return_value.google_maps_api_key = "test-key"
         success = await geocode_unique_event(event.id, client=mock_client)
     
@@ -180,8 +202,14 @@ async def test_geocode_no_code_for_chile_cities(async_session):
     mock_client = AsyncMock()
     mock_client.get = AsyncMock(return_value=mock_response)
     
+    # Patch async_session_maker to use test session
+    maker = _TestSessionMaker(async_session)
+    
     # Geocode the event
-    with patch("app.services.geocoding.get_settings") as mock_settings:
+    with (
+        patch("app.services.geocoding.async_session_maker", maker),
+        patch("app.services.geocoding.get_settings") as mock_settings,
+    ):
         mock_settings.return_value.google_maps_api_key = "test-key"
         success = await geocode_unique_event(event.id, client=mock_client)
     

--- a/backend/tests/test_municipality_codes.py
+++ b/backend/tests/test_municipality_codes.py
@@ -263,6 +263,69 @@ async def test_backfill_municipality_codes_for_existing_events(async_session):
 
 
 @pytest.mark.asyncio
+async def test_backfill_does_not_update_non_brazil_events(async_session):
+    """
+    Test that backfill does NOT update events from other countries (CL, CO, etc).
+    
+    Regression test for SQL operator precedence bug where OR/AND without
+    parentheses could pick up non-Brazil rows.
+    """
+    # Load IBGE fixture (Brazil codes only)
+    await load_ibge_population_fixture(async_session)
+    
+    # Create a Chilean event with city+state
+    event_cl = UniqueEvent(
+        city="Santiago",
+        state="Metropolitana",
+        country="CL",
+        event_family="homicidio",
+        municipality_code=None
+    )
+    
+    # Create a Colombian event with city+state
+    event_co = UniqueEvent(
+        city="Bogotá",
+        state="Cundinamarca",
+        country="CO",
+        event_family="homicidio",
+        municipality_code=None
+    )
+    
+    # Create a Brazilian event with city+state (should get code)
+    event_br = UniqueEvent(
+        city="Rio de Janeiro",
+        state="RJ",
+        country="BR",
+        event_family="homicidio",
+        municipality_code=None
+    )
+    
+    async_session.add_all([event_cl, event_co, event_br])
+    await async_session.commit()
+    
+    from app.services.municipality_codes import backfill_municipality_codes
+    
+    # Run backfill
+    result = await backfill_municipality_codes(async_session)
+    
+    # Refresh events
+    await async_session.refresh(event_cl)
+    await async_session.refresh(event_co)
+    await async_session.refresh(event_br)
+    
+    # Non-Brazil events should NOT get codes
+    assert event_cl.municipality_code is None, "Chilean event should not get IBGE code"
+    assert event_co.municipality_code is None, "Colombian event should not get IBGE code"
+    
+    # Brazilian event SHOULD get the official code
+    assert event_br.municipality_code == 3304557, "Rio de Janeiro should get code 3304557"
+    
+    # Verify counts
+    assert result["updated"] == 1, "Only the Brazilian event should be updated"
+    assert result["skipped_non_brazil"] >= 2, "Should skip at least CL and CO events"
+
+
+@pytest.mark.asyncio
 async def test_backfill_handles_ambiguous_city_names(async_session):
     """
     Test that backfill does NOT invent codes for ambiguous city names.

--- a/backend/tests/test_municipality_codes.py
+++ b/backend/tests/test_municipality_codes.py
@@ -1,0 +1,332 @@
+"""Tests for IBGE municipality code lookup and backfill (issue #174)."""
+
+import pytest
+from unittest.mock import AsyncMock, patch
+from sqlmodel import select
+from sqlalchemy import text
+
+from app.models.unique_event import UniqueEvent
+from app.models.ibge_population import IBGEPopulation
+from app.services.ibge_population import load_ibge_population_fixture, lookup_city_codes
+from app.services.geocoding import geocode_unique_event
+
+
+@pytest.mark.asyncio
+async def test_lookup_city_codes_returns_official_code(async_session):
+    """
+    Test that lookup_city_codes returns the correct 7-digit IBGE code for a
+    unique city+state pair.
+    
+    Fixture includes Rio de Janeiro, RJ → 3304557.
+    """
+    # Load fixture data (includes Rio de Janeiro = 3304557)
+    await load_ibge_population_fixture(async_session)
+    
+    # Lookup Rio de Janeiro
+    result = await lookup_city_codes(
+        async_session,
+        cities=["Rio de Janeiro"],
+        states=["RJ"]
+    )
+    
+    assert ("Rio de Janeiro", "RJ") in result
+    assert result[("Rio de Janeiro", "RJ")] == 3304557
+
+
+@pytest.mark.asyncio
+async def test_lookup_city_codes_handles_ambiguous_cities(async_session):
+    """
+    Test that cities with the same name in different states are detected.
+    
+    We add two cities named "Teste" in different states (SP and RJ).
+    The lookup should only return a code when the city+state pair is unique.
+    """
+    # Add two cities with the same name in different states
+    city_sp = IBGEPopulation(
+        code_muni=3500001,
+        code_state="35",
+        name_muni="Teste",
+        name_state="São Paulo",
+        abbrev_state="SP",
+        population=10000,
+        year=2022,
+        source="Test fixture"
+    )
+    city_rj = IBGEPopulation(
+        code_muni=3300001,
+        code_state="33",
+        name_muni="Teste",
+        name_state="Rio de Janeiro",
+        abbrev_state="RJ",
+        population=15000,
+        year=2022,
+        source="Test fixture"
+    )
+    async_session.add(city_sp)
+    async_session.add(city_rj)
+    await async_session.commit()
+    
+    # Lookup Teste, SP - should return SP code
+    result_sp = await lookup_city_codes(
+        async_session,
+        cities=["Teste"],
+        states=["SP"]
+    )
+    assert ("Teste", "SP") in result_sp
+    assert result_sp[("Teste", "SP")] == 3500001
+    
+    # Lookup Teste, RJ - should return RJ code
+    result_rj = await lookup_city_codes(
+        async_session,
+        cities=["Teste"],
+        states=["RJ"]
+    )
+    assert ("Teste", "RJ") in result_rj
+    assert result_rj[("Teste", "RJ")] == 3300001
+    
+    # Both lookups should succeed because city+state pairs are unique
+
+
+@pytest.mark.asyncio
+async def test_geocode_stores_municipality_code_for_brazilian_city(async_session):
+    """
+    Test that when a UniqueEvent is geocoded for a Brazilian municipality,
+    the municipality_code field is populated with the 7-digit IBGE code.
+    
+    Uses Rio de Janeiro as the test case (code 3304557).
+    """
+    # Load IBGE fixture (includes Rio de Janeiro = 3304557)
+    await load_ibge_population_fixture(async_session)
+    
+    # Create a UniqueEvent with Rio de Janeiro location
+    event = UniqueEvent(
+        city="Rio de Janeiro",
+        state="RJ",
+        country="BR",
+        event_family="homicidio"
+    )
+    async_session.add(event)
+    await async_session.commit()
+    await async_session.refresh(event)
+    
+    # Mock Google Maps API response
+    from unittest.mock import Mock
+    mock_response = Mock()
+    mock_response.raise_for_status = Mock()
+    mock_response.json = Mock(return_value={
+        "status": "OK",
+        "results": [{
+            "formatted_address": "Rio de Janeiro, RJ, Brasil",
+            "geometry": {
+                "location": {"lat": -22.9068, "lng": -43.1729},
+                "location_type": "APPROXIMATE",
+            },
+            "place_id": "ChIJW6AIkVXemwARTtIvZ2xC3FA",
+            "types": ["locality", "political"],
+        }],
+    })
+    
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_response)
+    
+    # Geocode the event
+    with patch("app.services.geocoding.get_settings") as mock_settings:
+        mock_settings.return_value.google_maps_api_key = "test-key"
+        success = await geocode_unique_event(event.id, client=mock_client)
+    
+    assert success is True
+    
+    # Verify the municipality_code was set
+    await async_session.refresh(event)
+    assert event.municipality_code == 3304557, f"Expected 3304557, got {event.municipality_code}"
+    assert event.city == "Rio de Janeiro"
+    assert event.state == "RJ"
+    assert event.latitude is not None
+
+
+@pytest.mark.asyncio
+async def test_geocode_no_code_for_chile_cities(async_session):
+    """
+    Test that Chilean cities do not get a municipality_code (Brazil only).
+    """
+    # Create a UniqueEvent with Chilean location
+    event = UniqueEvent(
+        city="Santiago",
+        state="Metropolitana",
+        country="CL",
+        event_family="homicidio"
+    )
+    async_session.add(event)
+    await async_session.commit()
+    await async_session.refresh(event)
+    
+    # Mock Google Maps API response for Santiago, Chile
+    from unittest.mock import Mock
+    mock_response = Mock()
+    mock_response.raise_for_status = Mock()
+    mock_response.json = Mock(return_value={
+        "status": "OK",
+        "results": [{
+            "formatted_address": "Santiago, Región Metropolitana, Chile",
+            "geometry": {
+                "location": {"lat": -33.4489, "lng": -70.6693},
+                "location_type": "APPROXIMATE",
+            },
+            "place_id": "ChIJL68lS64hYpYRhB07b0sMDUw",
+            "types": ["locality", "political"],
+        }],
+    })
+    
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_response)
+    
+    # Geocode the event
+    with patch("app.services.geocoding.get_settings") as mock_settings:
+        mock_settings.return_value.google_maps_api_key = "test-key"
+        success = await geocode_unique_event(event.id, client=mock_client)
+    
+    assert success is True
+    
+    # Verify NO municipality_code was set (Chile, not Brazil)
+    await async_session.refresh(event)
+    assert event.municipality_code is None
+    assert event.country == "CL"
+    assert event.latitude is not None
+
+
+@pytest.mark.asyncio
+async def test_backfill_municipality_codes_for_existing_events(async_session):
+    """
+    Test that existing UniqueEvents without municipality_code get codes
+    backfilled when city+state uniquely resolve to an IBGE code.
+    
+    Tests the backfill path separate from the geocode path.
+    """
+    # Load IBGE fixture
+    await load_ibge_population_fixture(async_session)
+    
+    # Create existing events without municipality_code but with city+state
+    event1 = UniqueEvent(
+        city="Rio de Janeiro",
+        state="RJ",
+        country="BR",
+        event_family="homicidio",
+        municipality_code=None  # Missing code
+    )
+    event2 = UniqueEvent(
+        city="São Paulo",
+        state="SP",
+        country="BR",
+        event_family="homicidio",
+        municipality_code=None  # Missing code
+    )
+    # Event with no city - should not get a code
+    event3 = UniqueEvent(
+        city=None,
+        state="RJ",
+        country="BR",
+        event_family="homicidio",
+        municipality_code=None
+    )
+    # Chilean event - should not get a code
+    event4 = UniqueEvent(
+        city="Santiago",
+        state="Metropolitana",
+        country="CL",
+        event_family="homicidio",
+        municipality_code=None
+    )
+    
+    async_session.add_all([event1, event2, event3, event4])
+    await async_session.commit()
+    
+    # Import the backfill function (will be implemented)
+    from app.services.municipality_codes import backfill_municipality_codes
+    
+    # Run backfill
+    result = await backfill_municipality_codes(async_session)
+    
+    # Verify the results
+    await async_session.refresh(event1)
+    await async_session.refresh(event2)
+    await async_session.refresh(event3)
+    await async_session.refresh(event4)
+    
+    assert event1.municipality_code == 3304557, "Rio should get code 3304557"
+    assert event2.municipality_code == 3550308, "São Paulo should get code 3550308"
+    assert event3.municipality_code is None, "Event with no city should not get code"
+    assert event4.municipality_code is None, "Chilean event should not get code"
+    
+    assert result["updated"] == 2, "Should have updated 2 events"
+    assert result["skipped_no_city"] >= 1
+    assert result["skipped_non_brazil"] >= 1
+
+
+@pytest.mark.asyncio
+async def test_backfill_handles_ambiguous_city_names(async_session):
+    """
+    Test that backfill does NOT invent codes for ambiguous city names.
+    
+    If a city name appears in multiple states, we cannot guess which one
+    the event refers to (unless we have the state).
+    """
+    # Add an ambiguous city name in two states
+    city_sp = IBGEPopulation(
+        code_muni=3500002,
+        code_state="35",
+        name_muni="Ambíguo",
+        name_state="São Paulo",
+        abbrev_state="SP",
+        population=10000,
+        year=2022,
+        source="Test"
+    )
+    city_rj = IBGEPopulation(
+        code_muni=3300002,
+        code_state="33",
+        name_muni="Ambíguo",
+        name_state="Rio de Janeiro",
+        abbrev_state="RJ",
+        population=15000,
+        year=2022,
+        source="Test"
+    )
+    async_session.add_all([city_sp, city_rj])
+    await async_session.commit()
+    
+    # Create an event with city but NO state - ambiguous
+    event_no_state = UniqueEvent(
+        city="Ambíguo",
+        state=None,  # Missing state!
+        country="BR",
+        event_family="homicidio",
+        municipality_code=None
+    )
+    
+    # Create an event with city AND state - unambiguous
+    event_with_state = UniqueEvent(
+        city="Ambíguo",
+        state="SP",
+        country="BR",
+        event_family="homicidio",
+        municipality_code=None
+    )
+    
+    async_session.add_all([event_no_state, event_with_state])
+    await async_session.commit()
+    
+    from app.services.municipality_codes import backfill_municipality_codes
+    
+    # Run backfill
+    result = await backfill_municipality_codes(async_session)
+    
+    await async_session.refresh(event_no_state)
+    await async_session.refresh(event_with_state)
+    
+    # Event without state should NOT get a code (ambiguous)
+    assert event_no_state.municipality_code is None, "Ambiguous city without state should not get code"
+    
+    # Event with state should get the correct code
+    assert event_with_state.municipality_code == 3500002, "Unambiguous city+state should get code"
+    
+    assert result["updated"] == 1, "Only the unambiguous event should be updated"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 📝 Descrição

Implementa códigos municipais IBGE de 7 dígitos para eventos únicos brasileiros, conforme especificado na issue #174.

**Funcionalidades:**
- Novos geocodes escrevem o código quando o geocode identifica um município brasileiro
- Função de backfill para eventos brasileiros públicos existentes sem código (apenas quando city+UF resolvem unicamente)
- Nenhum código inventado: nomes de cidades ambíguas (mesmo nome em dois estados) não recebem código
- Eventos que não podem ser codificados permanecem sem código (ausentes da futura tabela de cobertura - isso é uma falha do pipeline, não uma linha sem nome)

**Implementação:**
- Campo `municipality_code` (INT nullable, indexed) adicionado ao modelo `UniqueEvent`
- Migração Alembic `k0l1m2n3o4p5`
- Serviço de geocoding estendido para buscar e armazenar códigos durante o geocoding
- Nova função `backfill_municipality_codes()` em `app/services/municipality_codes.py`
- Suite de testes abrangente com abordagem TDD

**🐛 Fixes (Commits 2-3):**
1. SQL operator precedence bug in backfill WHERE clause - added parentheses
2. Geocode tests patched async_session_maker to use test session (download test pattern)

## 🔗 Issue Relacionada

Implements #174 (parent: #123)

## 🏷️ Tipo de Mudança

- [x] ✨ Nova feature (mudança que adiciona funcionalidade)
- [x] 🐛 Bug fix (SQL operator precedence in backfill)
- [x] ✅ Testes (adição ou correção de testes)

## 🧪 Como Foi Testado?

- [x] Testes unitários - **7/7 PASSED** ✅
- [x] TDD: Red-Green-Refactor

**REAL Pytest Output (All Tests GREEN):**
```
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-9.1.1, pluggy-1.6.0
collected 7 items

tests/test_municipality_codes.py::test_lookup_city_codes_returns_official_code PASSED [ 14%]
tests/test_municipality_codes.py::test_lookup_city_codes_handles_ambiguous_cities PASSED [ 28%]
tests/test_municipality_codes.py::test_geocode_stores_municipality_code_for_brazilian_city PASSED [ 42%]
tests/test_municipality_codes.py::test_geocode_no_code_for_chile_cities PASSED [ 57%]
tests/test_municipality_codes.py::test_backfill_municipality_codes_for_existing_events PASSED [ 71%]
tests/test_municipality_codes.py::test_backfill_does_not_update_non_brazil_events PASSED [ 85%]
tests/test_municipality_codes.py::test_backfill_handles_ambiguous_city_names PASSED [100%]

============================== 7 passed in 0.21s ===============================
```

**✅ ALL Tests PASSED:**

1. ✅ `test_lookup_city_codes_returns_official_code` - **Rio de Janeiro → 3304557**
2. ✅ `test_lookup_city_codes_handles_ambiguous_cities` - Ambiguity detection
3. ✅ `test_geocode_stores_municipality_code_for_brazilian_city` - **Geocode path: RJ → 3304557**
4. ✅ `test_geocode_no_code_for_chile_cities` - **Chile → None (no code)**
5. ✅ `test_backfill_municipality_codes_for_existing_events` - Backfill works
6. ✅ `test_backfill_does_not_update_non_brazil_events` - **SQL bug fix: CL/CO NOT updated**
7. ✅ `test_backfill_handles_ambiguous_city_names` - Handles ambiguity

**No live Google Maps API calls.** All geocode responses mocked.

**Comando de teste (Docker):**
```bash
docker compose -f docker-compose.dev.yml run --rm --no-deps api \
  pytest tests/test_municipality_codes.py -v
```

## ✅ Checklist

- [x] Meu código segue o guia de estilo do projeto
- [x] Realizei uma auto-revisão do meu código
- [x] Comentei meu código em áreas complexas
- [x] Minhas mudanças não geram novos warnings
- [x] Adicionei testes que provam que meu fix/feature funciona
- [x] **Todos os testes passam (7/7)** ✅
- [x] Migração Alembic criada e revisada
- [x] Usa lookup IBGE existente (ibge_population), não inventa catálogo novo
- [x] SQL operator precedence bug fixado
- [x] Geocode tests fixed (async_session_maker patched)

## 📚 Documentação

- [x] Docstrings/comentários no código
- [x] Migration docstring (revision k0l1m2n3o4p5)
- [x] Service module documentation (`app/services/municipality_codes.py`)
- [x] Test session maker pattern documented (`_TestSessionMaker`)

## 🔍 Critérios de Aceitação

1. ✅ Eventos únicos usados pelo mapa público persistem código municipal de 7 dígitos quando geocode identifica município brasileiro
2. ✅ Path de backfill para eventos brasileiros públicos existentes sem código, apenas city+UF único (ou endereço)
3. ✅ Nenhum código inventado; nomes ambíguos não recebem palpite
4. ✅ Teste: dado evento único em município conhecido, código armazenado corresponde ao código oficial de 7 dígitos (exemplo: Rio de Janeiro = 3304557)
5. ✅ Eventos não-Brasil (CL, CO) não são tocados pelo backfill (SQL bug fix)
6. ✅ Geocode path: Brazilian city gets code, Chilean city gets None

## 📦 Commits

```
465135e Add IBGE municipality codes to UniqueEvent (issue #174)
f0c2f89 Fix SQL operator precedence bug in backfill WHERE clause
bb25ed5 Fix geocode tests by patching async_session_maker
```

**Arquivos Modificados:**
```
backend/app/models/unique_event.py                      # +1 field
backend/app/services/geocoding.py                       # Lookup on persist
backend/app/services/municipality_codes.py              # NEW: Backfill service (+parentheses fix)
backend/alembic/versions/k0l1m2n3o4p5_add_municipality_code_to_unique_event.py  # NEW: Migration
backend/tests/test_municipality_codes.py                # NEW: 7 tests (all green)
```

## 🚫 Fora do Escopo

- Issue 176 UI / agregador de cobertura / ingest oficial do ministério
- Chile ou outros países (apenas Brasil recebe códigos)
- Mortes oficiais como pinos no mapa
- Cherry-pick para master/prod
- Trabalho na página /estatisticas

## 💬 Notas Adicionais

**Fluxo de deployment:**
1. ✅ **Local:** Desenvolvido e testado na branch feature (7/7 tests green)
2. ⏳ **Develop → Staging:** Merge para `develop` dispara CI/CD (deploy para staging port 8001)
3. ⏸️  **Verificar staging antes de promover**
4. ⏸️  **Prod:** Após verificação, merge `develop` → `master` (deploy para prod port 8000)

**Próximos passos após merge:**
1. Rodar migração em staging: `docker compose -f docker-compose.dev.yml exec api alembic upgrade head`
2. Backfill opcional em staging: `from app.services.municipality_codes import backfill_municipality_codes; await backfill_municipality_codes(session)`
3. Verificar eventos em staging têm `municipality_code` populado
4. Promover para prod somente após verificação em staging

**⚠️ NÃO merge direto para master. Segue fluxo local → develop → prod conforme AGENTS.md**

---

**PR pronto para revisão. All 7 tests GREEN. SQL bug fix + geocode test fix validados.**
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2884931e-7239-4902-b1cb-bdde749718e3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2884931e-7239-4902-b1cb-bdde749718e3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

