### PR TITLE
feat: Store official violence counts from Ministry of Justice VDE (issue #175)

### DIFF
--- a/backend/alembic/versions/k0l1m2n3o4p5_add_official_violence_count_table.py
+++ b/backend/alembic/versions/k0l1m2n3o4p5_add_official_violence_count_table.py
@@ -14,19 +14,16 @@ import sqlalchemy as sa
 from sqlalchemy import inspect
 import sqlmodel
 
-
 # revision identifiers, used by Alembic.
 revision: str = 'k0l1m2n3o4p5'
 down_revision: Union[str, Sequence[str], None] = 'j9k0l1m2n3o4'
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
-
 def _official_violence_count_exists(bind) -> bool:
     """Check if official_violence_count table exists."""
     inspector = inspect(bind)
     return 'official_violence_count' in inspector.get_table_names()
-
 
 def _index_exists(bind, index_name: str, table_name: str) -> bool:
     """Check if an index exists on a table."""
@@ -34,11 +31,10 @@ def _index_exists(bind, index_name: str, table_name: str) -> bool:
     indexes = inspector.get_indexes(table_name)
     return any(idx['name'] == index_name for idx in indexes)
 
-
 def upgrade() -> None:
     """Create official_violence_count table if it doesn't exist."""
     bind = op.get_bind()
-    
+
     if not _official_violence_count_exists(bind):
         op.create_table(
             'official_violence_count',
@@ -51,13 +47,14 @@ def upgrade() -> None:
             sa.Column('source', sqlmodel.sql.sqltypes.AutoString(length=100), nullable=False),
             sa.Column('created_at', sa.DateTime(), nullable=False),
             sa.Column('updated_at', sa.DateTime(), nullable=False),
-            sa.PrimaryKeyConstraint('id')
+            sa.PrimaryKeyConstraint('id'),
+            sa.UniqueConstraint('code_muni', 'year_month', 'indicator', name='uq_official_violence_key')
         )
         op.create_index(op.f('ix_official_violence_count_code_muni'), 'official_violence_count', ['code_muni'], unique=False)
         op.create_index(op.f('ix_official_violence_count_year_month'), 'official_violence_count', ['year_month'], unique=False)
         op.create_index(op.f('ix_official_violence_count_indicator'), 'official_violence_count', ['indicator'], unique=False)
     else:
-        # Table exists, ensure indexes exist
+        # Table exists, ensure indexes and unique constraint exist
         if not _index_exists(bind, 'ix_official_violence_count_code_muni', 'official_violence_count'):
             op.create_index(op.f('ix_official_violence_count_code_muni'), 'official_violence_count', ['code_muni'], unique=False)
         if not _index_exists(bind, 'ix_official_violence_count_year_month', 'official_violence_count'):
@@ -65,9 +62,28 @@ def upgrade() -> None:
         if not _index_exists(bind, 'ix_official_violence_count_indicator', 'official_violence_count'):
             op.create_index(op.f('ix_official_violence_count_indicator'), 'official_violence_count', ['indicator'], unique=False)
 
+        # Add unique constraint if it doesn't exist
+        inspector = inspect(bind)
+        constraints = inspector.get_unique_constraints('official_violence_count')
+        has_unique = any(
+            set(c['column_names']) == {'code_muni', 'year_month', 'indicator'}
+            for c in constraints
+        )
+        if not has_unique:
+            op.create_unique_constraint('uq_official_violence_key', 'official_violence_count',
+                                       ['code_muni', 'year_month', 'indicator'])
 
 def downgrade() -> None:
     """Drop official_violence_count table."""
+    bind = op.get_bind()
+
+    # Drop unique constraint if it exists
+    inspector = inspect(bind)
+    if _official_violence_count_exists(bind):
+        constraints = inspector.get_unique_constraints('official_violence_count')
+        if any(c.get('name') == 'uq_official_violence_key' for c in constraints):
+            op.drop_constraint('uq_official_violence_key', 'official_violence_count', type_='unique')
+
     op.drop_index(op.f('ix_official_violence_count_indicator'), table_name='official_violence_count')
     op.drop_index(op.f('ix_official_violence_count_year_month'), table_name='official_violence_count')
     op.drop_index(op.f('ix_official_violence_count_code_muni'), table_name='official_violence_count')

--- a/backend/alembic/versions/k0l1m2n3o4p5_add_official_violence_count_table.py
+++ b/backend/alembic/versions/k0l1m2n3o4p5_add_official_violence_count_table.py
@@ -1,0 +1,74 @@
+"""add_official_violence_count_table
+
+Revision ID: k0l1m2n3o4p5
+Revises: j9k0l1m2n3o4
+Create Date: 2026-08-25 12:35:00.000000
+
+Add official_violence_count table to store monthly victim counts from Ministry
+of Justice VDE (Validador de Dados Estatísticos) for coverage comparison.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+import sqlmodel
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'k0l1m2n3o4p5'
+down_revision: Union[str, Sequence[str], None] = 'j9k0l1m2n3o4'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _official_violence_count_exists(bind) -> bool:
+    """Check if official_violence_count table exists."""
+    inspector = inspect(bind)
+    return 'official_violence_count' in inspector.get_table_names()
+
+
+def _index_exists(bind, index_name: str, table_name: str) -> bool:
+    """Check if an index exists on a table."""
+    inspector = inspect(bind)
+    indexes = inspector.get_indexes(table_name)
+    return any(idx['name'] == index_name for idx in indexes)
+
+
+def upgrade() -> None:
+    """Create official_violence_count table if it doesn't exist."""
+    bind = op.get_bind()
+    
+    if not _official_violence_count_exists(bind):
+        op.create_table(
+            'official_violence_count',
+            sa.Column('id', sa.Integer(), nullable=False),
+            sa.Column('code_muni', sa.Integer(), nullable=False),
+            sa.Column('year_month', sqlmodel.sql.sqltypes.AutoString(length=7), nullable=False),
+            sa.Column('indicator', sqlmodel.sql.sqltypes.AutoString(length=50), nullable=False),
+            sa.Column('victim_count', sa.Integer(), nullable=False),
+            sa.Column('is_total', sa.Boolean(), nullable=False),
+            sa.Column('source', sqlmodel.sql.sqltypes.AutoString(length=100), nullable=False),
+            sa.Column('created_at', sa.DateTime(), nullable=False),
+            sa.Column('updated_at', sa.DateTime(), nullable=False),
+            sa.PrimaryKeyConstraint('id')
+        )
+        op.create_index(op.f('ix_official_violence_count_code_muni'), 'official_violence_count', ['code_muni'], unique=False)
+        op.create_index(op.f('ix_official_violence_count_year_month'), 'official_violence_count', ['year_month'], unique=False)
+        op.create_index(op.f('ix_official_violence_count_indicator'), 'official_violence_count', ['indicator'], unique=False)
+    else:
+        # Table exists, ensure indexes exist
+        if not _index_exists(bind, 'ix_official_violence_count_code_muni', 'official_violence_count'):
+            op.create_index(op.f('ix_official_violence_count_code_muni'), 'official_violence_count', ['code_muni'], unique=False)
+        if not _index_exists(bind, 'ix_official_violence_count_year_month', 'official_violence_count'):
+            op.create_index(op.f('ix_official_violence_count_year_month'), 'official_violence_count', ['year_month'], unique=False)
+        if not _index_exists(bind, 'ix_official_violence_count_indicator', 'official_violence_count'):
+            op.create_index(op.f('ix_official_violence_count_indicator'), 'official_violence_count', ['indicator'], unique=False)
+
+
+def downgrade() -> None:
+    """Drop official_violence_count table."""
+    op.drop_index(op.f('ix_official_violence_count_indicator'), table_name='official_violence_count')
+    op.drop_index(op.f('ix_official_violence_count_year_month'), table_name='official_violence_count')
+    op.drop_index(op.f('ix_official_violence_count_code_muni'), table_name='official_violence_count')
+    op.drop_table('official_violence_count')

--- a/backend/alembic/versions/l1m2n3o4p5q6_add_official_violence_count_table.py
+++ b/backend/alembic/versions/l1m2n3o4p5q6_add_official_violence_count_table.py
@@ -1,8 +1,8 @@
 """add_official_violence_count_table
 
-Revision ID: k0l1m2n3o4p5
-Revises: j9k0l1m2n3o4
-Create Date: 2026-08-25 12:35:00.000000
+Revision ID: l1m2n3o4p5q6
+Revises: k0l1m2n3o4p5
+Create Date: 2026-08-25 13:11:00.000000
 
 Add official_violence_count table to store monthly victim counts from Ministry
 of Justice VDE (Validador de Dados Estatísticos) for coverage comparison.
@@ -15,8 +15,8 @@ from sqlalchemy import inspect
 import sqlmodel
 
 # revision identifiers, used by Alembic.
-revision: str = 'k0l1m2n3o4p5'
-down_revision: Union[str, Sequence[str], None] = 'j9k0l1m2n3o4'
+revision: str = 'l1m2n3o4p5q6'
+down_revision: Union[str, Sequence[str], None] = 'k0l1m2n3o4p5'
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -31,6 +31,7 @@ from app.models.pipeline_attempt import (
     PipelineAttemptRead,
 )
 from app.models.ibge_population import IBGEPopulation
+from app.models.official_violence_data import OfficialViolenceCount
 
 __all__ = [
     # Source Google News
@@ -60,4 +61,6 @@ __all__ = [
     "PipelineAttemptRead",
     # IBGE Population
     "IBGEPopulation",
+    # Official Violence Data
+    "OfficialViolenceCount",
 ]

--- a/backend/app/models/official_violence_data.py
+++ b/backend/app/models/official_violence_data.py
@@ -1,0 +1,79 @@
+"""Official violence data model (Ministry of Justice VDE data)."""
+
+from datetime import datetime
+from typing import Optional
+
+from sqlmodel import Field, SQLModel
+
+
+class OfficialViolenceCount(SQLModel, table=True):
+    """
+    Official monthly victim counts from Ministry of Justice VDE (Validador de Dados Estatísticos).
+    
+    This table stores violence statistics at municipality granularity from the
+    SINESP VDE system (Formulário 1: Vítimas por sexo e municípios).
+    
+    Data source: https://dados.mj.gov.br/dataset/sistema-nacional-de-estatisticas-de-seguranca-publica
+    
+    The five indicators summed into "mortes violentas intencionais":
+    1. Homicídio doloso
+    2. Feminicídio
+    3. Latrocínio (roubo seguido de morte)
+    4. Lesão corporal seguida de morte
+    5. Morte por intervenção policial
+    """
+    __tablename__ = "official_violence_count"
+    
+    id: Optional[int] = Field(default=None, primary_key=True)
+    
+    # Geographic key
+    code_muni: int = Field(
+        index=True,
+        description="7-digit IBGE municipal code (e.g. 3550308 for São Paulo)"
+    )
+    
+    # Temporal key
+    year_month: str = Field(
+        index=True,
+        max_length=7,
+        description="Year-month in YYYY-MM format (e.g. '2025-09')"
+    )
+    
+    # Indicator key
+    indicator: str = Field(
+        index=True,
+        max_length=50,
+        description="Indicator slug (e.g. 'homicidio_doloso', 'feminicidio', 'mortes_violentas_intencionais')"
+    )
+    
+    # Value
+    victim_count: int = Field(
+        description="Total victim count (sum of male + female + unidentified)"
+    )
+    
+    # Flag for summed total row
+    is_total: bool = Field(
+        default=False,
+        description="True if this row is the summed 'mortes_violentas_intencionais' total"
+    )
+    
+    # Metadata
+    source: str = Field(
+        default="SINESP VDE",
+        max_length=100,
+        description="Data source (e.g. 'SINESP VDE - Formulário 1')"
+    )
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    updated_at: datetime = Field(default_factory=datetime.utcnow)
+    
+    class Config:
+        json_schema_extra = {
+            "example": {
+                "code_muni": 3550308,
+                "year_month": "2025-09",
+                "indicator": "homicidio_doloso",
+                "victim_count": 53,
+                "is_total": False,
+                "source": "SINESP VDE - Formulário 1"
+            }
+        }

--- a/backend/app/models/official_violence_data.py
+++ b/backend/app/models/official_violence_data.py
@@ -3,25 +3,28 @@
 from datetime import datetime
 from typing import Optional
 
-from sqlmodel import Field, SQLModel
+from sqlmodel import Field, SQLModel, UniqueConstraint
 
 class OfficialViolenceCount(SQLModel, table=True):
     """
     Official monthly victim counts from Ministry of Justice VDE (Validador de Dados Estatísticos).
 
     This table stores violence statistics at municipality granularity from the
-    SINESP VDE system (Formulário 1: Vítimas por sexo e municípios).
+    SINESP VDE system (bancovde-YYYY.xlsx files).
 
-    Data source: https://dados.mj.gov.br/dataset/sistema-nacional-de-estatisticas-de-seguranca-publica
+    Data source: https://www.gov.br/mj/pt-br/assuntos/sua-seguranca/seguranca-publica/estatistica/download/dnsp-base-de-dados/
 
     The five indicators summed into "mortes violentas intencionais":
     1. Homicídio doloso
     2. Feminicídio
     3. Latrocínio (roubo seguido de morte)
     4. Lesão corporal seguida de morte
-    5. Morte por intervenção policial
+    5. Morte por intervenção do Estado
     """
     __tablename__ = "official_violence_count"
+    __table_args__ = (
+        UniqueConstraint("code_muni", "year_month", "indicator", name="uq_official_violence_key"),
+    )
 
     id: Optional[int] = Field(default=None, primary_key=True)
 

--- a/backend/app/models/official_violence_data.py
+++ b/backend/app/models/official_violence_data.py
@@ -5,16 +5,15 @@ from typing import Optional
 
 from sqlmodel import Field, SQLModel
 
-
 class OfficialViolenceCount(SQLModel, table=True):
     """
     Official monthly victim counts from Ministry of Justice VDE (Validador de Dados Estatísticos).
-    
+
     This table stores violence statistics at municipality granularity from the
     SINESP VDE system (Formulário 1: Vítimas por sexo e municípios).
-    
+
     Data source: https://dados.mj.gov.br/dataset/sistema-nacional-de-estatisticas-de-seguranca-publica
-    
+
     The five indicators summed into "mortes violentas intencionais":
     1. Homicídio doloso
     2. Feminicídio
@@ -23,40 +22,40 @@ class OfficialViolenceCount(SQLModel, table=True):
     5. Morte por intervenção policial
     """
     __tablename__ = "official_violence_count"
-    
+
     id: Optional[int] = Field(default=None, primary_key=True)
-    
+
     # Geographic key
     code_muni: int = Field(
         index=True,
         description="7-digit IBGE municipal code (e.g. 3550308 for São Paulo)"
     )
-    
+
     # Temporal key
     year_month: str = Field(
         index=True,
         max_length=7,
         description="Year-month in YYYY-MM format (e.g. '2025-09')"
     )
-    
+
     # Indicator key
     indicator: str = Field(
         index=True,
         max_length=50,
         description="Indicator slug (e.g. 'homicidio_doloso', 'feminicidio', 'mortes_violentas_intencionais')"
     )
-    
+
     # Value
     victim_count: int = Field(
         description="Total victim count (sum of male + female + unidentified)"
     )
-    
+
     # Flag for summed total row
     is_total: bool = Field(
         default=False,
         description="True if this row is the summed 'mortes_violentas_intencionais' total"
     )
-    
+
     # Metadata
     source: str = Field(
         default="SINESP VDE",
@@ -65,7 +64,7 @@ class OfficialViolenceCount(SQLModel, table=True):
     )
     created_at: datetime = Field(default_factory=datetime.utcnow)
     updated_at: datetime = Field(default_factory=datetime.utcnow)
-    
+
     class Config:
         json_schema_extra = {
             "example": {

--- a/backend/app/services/official_violence_data.py
+++ b/backend/app/services/official_violence_data.py
@@ -2,33 +2,39 @@
 Official violence data service (Ministry of Justice VDE data).
 
 This module provides functions to:
-1. Ingest VDE Formulário 1 data (victim counts by municipality and month)
-2. Calculate summed "mortes violentas intencionais" totals
-3. Query official statistics with window filtering
+1. Ingest bancovde-YYYY.xlsx data (victim counts by municipality and month)
+2. Resolve municipality names to 7-digit IBGE codes via ibge_population table
+3. Calculate summed "mortes violentas intencionais" totals
+4. Query official statistics with window filtering
 
 Data source: SINESP VDE (Validador de Dados Estatísticos)
-URL: https://dados.mj.gov.br/dataset/sistema-nacional-de-estatisticas-de-seguranca-publica
+URL pattern: https://www.gov.br/mj/pt-br/assuntos/sua-seguranca/seguranca-publica/estatistica/download/dnsp-base-de-dados/bancovde-YYYY.xlsx/@@download/file
+
+File format: bancovde-2025.xlsx, sheet "2025", 14 columns
+Headers: ["uf","municipio","evento","data_referencia","agente","arma","faixa_etaria","feminino","masculino","nao_informado","total_vitima","total","total_peso","abrangencia"]
 """
 
 from typing import Dict, List, Any
-from datetime import datetime
+from datetime import datetime, timedelta
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 from loguru import logger
 
 from app.models.official_violence_data import OfficialViolenceCount
 
-# Mapping from VDE crime type names to our indicator slugs
-# These strings must match the exact names in the Ministry of Justice VDE dump
+
+# Mapping from VDE evento names to our indicator slugs
+# These strings must match the exact casing in bancovde-YYYY.xlsx
 INDICATOR_MAPPING = {
-    "Homicídio Doloso": "homicidio_doloso",
+    "Homicídio doloso": "homicidio_doloso",
     "Feminicídio": "feminicidio",
-    "Roubo Seguido de Morte (Latrocínio)": "latrocinio",
-    "Lesão Corporal Seguida de Morte": "lesao_corporal_seguida_morte",
-    "Morte por Intervenção de Agente do Estado": "morte_intervencao_policial",
+    "Roubo seguido de morte (latrocínio)": "latrocinio",
+    "Lesão corporal seguida de morte": "lesao_corporal_seguida_morte",
+    "Morte por intervenção de Agente do Estado": "morte_intervencao_policial",
 }
 
 # Indicators that comprise "mortes violentas intencionais"
+# Spec: homicídio doloso + feminicídio + latrocínio + lesão corporal seguida de morte + morte por intervenção do Estado
 MVI_INDICATORS = [
     "homicidio_doloso",
     "feminicidio",
@@ -37,35 +43,25 @@ MVI_INDICATORS = [
     "morte_intervencao_policial",
 ]
 
-def _parse_year_month(mes: str, ano: str) -> str:
-    """
-    Convert VDE date fields to YYYY-MM.
 
-    VDE format: separate mes (month as string or number) and ano (year) columns
-    Our format: "YYYY-MM" (e.g. "2025-09")
+def _excel_serial_to_year_month(serial_date: float) -> str:
+    """
+    Convert Excel serial date to YYYY-MM.
+
+    Excel serial date: days since 1899-12-30 (Excel epoch)
+    Examples: 45658 = 2025-01-01, 45689 = 2025-02-01
 
     Args:
-        mes: Month (can be "Janeiro", "janeiro", "1", "01", etc.)
-        ano: Year (e.g. "2025")
+        serial_date: Excel serial date number
 
     Returns:
-        String in YYYY-MM format
+        String in YYYY-MM format (e.g. "2025-09")
     """
-    # Handle month names (Portuguese)
-    month_map = {
-        "janeiro": "01", "fevereiro": "02", "março": "03", "abril": "04",
-        "maio": "05", "junho": "06", "julho": "07", "agosto": "08",
-        "setembro": "09", "outubro": "10", "novembro": "11", "dezembro": "12"
-    }
+    # Excel epoch is 1899-12-30
+    excel_epoch = datetime(1899, 12, 30)
+    date = excel_epoch + timedelta(days=int(serial_date))
+    return date.strftime("%Y-%m")
 
-    mes_lower = str(mes).lower().strip()
-    if mes_lower in month_map:
-        month = month_map[mes_lower]
-    else:
-        # Try as numeric
-        month = str(int(mes)).zfill(2)
-
-    return f"{ano}-{month}"
 
 async def ingest_official_violence_data(
     session: AsyncSession,
@@ -73,90 +69,120 @@ async def ingest_official_violence_data(
     source: str = "SINESP VDE"
 ) -> None:
     """
-    Ingest VDE data (victim counts by municipality and month).
+    Ingest bancovde-YYYY.xlsx data (victim counts by municipality and month).
 
-    Expected VDE data format (based on Ministry of Justice open data structure):
-    - ano: Year (e.g. "2025")
-    - mes: Month (e.g. "9", "09", or "Setembro")
+    Expected bancovde format (14 columns):
     - uf: State abbreviation (e.g. "SP")
-    - municipio: Municipality name (e.g. "São Paulo")
-    - cod_municipio or municipio_codigo: 7-digit IBGE code (e.g. "3550308")
-    - tipo_crime or indicador: Crime type indicator name
-    - vitimas or total_vitimas: Total victim count (or separate by sex)
+    - municipio: Municipality name (e.g. "SÃO PAULO")
+    - evento: Crime type (must match INDICATOR_MAPPING keys)
+    - data_referencia: Excel serial date for first of month (e.g. 45901 = 2025-09-01)
+    - agente, arma, faixa_etaria: Disaggregation dimensions (ignored for our totals)
+    - feminino, masculino, nao_informado: Sex-disaggregated counts (unused - we use total_vitima)
+    - total_vitima: Total victim count (sex-combined) - THIS IS WHAT WE USE
+    - total, total_peso, abrangencia: Other columns (unused)
+
+    Municipality resolution:
+    - No 7-digit IBGE code in the file
+    - Resolve (uf, municipio) → code_muni via ibge_population table
+    - Drop rows that don't match an IBGE code
+
+    Aggregation:
+    - Rows are sliced by agente/arma/faixa_etaria
+    - SUM total_vitima for same (uf, municipio, year_month, evento) before storing
 
     This function:
-    1. Parses VDE data rows
-    2. Stores per-indicator counts
-    3. Calculates and stores summed "mortes violentas intencionais" total
-    4. Is idempotent: re-ingesting the same month overwrites (via unique constraint)
+    1. Resolves municipality names to IBGE codes
+    2. Groups and sums by (code_muni, year_month, indicator)
+    3. Stores per-indicator counts
+    4. Calculates and stores summed "mortes violentas intencionais" total
+    5. Is idempotent: re-ingesting the same month updates existing rows
 
     Args:
         session: Database session
-        vde_data: List of VDE data rows (dicts)
+        vde_data: List of bancovde data rows (dicts with 14 columns)
         source: Data source description
     """
     if not vde_data:
         return
 
-    # Group by (code_muni, year_month) for batch processing
-    grouped: Dict[tuple, Dict[str, int]] = {}
+    # Import here to avoid circular dependency
+    from app.services.ibge_population import lookup_city_codes
+
+    # First pass: collect all unique (uf, municipio) pairs for batch lookup
+    unique_municipalities = set()
+    for row in vde_data:
+        uf = row.get("uf", "").strip()
+        municipio = row.get("municipio", "").strip()
+        if uf and municipio:
+            unique_municipalities.add((municipio, uf))
+
+    # Batch lookup IBGE codes
+    cities = [m[0] for m in unique_municipalities]
+    states = [m[1] for m in unique_municipalities]
+    code_lookup = await lookup_city_codes(session, cities, states)
+
+    # Second pass: group and sum by (code_muni, year_month, indicator)
+    grouped: Dict[tuple, int] = {}
 
     for row in vde_data:
-        # Parse municipality code (try multiple common column names)
-        code_muni_str = row.get("cod_municipio") or row.get("municipio_codigo") or row.get("codigo_municipio")
-        if not code_muni_str:
-            logger.warning(f"Missing municipality code in VDE row, skipping: {row}")
-            continue
-        code_muni = int(code_muni_str)
+        uf = row.get("uf", "").strip()
+        municipio = row.get("municipio", "").strip()
 
-        # Parse year-month
-        ano = str(row.get("ano", ""))
-        mes = str(row.get("mes", ""))
-        if not ano or not mes:
-            logger.warning(f"Missing ano/mes in VDE row, skipping: {row}")
-            continue
-        year_month = _parse_year_month(mes, ano)
-
-        # Parse crime type (try multiple common column names)
-        tipo_crime = row.get("tipo_crime") or row.get("indicador") or row.get("evento")
-        if not tipo_crime:
-            logger.warning(f"Missing crime type in VDE row, skipping: {row}")
+        if not uf or not municipio:
+            logger.debug(f"Missing uf/municipio in row, skipping")
             continue
 
-        # Skip unknown crime types
-        if tipo_crime not in INDICATOR_MAPPING:
-            logger.debug(f"Unknown crime type in VDE data (not in MVI bag): {tipo_crime}")
+        # Resolve to IBGE code
+        code_muni = code_lookup.get((municipio, uf))
+        if not code_muni:
+            logger.debug(f"Could not resolve IBGE code for {municipio}/{uf}, skipping")
             continue
 
-        indicator = INDICATOR_MAPPING[tipo_crime]
+        # Parse evento
+        evento = row.get("evento", "").strip()
+        if evento not in INDICATOR_MAPPING:
+            # Ignore other eventos
+            continue
 
-        # Parse victim count (try multiple common patterns)
-        if "vitimas" in row:
-            victim_count = int(row["vitimas"])
-        elif "total_vitimas" in row:
-            victim_count = int(row["total_vitimas"])
-        elif all(k in row for k in ["vitimas_masculinas", "vitimas_femininas"]):
-            # Sum by sex if separate columns
-            victim_count = (
-                int(row.get("vitimas_masculinas", 0)) +
-                int(row.get("vitimas_femininas", 0)) +
-                int(row.get("vitimas_nao_identificadas", 0))
-            )
-        elif "ocorrencias" in row:
-            # Some VDE files use "ocorrencias" instead of "vitimas"
-            victim_count = int(row["ocorrencias"])
+        indicator = INDICATOR_MAPPING[evento]
+
+        # Parse date
+        data_ref = row.get("data_referencia")
+        if not data_ref:
+            logger.debug(f"Missing data_referencia in row, skipping")
+            continue
+
+        try:
+            year_month = _excel_serial_to_year_month(float(data_ref))
+        except (ValueError, TypeError) as e:
+            logger.warning(f"Invalid data_referencia {data_ref}: {e}")
+            continue
+
+        # Parse victim count
+        total_vitima = row.get("total_vitima")
+        if total_vitima is None or total_vitima == "":
+            victim_count = 0
         else:
-            logger.warning(f"Missing victim count in VDE row, skipping: {row}")
-            continue
+            try:
+                victim_count = int(float(total_vitima))
+            except (ValueError, TypeError):
+                logger.warning(f"Invalid total_vitima value: {total_vitima}")
+                continue
 
+        # Group key
+        key = (code_muni, year_month, indicator)
+        grouped[key] = grouped.get(key, 0) + victim_count
+
+    # Convert to nested dict for storage
+    storage_grouped: Dict[tuple, Dict[str, int]] = {}
+    for (code_muni, year_month, indicator), victim_count in grouped.items():
         key = (code_muni, year_month)
-        if key not in grouped:
-            grouped[key] = {}
+        if key not in storage_grouped:
+            storage_grouped[key] = {}
+        storage_grouped[key][indicator] = victim_count
 
-        grouped[key][indicator] = victim_count
-
-    # Insert/update rows (unique constraint handles idempotence)
-    for (code_muni, year_month), indicators in grouped.items():
+    # Insert/update rows (explicit upsert for idempotence)
+    for (code_muni, year_month), indicators in storage_grouped.items():
         # Store individual indicators
         for indicator, victim_count in indicators.items():
             # Check if row exists
@@ -212,7 +238,8 @@ async def ingest_official_violence_data(
             session.add(total_row)
 
     await session.commit()
-    logger.info(f"Ingested official violence data for {len(grouped)} municipality-months")
+    logger.info(f"Ingested official violence data for {len(storage_grouped)} municipality-months")
+
 
 async def get_official_violence_totals(
     session: AsyncSession,

--- a/backend/app/services/official_violence_data.py
+++ b/backend/app/services/official_violence_data.py
@@ -106,7 +106,7 @@ async def ingest_official_violence_data(
         return
 
     # Import here to avoid circular dependency
-    from app.services.ibge_population import lookup_city_codes
+    from app.models.ibge_population import IBGEPopulation
 
     # First pass: collect all unique (uf, municipio) pairs for batch lookup
     unique_municipalities = set()
@@ -116,10 +116,19 @@ async def ingest_official_violence_data(
         if uf and municipio:
             unique_municipalities.add((municipio, uf))
 
-    # Batch lookup IBGE codes
-    cities = [m[0] for m in unique_municipalities]
-    states = [m[1] for m in unique_municipalities]
-    code_lookup = await lookup_city_codes(session, cities, states)
+    # Batch lookup IBGE codes with case-insensitive matching
+    # Dump uses "SÃO PAULO", IBGE has "São Paulo" - need casefold comparison
+    # Do NOT change lookup_city_codes globally (other callers rely on exact match)
+    query = select(IBGEPopulation.code_muni, IBGEPopulation.name_muni, IBGEPopulation.abbrev_state)
+    result = await session.execute(query)
+    ibge_records = result.all()
+
+    # Build case-insensitive lookup: (name_casefold, state_casefold) → code_muni
+    code_lookup: Dict[tuple, int] = {}
+    for code_muni, name_muni, abbrev_state in ibge_records:
+        if name_muni and abbrev_state:
+            key = (name_muni.strip().casefold(), abbrev_state.strip().casefold())
+            code_lookup[key] = code_muni
 
     # Second pass: group and sum by (code_muni, year_month, indicator)
     grouped: Dict[tuple, int] = {}
@@ -132,8 +141,9 @@ async def ingest_official_violence_data(
             logger.debug(f"Missing uf/municipio in row, skipping")
             continue
 
-        # Resolve to IBGE code
-        code_muni = code_lookup.get((municipio, uf))
+        # Resolve to IBGE code (case-insensitive)
+        lookup_key = (municipio.casefold(), uf.casefold())
+        code_muni = code_lookup.get(lookup_key)
         if not code_muni:
             logger.debug(f"Could not resolve IBGE code for {municipio}/{uf}, skipping")
             continue

--- a/backend/app/services/official_violence_data.py
+++ b/backend/app/services/official_violence_data.py
@@ -11,20 +11,21 @@ URL: https://dados.mj.gov.br/dataset/sistema-nacional-de-estatisticas-de-seguran
 """
 
 from typing import Dict, List, Any
-from sqlmodel import select, delete
+from datetime import datetime
+from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 from loguru import logger
 
 from app.models.official_violence_data import OfficialViolenceCount
 
-
 # Mapping from VDE crime type names to our indicator slugs
+# These strings must match the exact names in the Ministry of Justice VDE dump
 INDICATOR_MAPPING = {
     "Homicídio Doloso": "homicidio_doloso",
     "Feminicídio": "feminicidio",
     "Roubo Seguido de Morte (Latrocínio)": "latrocinio",
     "Lesão Corporal Seguida de Morte": "lesao_corporal_seguida_morte",
-    "Morte Decorrente de Intervenção Policial": "morte_intervencao_policial",
+    "Morte por Intervenção de Agente do Estado": "morte_intervencao_policial",
 }
 
 # Indicators that comprise "mortes violentas intencionais"
@@ -36,117 +37,182 @@ MVI_INDICATORS = [
     "morte_intervencao_policial",
 ]
 
-
-def _parse_year_month(mes_ano: str) -> str:
+def _parse_year_month(mes: str, ano: str) -> str:
     """
-    Convert VDE date format to YYYY-MM.
-    
-    VDE format: "MM/YYYY" (e.g. "09/2025")
+    Convert VDE date fields to YYYY-MM.
+
+    VDE format: separate mes (month as string or number) and ano (year) columns
     Our format: "YYYY-MM" (e.g. "2025-09")
-    """
-    month, year = mes_ano.split("/")
-    return f"{year}-{month.zfill(2)}"
 
+    Args:
+        mes: Month (can be "Janeiro", "janeiro", "1", "01", etc.)
+        ano: Year (e.g. "2025")
+
+    Returns:
+        String in YYYY-MM format
+    """
+    # Handle month names (Portuguese)
+    month_map = {
+        "janeiro": "01", "fevereiro": "02", "março": "03", "abril": "04",
+        "maio": "05", "junho": "06", "julho": "07", "agosto": "08",
+        "setembro": "09", "outubro": "10", "novembro": "11", "dezembro": "12"
+    }
+
+    mes_lower = str(mes).lower().strip()
+    if mes_lower in month_map:
+        month = month_map[mes_lower]
+    else:
+        # Try as numeric
+        month = str(int(mes)).zfill(2)
+
+    return f"{ano}-{month}"
 
 async def ingest_official_violence_data(
     session: AsyncSession,
     vde_data: List[Dict[str, Any]],
-    source: str = "SINESP VDE - Formulário 1"
+    source: str = "SINESP VDE"
 ) -> None:
     """
-    Ingest VDE Formulário 1 data (victim counts by municipality and month).
-    
+    Ingest VDE data (victim counts by municipality and month).
+
+    Expected VDE data format (based on Ministry of Justice open data structure):
+    - ano: Year (e.g. "2025")
+    - mes: Month (e.g. "9", "09", or "Setembro")
+    - uf: State abbreviation (e.g. "SP")
+    - municipio: Municipality name (e.g. "São Paulo")
+    - cod_municipio or municipio_codigo: 7-digit IBGE code (e.g. "3550308")
+    - tipo_crime or indicador: Crime type indicator name
+    - vitimas or total_vitimas: Total victim count (or separate by sex)
+
     This function:
     1. Parses VDE data rows
     2. Stores per-indicator counts
     3. Calculates and stores summed "mortes violentas intencionais" total
-    4. Is idempotent: re-ingesting the same month overwrites
-    
+    4. Is idempotent: re-ingesting the same month overwrites (via unique constraint)
+
     Args:
         session: Database session
-        vde_data: List of VDE Formulário 1 rows (dicts)
+        vde_data: List of VDE data rows (dicts)
         source: Data source description
-    
-    Example VDE row:
-        {
-            "mes_ano": "09/2025",
-            "uf": "SP",
-            "cod_municipio": "3550308",
-            "municipio": "São Paulo",
-            "tipo_crime": "Homicídio Doloso",
-            "vitimas_masculinas": 45,
-            "vitimas_femininas": 8,
-            "vitimas_nao_identificadas": 0,
-        }
     """
     if not vde_data:
         return
-    
-    # Group by (code_muni, year_month) for idempotent upsert
+
+    # Group by (code_muni, year_month) for batch processing
     grouped: Dict[tuple, Dict[str, int]] = {}
-    
+
     for row in vde_data:
-        code_muni = int(row["cod_municipio"])
-        year_month = _parse_year_month(row["mes_ano"])
-        tipo_crime = row["tipo_crime"]
-        
+        # Parse municipality code (try multiple common column names)
+        code_muni_str = row.get("cod_municipio") or row.get("municipio_codigo") or row.get("codigo_municipio")
+        if not code_muni_str:
+            logger.warning(f"Missing municipality code in VDE row, skipping: {row}")
+            continue
+        code_muni = int(code_muni_str)
+
+        # Parse year-month
+        ano = str(row.get("ano", ""))
+        mes = str(row.get("mes", ""))
+        if not ano or not mes:
+            logger.warning(f"Missing ano/mes in VDE row, skipping: {row}")
+            continue
+        year_month = _parse_year_month(mes, ano)
+
+        # Parse crime type (try multiple common column names)
+        tipo_crime = row.get("tipo_crime") or row.get("indicador") or row.get("evento")
+        if not tipo_crime:
+            logger.warning(f"Missing crime type in VDE row, skipping: {row}")
+            continue
+
         # Skip unknown crime types
         if tipo_crime not in INDICATOR_MAPPING:
-            logger.warning(f"Unknown crime type in VDE data: {tipo_crime}")
+            logger.debug(f"Unknown crime type in VDE data (not in MVI bag): {tipo_crime}")
             continue
-        
+
         indicator = INDICATOR_MAPPING[tipo_crime]
-        
-        # Sum all victims (male + female + unidentified)
-        victim_count = (
-            int(row.get("vitimas_masculinas", 0)) +
-            int(row.get("vitimas_femininas", 0)) +
-            int(row.get("vitimas_nao_identificadas", 0))
-        )
-        
+
+        # Parse victim count (try multiple common patterns)
+        if "vitimas" in row:
+            victim_count = int(row["vitimas"])
+        elif "total_vitimas" in row:
+            victim_count = int(row["total_vitimas"])
+        elif all(k in row for k in ["vitimas_masculinas", "vitimas_femininas"]):
+            # Sum by sex if separate columns
+            victim_count = (
+                int(row.get("vitimas_masculinas", 0)) +
+                int(row.get("vitimas_femininas", 0)) +
+                int(row.get("vitimas_nao_identificadas", 0))
+            )
+        elif "ocorrencias" in row:
+            # Some VDE files use "ocorrencias" instead of "vitimas"
+            victim_count = int(row["ocorrencias"])
+        else:
+            logger.warning(f"Missing victim count in VDE row, skipping: {row}")
+            continue
+
         key = (code_muni, year_month)
         if key not in grouped:
             grouped[key] = {}
-        
+
         grouped[key][indicator] = victim_count
-    
-    # Delete existing rows for these (code_muni, year_month) pairs to ensure idempotence
-    for (code_muni, year_month) in grouped.keys():
-        delete_stmt = delete(OfficialViolenceCount).where(
-            OfficialViolenceCount.code_muni == code_muni,
-            OfficialViolenceCount.year_month == year_month
-        )
-        await session.execute(delete_stmt)
-    
-    # Insert new rows
+
+    # Insert/update rows (unique constraint handles idempotence)
     for (code_muni, year_month), indicators in grouped.items():
         # Store individual indicators
         for indicator, victim_count in indicators.items():
-            count_row = OfficialViolenceCount(
-                code_muni=code_muni,
-                year_month=year_month,
-                indicator=indicator,
-                victim_count=victim_count,
-                is_total=False,
-                source=source
+            # Check if row exists
+            query_existing = select(OfficialViolenceCount).where(
+                OfficialViolenceCount.code_muni == code_muni,
+                OfficialViolenceCount.year_month == year_month,
+                OfficialViolenceCount.indicator == indicator
             )
-            session.add(count_row)
-        
+            result = await session.execute(query_existing)
+            existing = result.scalar_one_or_none()
+
+            if existing:
+                # Update existing row
+                existing.victim_count = victim_count
+                existing.updated_at = datetime.utcnow()
+            else:
+                # Insert new row
+                count_row = OfficialViolenceCount(
+                    code_muni=code_muni,
+                    year_month=year_month,
+                    indicator=indicator,
+                    victim_count=victim_count,
+                    is_total=False,
+                    source=source
+                )
+                session.add(count_row)
+
         # Calculate and store summed "mortes violentas intencionais" total
         mvi_total = sum(indicators.get(ind, 0) for ind in MVI_INDICATORS)
-        total_row = OfficialViolenceCount(
-            code_muni=code_muni,
-            year_month=year_month,
-            indicator="mortes_violentas_intencionais",
-            victim_count=mvi_total,
-            is_total=True,
-            source=source
+
+        query_existing_total = select(OfficialViolenceCount).where(
+            OfficialViolenceCount.code_muni == code_muni,
+            OfficialViolenceCount.year_month == year_month,
+            OfficialViolenceCount.indicator == "mortes_violentas_intencionais"
         )
-        session.add(total_row)
-    
+        result = await session.execute(query_existing_total)
+        existing_total = result.scalar_one_or_none()
+
+        if existing_total:
+            # Update existing total
+            existing_total.victim_count = mvi_total
+            existing_total.updated_at = datetime.utcnow()
+        else:
+            # Insert new total
+            total_row = OfficialViolenceCount(
+                code_muni=code_muni,
+                year_month=year_month,
+                indicator="mortes_violentas_intencionais",
+                victim_count=mvi_total,
+                is_total=True,
+                source=source
+            )
+            session.add(total_row)
+
     await session.commit()
     logger.info(f"Ingested official violence data for {len(grouped)} municipality-months")
-
 
 async def get_official_violence_totals(
     session: AsyncSession,
@@ -155,18 +221,18 @@ async def get_official_violence_totals(
 ) -> List[Dict[str, Any]]:
     """
     Get official "mortes violentas intencionais" totals for municipalities.
-    
+
     Args:
         session: Database session
         code_munis: List of IBGE municipal codes
         min_year_month: Minimum year-month (YYYY-MM) to include (default: 2025-09)
-    
+
     Returns:
         List of dicts with keys: code_muni, year_month, victim_count
     """
     if not code_munis:
         return []
-    
+
     query = select(OfficialViolenceCount).where(
         OfficialViolenceCount.code_muni.in_(code_munis),
         OfficialViolenceCount.indicator == "mortes_violentas_intencionais",
@@ -175,10 +241,10 @@ async def get_official_violence_totals(
         OfficialViolenceCount.code_muni,
         OfficialViolenceCount.year_month
     )
-    
+
     result = await session.execute(query)
     counts = result.scalars().all()
-    
+
     return [
         {
             "code_muni": c.code_muni,

--- a/backend/app/services/official_violence_data.py
+++ b/backend/app/services/official_violence_data.py
@@ -1,0 +1,189 @@
+"""
+Official violence data service (Ministry of Justice VDE data).
+
+This module provides functions to:
+1. Ingest VDE Formulário 1 data (victim counts by municipality and month)
+2. Calculate summed "mortes violentas intencionais" totals
+3. Query official statistics with window filtering
+
+Data source: SINESP VDE (Validador de Dados Estatísticos)
+URL: https://dados.mj.gov.br/dataset/sistema-nacional-de-estatisticas-de-seguranca-publica
+"""
+
+from typing import Dict, List, Any
+from sqlmodel import select, delete
+from sqlmodel.ext.asyncio.session import AsyncSession
+from loguru import logger
+
+from app.models.official_violence_data import OfficialViolenceCount
+
+
+# Mapping from VDE crime type names to our indicator slugs
+INDICATOR_MAPPING = {
+    "Homicídio Doloso": "homicidio_doloso",
+    "Feminicídio": "feminicidio",
+    "Roubo Seguido de Morte (Latrocínio)": "latrocinio",
+    "Lesão Corporal Seguida de Morte": "lesao_corporal_seguida_morte",
+    "Morte Decorrente de Intervenção Policial": "morte_intervencao_policial",
+}
+
+# Indicators that comprise "mortes violentas intencionais"
+MVI_INDICATORS = [
+    "homicidio_doloso",
+    "feminicidio",
+    "latrocinio",
+    "lesao_corporal_seguida_morte",
+    "morte_intervencao_policial",
+]
+
+
+def _parse_year_month(mes_ano: str) -> str:
+    """
+    Convert VDE date format to YYYY-MM.
+    
+    VDE format: "MM/YYYY" (e.g. "09/2025")
+    Our format: "YYYY-MM" (e.g. "2025-09")
+    """
+    month, year = mes_ano.split("/")
+    return f"{year}-{month.zfill(2)}"
+
+
+async def ingest_official_violence_data(
+    session: AsyncSession,
+    vde_data: List[Dict[str, Any]],
+    source: str = "SINESP VDE - Formulário 1"
+) -> None:
+    """
+    Ingest VDE Formulário 1 data (victim counts by municipality and month).
+    
+    This function:
+    1. Parses VDE data rows
+    2. Stores per-indicator counts
+    3. Calculates and stores summed "mortes violentas intencionais" total
+    4. Is idempotent: re-ingesting the same month overwrites
+    
+    Args:
+        session: Database session
+        vde_data: List of VDE Formulário 1 rows (dicts)
+        source: Data source description
+    
+    Example VDE row:
+        {
+            "mes_ano": "09/2025",
+            "uf": "SP",
+            "cod_municipio": "3550308",
+            "municipio": "São Paulo",
+            "tipo_crime": "Homicídio Doloso",
+            "vitimas_masculinas": 45,
+            "vitimas_femininas": 8,
+            "vitimas_nao_identificadas": 0,
+        }
+    """
+    if not vde_data:
+        return
+    
+    # Group by (code_muni, year_month) for idempotent upsert
+    grouped: Dict[tuple, Dict[str, int]] = {}
+    
+    for row in vde_data:
+        code_muni = int(row["cod_municipio"])
+        year_month = _parse_year_month(row["mes_ano"])
+        tipo_crime = row["tipo_crime"]
+        
+        # Skip unknown crime types
+        if tipo_crime not in INDICATOR_MAPPING:
+            logger.warning(f"Unknown crime type in VDE data: {tipo_crime}")
+            continue
+        
+        indicator = INDICATOR_MAPPING[tipo_crime]
+        
+        # Sum all victims (male + female + unidentified)
+        victim_count = (
+            int(row.get("vitimas_masculinas", 0)) +
+            int(row.get("vitimas_femininas", 0)) +
+            int(row.get("vitimas_nao_identificadas", 0))
+        )
+        
+        key = (code_muni, year_month)
+        if key not in grouped:
+            grouped[key] = {}
+        
+        grouped[key][indicator] = victim_count
+    
+    # Delete existing rows for these (code_muni, year_month) pairs to ensure idempotence
+    for (code_muni, year_month) in grouped.keys():
+        delete_stmt = delete(OfficialViolenceCount).where(
+            OfficialViolenceCount.code_muni == code_muni,
+            OfficialViolenceCount.year_month == year_month
+        )
+        await session.execute(delete_stmt)
+    
+    # Insert new rows
+    for (code_muni, year_month), indicators in grouped.items():
+        # Store individual indicators
+        for indicator, victim_count in indicators.items():
+            count_row = OfficialViolenceCount(
+                code_muni=code_muni,
+                year_month=year_month,
+                indicator=indicator,
+                victim_count=victim_count,
+                is_total=False,
+                source=source
+            )
+            session.add(count_row)
+        
+        # Calculate and store summed "mortes violentas intencionais" total
+        mvi_total = sum(indicators.get(ind, 0) for ind in MVI_INDICATORS)
+        total_row = OfficialViolenceCount(
+            code_muni=code_muni,
+            year_month=year_month,
+            indicator="mortes_violentas_intencionais",
+            victim_count=mvi_total,
+            is_total=True,
+            source=source
+        )
+        session.add(total_row)
+    
+    await session.commit()
+    logger.info(f"Ingested official violence data for {len(grouped)} municipality-months")
+
+
+async def get_official_violence_totals(
+    session: AsyncSession,
+    code_munis: List[int],
+    min_year_month: str = "2025-09"
+) -> List[Dict[str, Any]]:
+    """
+    Get official "mortes violentas intencionais" totals for municipalities.
+    
+    Args:
+        session: Database session
+        code_munis: List of IBGE municipal codes
+        min_year_month: Minimum year-month (YYYY-MM) to include (default: 2025-09)
+    
+    Returns:
+        List of dicts with keys: code_muni, year_month, victim_count
+    """
+    if not code_munis:
+        return []
+    
+    query = select(OfficialViolenceCount).where(
+        OfficialViolenceCount.code_muni.in_(code_munis),
+        OfficialViolenceCount.indicator == "mortes_violentas_intencionais",
+        OfficialViolenceCount.year_month >= min_year_month
+    ).order_by(
+        OfficialViolenceCount.code_muni,
+        OfficialViolenceCount.year_month
+    )
+    
+    result = await session.execute(query)
+    counts = result.scalars().all()
+    
+    return [
+        {
+            "code_muni": c.code_muni,
+            "year_month": c.year_month,
+            "victim_count": c.victim_count
+        }
+        for c in counts
+    ]

--- a/backend/scripts/load_official_violence_data.py
+++ b/backend/scripts/load_official_violence_data.py
@@ -1,25 +1,23 @@
 #!/usr/bin/env python3
 """
-Load official violence data from Ministry of Justice VDE dump into the database.
+Load official violence data from Ministry of Justice bancovde-YYYY.xlsx into the database.
 
-This script downloads and ingests VDE municipal data (victim counts by
-municipality and month) from the SINESP open data portal.
+This script downloads and ingests municipal victim counts by month from the
+SINESP VDE (Validador de Dados Estatísticos) open data portal.
 
-Data sources on https://dados.mj.gov.br/dataset/sistema-nacional-de-estatisticas-de-seguranca-publica :
-- XLSX: "Dados Nacionais de Segurança Pública - Municípios" (recommended)
-- ZIP: "Base de Dados VDE" (raw VDE dump, multiple formulários)
+Data source: https://www.gov.br/mj/pt-br/assuntos/sua-seguranca/seguranca-publica/estatistica/download/dnsp-base-de-dados/
+URL pattern: bancovde-YYYY.xlsx
 
 Usage:
-    python scripts/load_official_violence_data.py [--since YYYY-MM] [--source XLSX|ZIP]
+    python scripts/load_official_violence_data.py [--year YYYY] [--since YYYY-MM]
 
 Options:
+    --year YYYY      Year to download (default: 2025)
     --since YYYY-MM  Only load data from this month onwards (default: 2025-09)
-    --source TYPE    Data source: XLSX (municipal aggregated) or ZIP (raw VDE)
 """
 
 import asyncio
 import sys
-import zipfile
 from pathlib import Path
 from io import BytesIO
 
@@ -33,158 +31,149 @@ from loguru import logger
 from app.database import get_engine, init_db
 from app.services.official_violence_data import ingest_official_violence_data
 
-# Official data URLs from dados.mj.gov.br
-VDE_ZIP_URL = "https://dados.mj.gov.br/dataset/210b9ae2-21fc-4986-89c6-2006eb4db247/resource/e9d6cc2b-33f1-468d-ab09-9aa8303c2eba/download/basededadosvde.zip"
-VDE_XLSX_URL = "https://dados.mj.gov.br/dataset/210b9ae2-21fc-4986-89c6-2006eb4db247/resource/03af7ce2-174e-4ebd-b085-384503cfb40f/download/dados-nacionais-seguranca-publica-municipios.xlsx"
+# bancovde URL pattern (gov.br portal)
+BANCOVDE_URL_TEMPLATE = "https://www.gov.br/mj/pt-br/assuntos/sua-seguranca/seguranca-publica/estatistica/download/dnsp-base-de-dados/bancovde-{year}.xlsx/@@download/file"
 
-async def download_and_parse_vde_xlsx(since_year_month: str = "2025-09") -> list:
+# Expected bancovde-2025.xlsx headers (14 columns)
+EXPECTED_HEADERS = [
+    "uf", "municipio", "evento", "data_referencia", "agente", "arma",
+    "faixa_etaria", "feminino", "masculino", "nao_informado",
+    "total_vitima", "total", "total_peso", "abrangencia"
+]
+
+async def download_and_parse_bancovde(year: int = 2025, since_year_month: str = "2025-09") -> list:
     """
-    Download and parse municipal XLSX file (recommended).
+    Download and parse bancovde-YYYY.xlsx file.
 
-    This file contains aggregated municipal-level indicators.
-    Expected columns (based on common Brazilian government data patterns):
-    - ano, mes, uf, municipio, cod_municipio (or similar)
-    - One column per indicator, or tipo_crime/indicador column (long format)
+    Expected structure:
+    - Sheet name: "{year}" (e.g. "2025")
+    - 14 columns (see EXPECTED_HEADERS)
+    - ~832k rows per year
+    - Excel serial dates in data_referencia column
+
+    Municipality resolution:
+    - No 7-digit IBGE code in file
+    - Resolve (uf, municipio) → code_muni via ibge_population table
+    - Drop rows that don't match
 
     Args:
+        year: Year to download (e.g. 2025)
         since_year_month: Only return data >= this month (YYYY-MM format)
 
     Returns:
-        List of parsed VDE data rows (dicts)
+        List of parsed bancovde data rows (dicts with 14 columns)
     """
-    logger.info(f"Downloading VDE municipal XLSX from {VDE_XLSX_URL}...")
+    url = BANCOVDE_URL_TEMPLATE.format(year=year)
+    logger.info(f"Downloading bancovde-{year}.xlsx from {url}...")
 
     try:
         import httpx
-        import pandas as pd
+        from openpyxl import load_workbook
+        from openpyxl.utils import get_column_letter
+        from datetime import datetime, timedelta
 
         # Download XLSX
         async with httpx.AsyncClient(timeout=120.0) as client:
-            response = await client.get(VDE_XLSX_URL)
+            response = await client.get(url)
             response.raise_for_status()
 
         logger.info(f"Downloaded {len(response.content)} bytes")
 
-        # Parse XLSX
-        df = pd.read_excel(BytesIO(response.content), dtype=str)
-        logger.info(f"Loaded {len(df)} rows from XLSX")
-        logger.info(f"Columns: {list(df.columns)}")
+        # Load workbook
+        wb = load_workbook(BytesIO(response.content), read_only=True, data_only=True)
+        sheet_name = str(year)
 
-        # Normalize column names (lowercase, strip spaces)
-        df.columns = df.columns.str.strip().str.lower()
-
-        # Filter by date
-        # Try to construct year-month from ano + mes columns
-        if 'ano' in df.columns and 'mes' in df.columns:
-            df['year_month_parsed'] = df.apply(
-                lambda row: f"{row['ano']}-{str(int(row['mes'])).zfill(2)}"
-                if row['mes'].isdigit() else None,
-                axis=1
+        if sheet_name not in wb.sheetnames:
+            raise ValueError(
+                f"Sheet '{sheet_name}' not found in workbook. "
+                f"Available sheets: {wb.sheetnames}"
             )
-            df_filtered = df[df['year_month_parsed'] >= since_year_month]
-        else:
-            logger.warning("Could not find ano/mes columns, returning all rows")
-            df_filtered = df
 
-        logger.info(f"Filtered to {len(df_filtered)} rows >= {since_year_month}")
+        ws = wb[sheet_name]
+        logger.info(f"Loaded sheet '{sheet_name}' with {ws.max_row} rows")
 
-        # Convert to list of dicts
-        records = df_filtered.to_dict('records')
+        # Read header row (row 1)
+        headers = []
+        for col_idx in range(1, 15):  # 14 columns (A-N)
+            cell = ws.cell(row=1, column=col_idx)
+            header_value = cell.value
+            if header_value is None:
+                # Empty header - use positional fallback
+                headers.append(f"col_{col_idx}")
+            else:
+                headers.append(str(header_value).strip())
+
+        logger.info(f"Headers: {headers}")
+
+        # Verify headers match expected structure
+        if headers != EXPECTED_HEADERS:
+            logger.warning(
+                f"Header mismatch! Expected: {EXPECTED_HEADERS}, "
+                f"Got: {headers}"
+            )
+
+        # Parse data rows (skip header row)
+        records = []
+        row_count = 0
+        skipped_count = 0
+
+        for row_idx, row in enumerate(ws.iter_rows(min_row=2, values_only=True), start=2):
+            row_count += 1
+
+            # Parse row into dict (14 columns)
+            record = {}
+            for col_idx, value in enumerate(row):
+                if col_idx >= len(headers):
+                    break
+                header = headers[col_idx]
+                record[header] = value
+
+            # Filter by date
+            data_ref = record.get("data_referencia")
+            if data_ref is not None:
+                try:
+                    # Convert Excel serial date to YYYY-MM
+                    excel_epoch = datetime(1899, 12, 30)
+                    date = excel_epoch + timedelta(days=int(data_ref))
+                    year_month = date.strftime("%Y-%m")
+
+                    # Skip rows before cutoff
+                    if year_month < since_year_month:
+                        skipped_count += 1
+                        continue
+                except (ValueError, TypeError):
+                    # Invalid date - skip
+                    skipped_count += 1
+                    continue
+            else:
+                # Missing date - skip
+                skipped_count += 1
+                continue
+
+            records.append(record)
+
+            # Progress log every 100k rows
+            if row_count % 100000 == 0:
+                logger.info(f"Processed {row_count} rows, kept {len(records)}")
+
+        wb.close()
+
+        logger.info(f"Loaded {len(records)} rows from bancovde-{year}.xlsx (skipped {skipped_count} rows)")
+        logger.info(f"Filtered to {len(records)} rows >= {since_year_month}")
+
         return records
 
     except ImportError as e:
-        logger.error(f"Missing required package: {e}. Install with: pip install httpx pandas openpyxl")
+        logger.error(f"Missing required package: {e}. Install with: pip install httpx openpyxl")
         raise
     except Exception as e:
-        logger.error(f"Failed to download/parse VDE XLSX: {e}")
+        logger.error(f"Failed to download/parse bancovde-{year}.xlsx: {e}")
         raise
 
-async def download_and_parse_vde_zip(since_year_month: str = "2025-09") -> list:
-    """
-    Download and parse VDE ZIP file (raw VDE dump, multiple formulários).
-
-    This is the comprehensive VDE export. We need to identify and parse
-    Formulário 1 and Formulário 3 for the 5 MVI indicators.
-
-    Args:
-        since_year_month: Only return data >= this month (YYYY-MM format)
-
-    Returns:
-        List of parsed VDE data rows (dicts)
-    """
-    logger.info(f"Downloading VDE zip from {VDE_ZIP_URL}...")
-
-    try:
-        import httpx
-        import pandas as pd
-
-        # Download zip
-        async with httpx.AsyncClient(timeout=120.0) as client:
-            response = await client.get(VDE_ZIP_URL)
-            response.raise_for_status()
-
-        logger.info(f"Downloaded {len(response.content)} bytes")
-
-        # Extract and identify relevant files
-        with zipfile.ZipFile(BytesIO(response.content)) as zf:
-            logger.info(f"Files in VDE zip: {zf.namelist()}")
-
-            # Find Formulário 1 and Formulário 3 CSV files
-            # Expected patterns: "formulario_1", "form1", "formulario1", etc.
-            form1_file = None
-            form3_file = None
-
-            for filename in zf.namelist():
-                if not filename.endswith('.csv'):
-                    continue
-                lower_name = filename.lower()
-                if 'formulario' in lower_name or 'form' in lower_name:
-                    if '1' in lower_name and not form1_file:
-                        form1_file = filename
-                    elif '3' in lower_name and not form3_file:
-                        form3_file = filename
-
-            if not form1_file:
-                raise ValueError(
-                    f"Could not identify Formulário 1 file in VDE zip. "
-                    f"Files found: {zf.namelist()}"
-                )
-
-            logger.info(f"Reading Formulário 1: {form1_file}")
-            with zf.open(form1_file) as csvfile:
-                df1 = pd.read_csv(csvfile, encoding='utf-8', dtype=str)
-
-            all_rows = []
-            all_rows.extend(df1.to_dict('records'))
-
-            # Also read Formulário 3 if found (for "Morte por Intervenção de Agente do Estado")
-            if form3_file:
-                logger.info(f"Reading Formulário 3: {form3_file}")
-                with zf.open(form3_file) as csvfile:
-                    df3 = pd.read_csv(csvfile, encoding='utf-8', dtype=str)
-                all_rows.extend(df3.to_dict('records'))
-            else:
-                logger.warning("Formulário 3 not found; 'Morte por Intervenção de Agente do Estado' will be missing")
-
-            logger.info(f"Loaded {len(all_rows)} total rows from VDE")
-
-            # Filter by date
-            # TODO: Implement date filtering based on actual column structure
-            # This depends on the real VDE file format
-
-            return all_rows
-
-    except ImportError as e:
-        logger.error(f"Missing required package: {e}. Install with: pip install httpx pandas")
-        raise
-    except Exception as e:
-        logger.error(f"Failed to download/parse VDE ZIP: {e}")
-        raise
-
-async def main(since: str = "2025-09", source: str = "XLSX"):
+async def main(year: int = 2025, since: str = "2025-09"):
     """Load official violence data into database."""
     logger.info("=" * 80)
-    logger.info(f"Loading official violence data (source={source}, since={since})")
+    logger.info(f"Loading official violence data (bancovde-{year}.xlsx, since={since})")
     logger.info("=" * 80)
 
     # Initialize database tables
@@ -194,15 +183,12 @@ async def main(since: str = "2025-09", source: str = "XLSX"):
     # Get engine
     engine = get_engine()
 
-    # Download and parse VDE data
+    # Download and parse bancovde data
     try:
-        if source.upper() == "XLSX":
-            vde_data = await download_and_parse_vde_xlsx(since_year_month=since)
-        else:
-            vde_data = await download_and_parse_vde_zip(since_year_month=since)
+        vde_data = await download_and_parse_bancovde(year=year, since_year_month=since)
     except Exception as e:
-        logger.error(f"✗ Failed to download VDE data: {e}")
-        logger.info("Manual alternative: Download the file from dados.mj.gov.br and adapt this script")
+        logger.error(f"✗ Failed to download bancovde data: {e}")
+        logger.info("Manual alternative: Download the file from www.gov.br and adapt this script")
         return
 
     # Ingest data
@@ -226,7 +212,13 @@ if __name__ == "__main__":
     import argparse
 
     parser = argparse.ArgumentParser(
-        description="Load official violence data from Ministry of Justice VDE"
+        description="Load official violence data from Ministry of Justice bancovde-YYYY.xlsx"
+    )
+    parser.add_argument(
+        "--year",
+        type=int,
+        default=2025,
+        help="Year to download (default: 2025)"
     )
     parser.add_argument(
         "--since",
@@ -234,14 +226,7 @@ if __name__ == "__main__":
         default="2025-09",
         help="Only load data from this month onwards (YYYY-MM format, default: 2025-09)"
     )
-    parser.add_argument(
-        "--source",
-        type=str,
-        default="XLSX",
-        choices=["XLSX", "ZIP"],
-        help="Data source: XLSX (municipal aggregated, recommended) or ZIP (raw VDE)"
-    )
 
     args = parser.parse_args()
 
-    asyncio.run(main(since=args.since, source=args.source))
+    asyncio.run(main(year=args.year, since=args.since))

--- a/backend/scripts/load_official_violence_data.py
+++ b/backend/scripts/load_official_violence_data.py
@@ -2,15 +2,19 @@
 """
 Load official violence data from Ministry of Justice VDE dump into the database.
 
-This script downloads and ingests VDE Formulário 1 data (victim counts by
+This script downloads and ingests VDE municipal data (victim counts by
 municipality and month) from the SINESP open data portal.
 
+Data sources on https://dados.mj.gov.br/dataset/sistema-nacional-de-estatisticas-de-seguranca-publica :
+- XLSX: "Dados Nacionais de Segurança Pública - Municípios" (recommended)
+- ZIP: "Base de Dados VDE" (raw VDE dump, multiple formulários)
+
 Usage:
-    python scripts/load_official_violence_data.py [--force] [--since YYYY-MM]
+    python scripts/load_official_violence_data.py [--since YYYY-MM] [--source XLSX|ZIP]
 
 Options:
-    --force          Force reload even if data already exists
     --since YYYY-MM  Only load data from this month onwards (default: 2025-09)
+    --source TYPE    Data source: XLSX (municipal aggregated) or ZIP (raw VDE)
 """
 
 import asyncio
@@ -29,107 +33,178 @@ from loguru import logger
 from app.database import get_engine, init_db
 from app.services.official_violence_data import ingest_official_violence_data
 
+# Official data URLs from dados.mj.gov.br
+VDE_ZIP_URL = "https://dados.mj.gov.br/dataset/210b9ae2-21fc-4986-89c6-2006eb4db247/resource/e9d6cc2b-33f1-468d-ab09-9aa8303c2eba/download/basededadosvde.zip"
+VDE_XLSX_URL = "https://dados.mj.gov.br/dataset/210b9ae2-21fc-4986-89c6-2006eb4db247/resource/03af7ce2-174e-4ebd-b085-384503cfb40f/download/dados-nacionais-seguranca-publica-municipios.xlsx"
 
-VDE_DOWNLOAD_URL = "https://dados.mj.gov.br/dataset/210b9ae2-21fc-4986-89c6-2006eb4db247/resource/e9d6cc2b-33f1-468d-ab09-9aa8303c2eba/download/basededadosvde.zip"
-
-
-async def download_and_parse_vde_data(since_year_month: str = "2025-09") -> list:
+async def download_and_parse_vde_xlsx(since_year_month: str = "2025-09") -> list:
     """
-    Download VDE zip file and parse Formulário 1 CSV.
-    
+    Download and parse municipal XLSX file (recommended).
+
+    This file contains aggregated municipal-level indicators.
+    Expected columns (based on common Brazilian government data patterns):
+    - ano, mes, uf, municipio, cod_municipio (or similar)
+    - One column per indicator, or tipo_crime/indicador column (long format)
+
     Args:
         since_year_month: Only return data >= this month (YYYY-MM format)
-    
+
     Returns:
-        List of parsed VDE data rows
+        List of parsed VDE data rows (dicts)
     """
-    logger.info(f"Downloading VDE data from {VDE_DOWNLOAD_URL}...")
-    
+    logger.info(f"Downloading VDE municipal XLSX from {VDE_XLSX_URL}...")
+
     try:
         import httpx
         import pandas as pd
-        
-        # Download zip file
+
+        # Download XLSX
         async with httpx.AsyncClient(timeout=120.0) as client:
-            response = await client.get(VDE_DOWNLOAD_URL)
+            response = await client.get(VDE_XLSX_URL)
             response.raise_for_status()
-        
+
         logger.info(f"Downloaded {len(response.content)} bytes")
-        
-        # Extract CSV from zip
-        with zipfile.ZipFile(BytesIO(response.content)) as zf:
-            # Find Formulário 1 CSV (victim counts by municipality)
-            csv_files = [name for name in zf.namelist() if name.endswith('.csv')]
-            
-            if not csv_files:
-                raise ValueError("No CSV files found in VDE zip")
-            
-            # The VDE dump typically contains multiple CSVs, one per formulário
-            # We need Formulário 1 (vítimas por sexo e município)
-            # File naming pattern from docs: likely includes "formulario_1" or similar
-            form1_file = None
-            for csv_file in csv_files:
-                if 'formulario' in csv_file.lower() and '1' in csv_file:
-                    form1_file = csv_file
-                    break
-            
-            if not form1_file:
-                # Fallback: use first CSV (may need adjustment based on actual file structure)
-                logger.warning(f"Could not identify Formulário 1 file, using first CSV: {csv_files[0]}")
-                form1_file = csv_files[0]
-            
-            logger.info(f"Reading {form1_file} from VDE zip...")
-            
-            # Read CSV
-            with zf.open(form1_file) as csvfile:
-                df = pd.read_csv(csvfile, encoding='utf-8', dtype=str)
-        
-        logger.info(f"Loaded {len(df)} rows from VDE CSV")
-        
-        # Filter by date (>= since_year_month)
-        # Convert mes_ano "MM/YYYY" to "YYYY-MM" for comparison
-        def parse_mes_ano(mes_ano: str) -> str:
-            month, year = mes_ano.split("/")
-            return f"{year}-{month.zfill(2)}"
-        
-        df['year_month_parsed'] = df['mes_ano'].apply(parse_mes_ano)
-        df_filtered = df[df['year_month_parsed'] >= since_year_month]
-        
+
+        # Parse XLSX
+        df = pd.read_excel(BytesIO(response.content), dtype=str)
+        logger.info(f"Loaded {len(df)} rows from XLSX")
+        logger.info(f"Columns: {list(df.columns)}")
+
+        # Normalize column names (lowercase, strip spaces)
+        df.columns = df.columns.str.strip().str.lower()
+
+        # Filter by date
+        # Try to construct year-month from ano + mes columns
+        if 'ano' in df.columns and 'mes' in df.columns:
+            df['year_month_parsed'] = df.apply(
+                lambda row: f"{row['ano']}-{str(int(row['mes'])).zfill(2)}"
+                if row['mes'].isdigit() else None,
+                axis=1
+            )
+            df_filtered = df[df['year_month_parsed'] >= since_year_month]
+        else:
+            logger.warning("Could not find ano/mes columns, returning all rows")
+            df_filtered = df
+
         logger.info(f"Filtered to {len(df_filtered)} rows >= {since_year_month}")
-        
+
         # Convert to list of dicts
         records = df_filtered.to_dict('records')
         return records
-        
+
+    except ImportError as e:
+        logger.error(f"Missing required package: {e}. Install with: pip install httpx pandas openpyxl")
+        raise
+    except Exception as e:
+        logger.error(f"Failed to download/parse VDE XLSX: {e}")
+        raise
+
+async def download_and_parse_vde_zip(since_year_month: str = "2025-09") -> list:
+    """
+    Download and parse VDE ZIP file (raw VDE dump, multiple formulários).
+
+    This is the comprehensive VDE export. We need to identify and parse
+    Formulário 1 and Formulário 3 for the 5 MVI indicators.
+
+    Args:
+        since_year_month: Only return data >= this month (YYYY-MM format)
+
+    Returns:
+        List of parsed VDE data rows (dicts)
+    """
+    logger.info(f"Downloading VDE zip from {VDE_ZIP_URL}...")
+
+    try:
+        import httpx
+        import pandas as pd
+
+        # Download zip
+        async with httpx.AsyncClient(timeout=120.0) as client:
+            response = await client.get(VDE_ZIP_URL)
+            response.raise_for_status()
+
+        logger.info(f"Downloaded {len(response.content)} bytes")
+
+        # Extract and identify relevant files
+        with zipfile.ZipFile(BytesIO(response.content)) as zf:
+            logger.info(f"Files in VDE zip: {zf.namelist()}")
+
+            # Find Formulário 1 and Formulário 3 CSV files
+            # Expected patterns: "formulario_1", "form1", "formulario1", etc.
+            form1_file = None
+            form3_file = None
+
+            for filename in zf.namelist():
+                if not filename.endswith('.csv'):
+                    continue
+                lower_name = filename.lower()
+                if 'formulario' in lower_name or 'form' in lower_name:
+                    if '1' in lower_name and not form1_file:
+                        form1_file = filename
+                    elif '3' in lower_name and not form3_file:
+                        form3_file = filename
+
+            if not form1_file:
+                raise ValueError(
+                    f"Could not identify Formulário 1 file in VDE zip. "
+                    f"Files found: {zf.namelist()}"
+                )
+
+            logger.info(f"Reading Formulário 1: {form1_file}")
+            with zf.open(form1_file) as csvfile:
+                df1 = pd.read_csv(csvfile, encoding='utf-8', dtype=str)
+
+            all_rows = []
+            all_rows.extend(df1.to_dict('records'))
+
+            # Also read Formulário 3 if found (for "Morte por Intervenção de Agente do Estado")
+            if form3_file:
+                logger.info(f"Reading Formulário 3: {form3_file}")
+                with zf.open(form3_file) as csvfile:
+                    df3 = pd.read_csv(csvfile, encoding='utf-8', dtype=str)
+                all_rows.extend(df3.to_dict('records'))
+            else:
+                logger.warning("Formulário 3 not found; 'Morte por Intervenção de Agente do Estado' will be missing")
+
+            logger.info(f"Loaded {len(all_rows)} total rows from VDE")
+
+            # Filter by date
+            # TODO: Implement date filtering based on actual column structure
+            # This depends on the real VDE file format
+
+            return all_rows
+
     except ImportError as e:
         logger.error(f"Missing required package: {e}. Install with: pip install httpx pandas")
         raise
     except Exception as e:
-        logger.error(f"Failed to download/parse VDE data: {e}")
+        logger.error(f"Failed to download/parse VDE ZIP: {e}")
         raise
 
-
-async def main(force: bool = False, since: str = "2025-09"):
+async def main(since: str = "2025-09", source: str = "XLSX"):
     """Load official violence data into database."""
     logger.info("=" * 80)
-    logger.info(f"Loading official violence data (force={force}, since={since})")
+    logger.info(f"Loading official violence data (source={source}, since={since})")
     logger.info("=" * 80)
-    
+
     # Initialize database tables
     await init_db()
     logger.info("Database tables verified")
-    
+
     # Get engine
     engine = get_engine()
-    
+
     # Download and parse VDE data
     try:
-        vde_data = await download_and_parse_vde_data(since_year_month=since)
+        if source.upper() == "XLSX":
+            vde_data = await download_and_parse_vde_xlsx(since_year_month=since)
+        else:
+            vde_data = await download_and_parse_vde_zip(since_year_month=since)
     except Exception as e:
         logger.error(f"✗ Failed to download VDE data: {e}")
-        logger.info("You may need to manually download the VDE zip file and adapt this script")
+        logger.info("Manual alternative: Download the file from dados.mj.gov.br and adapt this script")
         return
-    
+
     # Ingest data
     async with AsyncSession(engine) as session:
         try:
@@ -147,17 +222,11 @@ async def main(force: bool = False, since: str = "2025-09"):
             logger.error(f"✗ Failed to ingest official violence data: {e}")
             raise
 
-
 if __name__ == "__main__":
     import argparse
-    
+
     parser = argparse.ArgumentParser(
         description="Load official violence data from Ministry of Justice VDE"
-    )
-    parser.add_argument(
-        "--force",
-        action="store_true",
-        help="Force reload even if data exists"
     )
     parser.add_argument(
         "--since",
@@ -165,7 +234,14 @@ if __name__ == "__main__":
         default="2025-09",
         help="Only load data from this month onwards (YYYY-MM format, default: 2025-09)"
     )
-    
+    parser.add_argument(
+        "--source",
+        type=str,
+        default="XLSX",
+        choices=["XLSX", "ZIP"],
+        help="Data source: XLSX (municipal aggregated, recommended) or ZIP (raw VDE)"
+    )
+
     args = parser.parse_args()
-    
-    asyncio.run(main(force=args.force, since=args.since))
+
+    asyncio.run(main(since=args.since, source=args.source))

--- a/backend/scripts/load_official_violence_data.py
+++ b/backend/scripts/load_official_violence_data.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""
+Load official violence data from Ministry of Justice VDE dump into the database.
+
+This script downloads and ingests VDE Formulário 1 data (victim counts by
+municipality and month) from the SINESP open data portal.
+
+Usage:
+    python scripts/load_official_violence_data.py [--force] [--since YYYY-MM]
+
+Options:
+    --force          Force reload even if data already exists
+    --since YYYY-MM  Only load data from this month onwards (default: 2025-09)
+"""
+
+import asyncio
+import sys
+import zipfile
+from pathlib import Path
+from io import BytesIO
+
+# Add parent directory to path
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from sqlmodel import SQLModel
+from sqlmodel.ext.asyncio.session import AsyncSession
+from loguru import logger
+
+from app.database import get_engine, init_db
+from app.services.official_violence_data import ingest_official_violence_data
+
+
+VDE_DOWNLOAD_URL = "https://dados.mj.gov.br/dataset/210b9ae2-21fc-4986-89c6-2006eb4db247/resource/e9d6cc2b-33f1-468d-ab09-9aa8303c2eba/download/basededadosvde.zip"
+
+
+async def download_and_parse_vde_data(since_year_month: str = "2025-09") -> list:
+    """
+    Download VDE zip file and parse Formulário 1 CSV.
+    
+    Args:
+        since_year_month: Only return data >= this month (YYYY-MM format)
+    
+    Returns:
+        List of parsed VDE data rows
+    """
+    logger.info(f"Downloading VDE data from {VDE_DOWNLOAD_URL}...")
+    
+    try:
+        import httpx
+        import pandas as pd
+        
+        # Download zip file
+        async with httpx.AsyncClient(timeout=120.0) as client:
+            response = await client.get(VDE_DOWNLOAD_URL)
+            response.raise_for_status()
+        
+        logger.info(f"Downloaded {len(response.content)} bytes")
+        
+        # Extract CSV from zip
+        with zipfile.ZipFile(BytesIO(response.content)) as zf:
+            # Find Formulário 1 CSV (victim counts by municipality)
+            csv_files = [name for name in zf.namelist() if name.endswith('.csv')]
+            
+            if not csv_files:
+                raise ValueError("No CSV files found in VDE zip")
+            
+            # The VDE dump typically contains multiple CSVs, one per formulário
+            # We need Formulário 1 (vítimas por sexo e município)
+            # File naming pattern from docs: likely includes "formulario_1" or similar
+            form1_file = None
+            for csv_file in csv_files:
+                if 'formulario' in csv_file.lower() and '1' in csv_file:
+                    form1_file = csv_file
+                    break
+            
+            if not form1_file:
+                # Fallback: use first CSV (may need adjustment based on actual file structure)
+                logger.warning(f"Could not identify Formulário 1 file, using first CSV: {csv_files[0]}")
+                form1_file = csv_files[0]
+            
+            logger.info(f"Reading {form1_file} from VDE zip...")
+            
+            # Read CSV
+            with zf.open(form1_file) as csvfile:
+                df = pd.read_csv(csvfile, encoding='utf-8', dtype=str)
+        
+        logger.info(f"Loaded {len(df)} rows from VDE CSV")
+        
+        # Filter by date (>= since_year_month)
+        # Convert mes_ano "MM/YYYY" to "YYYY-MM" for comparison
+        def parse_mes_ano(mes_ano: str) -> str:
+            month, year = mes_ano.split("/")
+            return f"{year}-{month.zfill(2)}"
+        
+        df['year_month_parsed'] = df['mes_ano'].apply(parse_mes_ano)
+        df_filtered = df[df['year_month_parsed'] >= since_year_month]
+        
+        logger.info(f"Filtered to {len(df_filtered)} rows >= {since_year_month}")
+        
+        # Convert to list of dicts
+        records = df_filtered.to_dict('records')
+        return records
+        
+    except ImportError as e:
+        logger.error(f"Missing required package: {e}. Install with: pip install httpx pandas")
+        raise
+    except Exception as e:
+        logger.error(f"Failed to download/parse VDE data: {e}")
+        raise
+
+
+async def main(force: bool = False, since: str = "2025-09"):
+    """Load official violence data into database."""
+    logger.info("=" * 80)
+    logger.info(f"Loading official violence data (force={force}, since={since})")
+    logger.info("=" * 80)
+    
+    # Initialize database tables
+    await init_db()
+    logger.info("Database tables verified")
+    
+    # Get engine
+    engine = get_engine()
+    
+    # Download and parse VDE data
+    try:
+        vde_data = await download_and_parse_vde_data(since_year_month=since)
+    except Exception as e:
+        logger.error(f"✗ Failed to download VDE data: {e}")
+        logger.info("You may need to manually download the VDE zip file and adapt this script")
+        return
+    
+    # Ingest data
+    async with AsyncSession(engine) as session:
+        try:
+            await ingest_official_violence_data(
+                session=session,
+                vde_data=vde_data
+            )
+            logger.success("✓ Official violence data loaded successfully")
+            logger.info("=" * 80)
+            logger.info("Next steps:")
+            logger.info("  1. Verify: SELECT COUNT(*) FROM official_violence_count;")
+            logger.info("  2. Test coverage calculation (issue 176)")
+            logger.info("=" * 80)
+        except Exception as e:
+            logger.error(f"✗ Failed to ingest official violence data: {e}")
+            raise
+
+
+if __name__ == "__main__":
+    import argparse
+    
+    parser = argparse.ArgumentParser(
+        description="Load official violence data from Ministry of Justice VDE"
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Force reload even if data exists"
+    )
+    parser.add_argument(
+        "--since",
+        type=str,
+        default="2025-09",
+        help="Only load data from this month onwards (YYYY-MM format, default: 2025-09)"
+    )
+    
+    args = parser.parse_args()
+    
+    asyncio.run(main(force=args.force, since=args.since))

--- a/backend/tests/test_official_violence_data.py
+++ b/backend/tests/test_official_violence_data.py
@@ -1,0 +1,223 @@
+"""Tests for official violence data service (Ministry of Justice VDE data)."""
+
+import pytest
+from sqlmodel import select
+
+from app.models.official_violence_data import OfficialViolenceCount
+from app.services.official_violence_data import (
+    ingest_official_violence_data,
+    get_official_violence_totals,
+)
+
+
+@pytest.mark.asyncio
+async def test_ingest_official_violence_data_single_municipality(async_session):
+    """
+    Test ingesting official violence data for one municipality and one month.
+    
+    This is the core seam: given fixture VDE data for one municipality/month,
+    persist per-indicator counts and the summed mortes_violentas_intencionais total.
+    
+    Acceptance criteria from issue 175:
+    - Store by municipality code + year-month + indicator
+    - Sum the 5 indicators into mortes_violentas_intencionais total
+    """
+    # Fixture: VDE Formulário 1 data for São Paulo (3550308) in Sep 2025
+    # Realistic column structure from Ministry of Justice VDE dump
+    vde_fixture = [
+        {
+            "mes_ano": "09/2025",
+            "uf": "SP",
+            "cod_municipio": "3550308",
+            "municipio": "São Paulo",
+            "tipo_crime": "Homicídio Doloso",
+            "vitimas_masculinas": 45,
+            "vitimas_femininas": 8,
+            "vitimas_nao_identificadas": 0,
+        },
+        {
+            "mes_ano": "09/2025",
+            "uf": "SP",
+            "cod_municipio": "3550308",
+            "municipio": "São Paulo",
+            "tipo_crime": "Feminicídio",
+            "vitimas_masculinas": 0,
+            "vitimas_femininas": 3,
+            "vitimas_nao_identificadas": 0,
+        },
+        {
+            "mes_ano": "09/2025",
+            "uf": "SP",
+            "cod_municipio": "3550308",
+            "municipio": "São Paulo",
+            "tipo_crime": "Roubo Seguido de Morte (Latrocínio)",
+            "vitimas_masculinas": 5,
+            "vitimas_femininas": 1,
+            "vitimas_nao_identificadas": 0,
+        },
+        {
+            "mes_ano": "09/2025",
+            "uf": "SP",
+            "cod_municipio": "3550308",
+            "municipio": "São Paulo",
+            "tipo_crime": "Lesão Corporal Seguida de Morte",
+            "vitimas_masculinas": 2,
+            "vitimas_femininas": 0,
+            "vitimas_nao_identificadas": 0,
+        },
+        {
+            "mes_ano": "09/2025",
+            "uf": "SP",
+            "cod_municipio": "3550308",
+            "municipio": "São Paulo",
+            "tipo_crime": "Morte Decorrente de Intervenção Policial",
+            "vitimas_masculinas": 12,
+            "vitimas_femininas": 1,
+            "vitimas_nao_identificadas": 0,
+        },
+    ]
+    
+    # Ingest
+    await ingest_official_violence_data(async_session, vde_fixture)
+    
+    # Verify per-indicator counts were stored
+    query = select(OfficialViolenceCount).where(
+        OfficialViolenceCount.code_muni == 3550308,
+        OfficialViolenceCount.year_month == "2025-09"
+    ).order_by(OfficialViolenceCount.indicator)
+    
+    result = await async_session.execute(query)
+    counts = result.scalars().all()
+    
+    # Should have 5 indicator rows + 1 summed total row
+    assert len(counts) == 6, f"Expected 6 rows (5 indicators + 1 total), got {len(counts)}"
+    
+    # Check individual indicators
+    homicidio = next(c for c in counts if c.indicator == "homicidio_doloso")
+    assert homicidio.victim_count == 53  # 45 + 8 + 0
+    
+    feminicidio = next(c for c in counts if c.indicator == "feminicidio")
+    assert feminicidio.victim_count == 3
+    
+    latrocinio = next(c for c in counts if c.indicator == "latrocinio")
+    assert latrocinio.victim_count == 6
+    
+    lesao = next(c for c in counts if c.indicator == "lesao_corporal_seguida_morte")
+    assert lesao.victim_count == 2
+    
+    intervencao = next(c for c in counts if c.indicator == "morte_intervencao_policial")
+    assert intervencao.victim_count == 13
+    
+    # Check summed total (mortes violentas intencionais)
+    total = next(c for c in counts if c.indicator == "mortes_violentas_intencionais")
+    assert total.victim_count == 77  # 53 + 3 + 6 + 2 + 13
+    assert total.is_total is True
+
+
+@pytest.mark.asyncio
+async def test_ingest_idempotence(async_session):
+    """
+    Test that re-ingesting the same month overwrites (does not duplicate).
+    
+    Acceptance criteria from issue 175:
+    - Re-running ingest for the same month overwrites, does not duplicate
+    """
+    vde_fixture_v1 = [
+        {
+            "mes_ano": "09/2025",
+            "uf": "RJ",
+            "cod_municipio": "3304557",
+            "municipio": "Rio de Janeiro",
+            "tipo_crime": "Homicídio Doloso",
+            "vitimas_masculinas": 20,
+            "vitimas_femininas": 3,
+            "vitimas_nao_identificadas": 0,
+        },
+    ]
+    
+    vde_fixture_v2 = [
+        {
+            "mes_ano": "09/2025",
+            "uf": "RJ",
+            "cod_municipio": "3304557",
+            "municipio": "Rio de Janeiro",
+            "tipo_crime": "Homicídio Doloso",
+            "vitimas_masculinas": 25,  # Updated count
+            "vitimas_femininas": 5,    # Updated count
+            "vitimas_nao_identificadas": 0,
+        },
+    ]
+    
+    # First ingest
+    await ingest_official_violence_data(async_session, vde_fixture_v1)
+    
+    # Second ingest (same month, updated data)
+    await ingest_official_violence_data(async_session, vde_fixture_v2)
+    
+    # Query results
+    query = select(OfficialViolenceCount).where(
+        OfficialViolenceCount.code_muni == 3304557,
+        OfficialViolenceCount.year_month == "2025-09",
+        OfficialViolenceCount.indicator == "homicidio_doloso"
+    )
+    result = await async_session.execute(query)
+    counts = result.scalars().all()
+    
+    # Should have exactly 1 row (not duplicated)
+    assert len(counts) == 1
+    # Should have the updated values
+    assert counts[0].victim_count == 30  # 25 + 5
+
+
+@pytest.mark.asyncio
+async def test_get_official_violence_totals_window_filter(async_session):
+    """
+    Test that querying official totals respects the v1 window (>= 2025-09).
+    
+    Acceptance criteria from issue 175:
+    - Window starts at 2025-09 (first full month after Arquivo start 2025-08-26)
+    - Older months may be stored but are out of the v1 table
+    """
+    # Fixture: data before and after the window cutoff
+    fixture_before_window = [
+        {
+            "mes_ano": "08/2025",  # Before window
+            "uf": "SP",
+            "cod_municipio": "3550308",
+            "municipio": "São Paulo",
+            "tipo_crime": "Homicídio Doloso",
+            "vitimas_masculinas": 50,
+            "vitimas_femininas": 10,
+            "vitimas_nao_identificadas": 0,
+        },
+    ]
+    
+    fixture_in_window = [
+        {
+            "mes_ano": "09/2025",  # In window
+            "uf": "SP",
+            "cod_municipio": "3550308",
+            "municipio": "São Paulo",
+            "tipo_crime": "Homicídio Doloso",
+            "vitimas_masculinas": 45,
+            "vitimas_femininas": 8,
+            "vitimas_nao_identificadas": 0,
+        },
+    ]
+    
+    # Ingest both
+    await ingest_official_violence_data(async_session, fixture_before_window)
+    await ingest_official_violence_data(async_session, fixture_in_window)
+    
+    # Query with window filter
+    totals = await get_official_violence_totals(
+        async_session,
+        code_munis=[3550308],
+        min_year_month="2025-09"  # Window starts here
+    )
+    
+    # Should only return data >= 2025-09
+    assert len(totals) == 1
+    assert totals[0]["code_muni"] == 3550308
+    assert totals[0]["year_month"] == "2025-09"
+    # Should NOT include the August data

--- a/backend/tests/test_official_violence_data.py
+++ b/backend/tests/test_official_violence_data.py
@@ -16,18 +16,19 @@ from app.services.official_violence_data import (
 @pytest.fixture
 async def setup_ibge_data(async_session):
     """Load IBGE population data for municipality name resolution."""
-    # Add test municipalities
+    # Add test municipalities with title case names (as geobr provides)
+    # Real dump uses uppercase ("SÃO PAULO"), IBGE uses title case ("São Paulo")
     municipalities = [
         IBGEPopulation(
             code_muni=3550308,
-            name_muni="SÃO PAULO",
+            name_muni="São Paulo",  # Title case (as from geobr)
             abbrev_state="SP",
             population=12396372,
             year=2022
         ),
         IBGEPopulation(
             code_muni=3304557,
-            name_muni="RIO DE JANEIRO",
+            name_muni="Rio de Janeiro",  # Title case (as from geobr)
             abbrev_state="RJ",
             population=6775561,
             year=2022
@@ -325,3 +326,94 @@ async def test_get_official_violence_totals_window_filter(async_session, setup_i
     assert totals[0]["code_muni"] == 3550308
     assert totals[0]["year_month"] == "2025-09"
     # Should NOT include the August data
+
+@pytest.mark.asyncio
+async def test_case_insensitive_municipality_resolution(async_session, setup_ibge_data):
+    """
+    Test that municipality name resolution is case-insensitive.
+
+    The dump uses uppercase names ("SÃO PAULO"), while ibge_population
+    from geobr uses title case ("São Paulo"). Resolution must be case-insensitive
+    (casefold both sides) to avoid dropping all rows.
+
+    Spec: Accents stay as-is (Ã = Ã), only case is normalized.
+    """
+    # IBGE fixture already has name_muni="SÃO PAULO", abbrev_state="SP" (uppercase in setup_ibge_data)
+    # But let's verify with explicit title case entry too
+    # Actually, setup_ibge_data uses uppercase - let me check the fixture
+
+    # Dump row with uppercase municipality name
+    vde_fixture = [
+        {
+            "uf": "SP",
+            "municipio": "SÃO PAULO",  # Uppercase (as in real dump)
+            "evento": "Homicídio doloso",
+            "data_referencia": 45901,  # 2025-09-01
+            "agente": "",
+            "arma": "",
+            "faixa_etaria": "",
+            "feminino": 0,
+            "masculino": 42,
+            "nao_informado": 0,
+            "total_vitima": 42,
+            "total": 0,
+            "total_peso": 0,
+            "abrangencia": ""
+        },
+    ]
+
+    # Ingest
+    await ingest_official_violence_data(async_session, vde_fixture)
+
+    # Verify row was stored with correct code_muni
+    query = select(OfficialViolenceCount).where(
+        OfficialViolenceCount.code_muni == 3550308,
+        OfficialViolenceCount.year_month == "2025-09",
+        OfficialViolenceCount.indicator == "homicidio_doloso"
+    )
+    result = await async_session.execute(query)
+    counts = result.scalars().all()
+
+    # Should match despite case difference
+    assert len(counts) == 1
+    assert counts[0].victim_count == 42
+    assert counts[0].code_muni == 3550308
+
+@pytest.mark.asyncio
+async def test_unmatched_municipality_dropped(async_session, setup_ibge_data):
+    """
+    Test that rows with unmatched municipality names are dropped.
+
+    Spec: Rows that don't match an IBGE code are dropped (no unmatched name-only rows).
+    """
+    # Dump row with non-existent municipality
+    vde_fixture = [
+        {
+            "uf": "ZZ",
+            "municipio": "CIDADE INEXISTENTE",  # Does not exist in IBGE
+            "evento": "Homicídio doloso",
+            "data_referencia": 45901,  # 2025-09-01
+            "agente": "",
+            "arma": "",
+            "faixa_etaria": "",
+            "feminino": 0,
+            "masculino": 99,
+            "nao_informado": 0,
+            "total_vitima": 99,
+            "total": 0,
+            "total_peso": 0,
+            "abrangencia": ""
+        },
+    ]
+
+    # Ingest
+    await ingest_official_violence_data(async_session, vde_fixture)
+
+    # Query all rows - should be empty (unmatched row dropped)
+    query = select(OfficialViolenceCount)
+    result = await async_session.execute(query)
+    counts = result.scalars().all()
+
+    # Should have zero rows (unmatched municipality dropped)
+    assert len(counts) == 0
+

--- a/backend/tests/test_official_violence_data.py
+++ b/backend/tests/test_official_violence_data.py
@@ -9,151 +9,142 @@ from app.services.official_violence_data import (
     get_official_violence_totals,
 )
 
-
 @pytest.mark.asyncio
 async def test_ingest_official_violence_data_single_municipality(async_session):
     """
     Test ingesting official violence data for one municipality and one month.
-    
+
     This is the core seam: given fixture VDE data for one municipality/month,
     persist per-indicator counts and the summed mortes_violentas_intencionais total.
-    
-    Acceptance criteria from issue 175:
+
+    Acceptance criteria from issue #175:
     - Store by municipality code + year-month + indicator
     - Sum the 5 indicators into mortes_violentas_intencionais total
     """
-    # Fixture: VDE Formulário 1 data for São Paulo (3550308) in Sep 2025
-    # Realistic column structure from Ministry of Justice VDE dump
+    # Fixture: VDE data for São Paulo (3550308) in Sep 2025
+    # Realistic column structure from Ministry of Justice VDE municipal data
     vde_fixture = [
         {
-            "mes_ano": "09/2025",
+            "ano": "2025",
+            "mes": "9",
             "uf": "SP",
-            "cod_municipio": "3550308",
             "municipio": "São Paulo",
+            "cod_municipio": "3550308",
             "tipo_crime": "Homicídio Doloso",
-            "vitimas_masculinas": 45,
-            "vitimas_femininas": 8,
-            "vitimas_nao_identificadas": 0,
+            "vitimas": "53",
         },
         {
-            "mes_ano": "09/2025",
+            "ano": "2025",
+            "mes": "9",
             "uf": "SP",
-            "cod_municipio": "3550308",
             "municipio": "São Paulo",
+            "cod_municipio": "3550308",
             "tipo_crime": "Feminicídio",
-            "vitimas_masculinas": 0,
-            "vitimas_femininas": 3,
-            "vitimas_nao_identificadas": 0,
+            "vitimas": "3",
         },
         {
-            "mes_ano": "09/2025",
+            "ano": "2025",
+            "mes": "9",
             "uf": "SP",
-            "cod_municipio": "3550308",
             "municipio": "São Paulo",
+            "cod_municipio": "3550308",
             "tipo_crime": "Roubo Seguido de Morte (Latrocínio)",
-            "vitimas_masculinas": 5,
-            "vitimas_femininas": 1,
-            "vitimas_nao_identificadas": 0,
+            "vitimas": "6",
         },
         {
-            "mes_ano": "09/2025",
+            "ano": "2025",
+            "mes": "9",
             "uf": "SP",
-            "cod_municipio": "3550308",
             "municipio": "São Paulo",
+            "cod_municipio": "3550308",
             "tipo_crime": "Lesão Corporal Seguida de Morte",
-            "vitimas_masculinas": 2,
-            "vitimas_femininas": 0,
-            "vitimas_nao_identificadas": 0,
+            "vitimas": "2",
         },
         {
-            "mes_ano": "09/2025",
+            "ano": "2025",
+            "mes": "9",
             "uf": "SP",
-            "cod_municipio": "3550308",
             "municipio": "São Paulo",
-            "tipo_crime": "Morte Decorrente de Intervenção Policial",
-            "vitimas_masculinas": 12,
-            "vitimas_femininas": 1,
-            "vitimas_nao_identificadas": 0,
+            "cod_municipio": "3550308",
+            "tipo_crime": "Morte por Intervenção de Agente do Estado",
+            "vitimas": "13",
         },
     ]
-    
+
     # Ingest
     await ingest_official_violence_data(async_session, vde_fixture)
-    
+
     # Verify per-indicator counts were stored
     query = select(OfficialViolenceCount).where(
         OfficialViolenceCount.code_muni == 3550308,
         OfficialViolenceCount.year_month == "2025-09"
     ).order_by(OfficialViolenceCount.indicator)
-    
+
     result = await async_session.execute(query)
     counts = result.scalars().all()
-    
+
     # Should have 5 indicator rows + 1 summed total row
     assert len(counts) == 6, f"Expected 6 rows (5 indicators + 1 total), got {len(counts)}"
-    
+
     # Check individual indicators
     homicidio = next(c for c in counts if c.indicator == "homicidio_doloso")
-    assert homicidio.victim_count == 53  # 45 + 8 + 0
-    
+    assert homicidio.victim_count == 53
+
     feminicidio = next(c for c in counts if c.indicator == "feminicidio")
     assert feminicidio.victim_count == 3
-    
+
     latrocinio = next(c for c in counts if c.indicator == "latrocinio")
     assert latrocinio.victim_count == 6
-    
+
     lesao = next(c for c in counts if c.indicator == "lesao_corporal_seguida_morte")
     assert lesao.victim_count == 2
-    
+
     intervencao = next(c for c in counts if c.indicator == "morte_intervencao_policial")
     assert intervencao.victim_count == 13
-    
+
     # Check summed total (mortes violentas intencionais)
     total = next(c for c in counts if c.indicator == "mortes_violentas_intencionais")
     assert total.victim_count == 77  # 53 + 3 + 6 + 2 + 13
     assert total.is_total is True
 
-
 @pytest.mark.asyncio
 async def test_ingest_idempotence(async_session):
     """
     Test that re-ingesting the same month overwrites (does not duplicate).
-    
-    Acceptance criteria from issue 175:
+
+    Acceptance criteria from issue #175:
     - Re-running ingest for the same month overwrites, does not duplicate
     """
     vde_fixture_v1 = [
         {
-            "mes_ano": "09/2025",
+            "ano": "2025",
+            "mes": "9",
             "uf": "RJ",
-            "cod_municipio": "3304557",
             "municipio": "Rio de Janeiro",
+            "cod_municipio": "3304557",
             "tipo_crime": "Homicídio Doloso",
-            "vitimas_masculinas": 20,
-            "vitimas_femininas": 3,
-            "vitimas_nao_identificadas": 0,
+            "vitimas": "23",
         },
     ]
-    
+
     vde_fixture_v2 = [
         {
-            "mes_ano": "09/2025",
+            "ano": "2025",
+            "mes": "9",
             "uf": "RJ",
-            "cod_municipio": "3304557",
             "municipio": "Rio de Janeiro",
+            "cod_municipio": "3304557",
             "tipo_crime": "Homicídio Doloso",
-            "vitimas_masculinas": 25,  # Updated count
-            "vitimas_femininas": 5,    # Updated count
-            "vitimas_nao_identificadas": 0,
+            "vitimas": "30",  # Updated count
         },
     ]
-    
+
     # First ingest
     await ingest_official_violence_data(async_session, vde_fixture_v1)
-    
+
     # Second ingest (same month, updated data)
     await ingest_official_violence_data(async_session, vde_fixture_v2)
-    
+
     # Query results
     query = select(OfficialViolenceCount).where(
         OfficialViolenceCount.code_muni == 3304557,
@@ -162,60 +153,57 @@ async def test_ingest_idempotence(async_session):
     )
     result = await async_session.execute(query)
     counts = result.scalars().all()
-    
+
     # Should have exactly 1 row (not duplicated)
     assert len(counts) == 1
     # Should have the updated values
-    assert counts[0].victim_count == 30  # 25 + 5
-
+    assert counts[0].victim_count == 30
 
 @pytest.mark.asyncio
 async def test_get_official_violence_totals_window_filter(async_session):
     """
     Test that querying official totals respects the v1 window (>= 2025-09).
-    
-    Acceptance criteria from issue 175:
+
+    Acceptance criteria from issue #175:
     - Window starts at 2025-09 (first full month after Arquivo start 2025-08-26)
     - Older months may be stored but are out of the v1 table
     """
     # Fixture: data before and after the window cutoff
     fixture_before_window = [
         {
-            "mes_ano": "08/2025",  # Before window
+            "ano": "2025",
+            "mes": "8",  # Before window
             "uf": "SP",
-            "cod_municipio": "3550308",
             "municipio": "São Paulo",
+            "cod_municipio": "3550308",
             "tipo_crime": "Homicídio Doloso",
-            "vitimas_masculinas": 50,
-            "vitimas_femininas": 10,
-            "vitimas_nao_identificadas": 0,
+            "vitimas": "60",
         },
     ]
-    
+
     fixture_in_window = [
         {
-            "mes_ano": "09/2025",  # In window
+            "ano": "2025",
+            "mes": "9",  # In window
             "uf": "SP",
-            "cod_municipio": "3550308",
             "municipio": "São Paulo",
+            "cod_municipio": "3550308",
             "tipo_crime": "Homicídio Doloso",
-            "vitimas_masculinas": 45,
-            "vitimas_femininas": 8,
-            "vitimas_nao_identificadas": 0,
+            "vitimas": "53",
         },
     ]
-    
+
     # Ingest both
     await ingest_official_violence_data(async_session, fixture_before_window)
     await ingest_official_violence_data(async_session, fixture_in_window)
-    
+
     # Query with window filter
     totals = await get_official_violence_totals(
         async_session,
         code_munis=[3550308],
         min_year_month="2025-09"  # Window starts here
     )
-    
+
     # Should only return data >= 2025-09
     assert len(totals) == 1
     assert totals[0]["code_muni"] == 3550308

--- a/backend/tests/test_official_violence_data.py
+++ b/backend/tests/test_official_violence_data.py
@@ -4,13 +4,41 @@ import pytest
 from sqlmodel import select
 
 from app.models.official_violence_data import OfficialViolenceCount
+from app.models.ibge_population import IBGEPopulation
 from app.services.official_violence_data import (
     ingest_official_violence_data,
     get_official_violence_totals,
 )
 
+# dump headers from bancovde-2025.xlsx:
+# ["uf","municipio","evento","data_referencia","agente","arma","faixa_etaria","feminino","masculino","nao_informado","total_vitima","total","total_peso","abrangencia"]
+
+@pytest.fixture
+async def setup_ibge_data(async_session):
+    """Load IBGE population data for municipality name resolution."""
+    # Add test municipalities
+    municipalities = [
+        IBGEPopulation(
+            code_muni=3550308,
+            name_muni="SÃO PAULO",
+            abbrev_state="SP",
+            population=12396372,
+            year=2022
+        ),
+        IBGEPopulation(
+            code_muni=3304557,
+            name_muni="RIO DE JANEIRO",
+            abbrev_state="RJ",
+            population=6775561,
+            year=2022
+        ),
+    ]
+    for muni in municipalities:
+        async_session.add(muni)
+    await async_session.commit()
+
 @pytest.mark.asyncio
-async def test_ingest_official_violence_data_single_municipality(async_session):
+async def test_ingest_official_violence_data_single_municipality(async_session, setup_ibge_data):
     """
     Test ingesting official violence data for one municipality and one month.
 
@@ -20,54 +48,114 @@ async def test_ingest_official_violence_data_single_municipality(async_session):
     Acceptance criteria from issue #175:
     - Store by municipality code + year-month + indicator
     - Sum the 5 indicators into mortes_violentas_intencionais total
+
+    Fixture uses real bancovde-2025.xlsx column structure (14 columns).
+    Excel serial date 45901 = 2025-09-01.
+    Rows are sliced by agente/arma/faixa_etaria - we sum total_vitima.
     """
-    # Fixture: VDE data for São Paulo (3550308) in Sep 2025
-    # Realistic column structure from Ministry of Justice VDE municipal data
+    # Fixture: bancovde data for São Paulo (SP) in Sep 2025
+    # Multiple rows per evento (disaggregated by agente/arma/faixa_etaria) - should be summed
     vde_fixture = [
+        # Homicídio doloso: 2 rows, sum = 53
         {
-            "ano": "2025",
-            "mes": "9",
             "uf": "SP",
-            "municipio": "São Paulo",
-            "cod_municipio": "3550308",
-            "tipo_crime": "Homicídio Doloso",
-            "vitimas": "53",
+            "municipio": "SÃO PAULO",
+            "evento": "Homicídio doloso",
+            "data_referencia": 45901,  # 2025-09-01
+            "agente": "",
+            "arma": "Arma de fogo",
+            "faixa_etaria": "18 a 24",
+            "feminino": 0,
+            "masculino": 30,
+            "nao_informado": 0,
+            "total_vitima": 30,
+            "total": 0,
+            "total_peso": 0,
+            "abrangencia": ""
         },
         {
-            "ano": "2025",
-            "mes": "9",
             "uf": "SP",
-            "municipio": "São Paulo",
-            "cod_municipio": "3550308",
-            "tipo_crime": "Feminicídio",
-            "vitimas": "3",
+            "municipio": "SÃO PAULO",
+            "evento": "Homicídio doloso",
+            "data_referencia": 45901,
+            "agente": "",
+            "arma": "Arma branca",
+            "faixa_etaria": "25 a 29",
+            "feminino": 0,
+            "masculino": 23,
+            "nao_informado": 0,
+            "total_vitima": 23,
+            "total": 0,
+            "total_peso": 0,
+            "abrangencia": ""
         },
+        # Feminicídio: 1 row
         {
-            "ano": "2025",
-            "mes": "9",
             "uf": "SP",
-            "municipio": "São Paulo",
-            "cod_municipio": "3550308",
-            "tipo_crime": "Roubo Seguido de Morte (Latrocínio)",
-            "vitimas": "6",
+            "municipio": "SÃO PAULO",
+            "evento": "Feminicídio",
+            "data_referencia": 45901,
+            "agente": "",
+            "arma": "",
+            "faixa_etaria": "",
+            "feminino": 3,
+            "masculino": 0,
+            "nao_informado": 0,
+            "total_vitima": 3,
+            "total": 0,
+            "total_peso": 0,
+            "abrangencia": ""
         },
+        # Roubo seguido de morte (latrocínio): 1 row
         {
-            "ano": "2025",
-            "mes": "9",
             "uf": "SP",
-            "municipio": "São Paulo",
-            "cod_municipio": "3550308",
-            "tipo_crime": "Lesão Corporal Seguida de Morte",
-            "vitimas": "2",
+            "municipio": "SÃO PAULO",
+            "evento": "Roubo seguido de morte (latrocínio)",
+            "data_referencia": 45901,
+            "agente": "",
+            "arma": "",
+            "faixa_etaria": "",
+            "feminino": 0,
+            "masculino": 6,
+            "nao_informado": 0,
+            "total_vitima": 6,
+            "total": 0,
+            "total_peso": 0,
+            "abrangencia": ""
         },
+        # Lesão corporal seguida de morte: 1 row
         {
-            "ano": "2025",
-            "mes": "9",
             "uf": "SP",
-            "municipio": "São Paulo",
-            "cod_municipio": "3550308",
-            "tipo_crime": "Morte por Intervenção de Agente do Estado",
-            "vitimas": "13",
+            "municipio": "SÃO PAULO",
+            "evento": "Lesão corporal seguida de morte",
+            "data_referencia": 45901,
+            "agente": "",
+            "arma": "",
+            "faixa_etaria": "",
+            "feminino": 0,
+            "masculino": 2,
+            "nao_informado": 0,
+            "total_vitima": 2,
+            "total": 0,
+            "total_peso": 0,
+            "abrangencia": ""
+        },
+        # Morte por intervenção de Agente do Estado: 1 row
+        {
+            "uf": "SP",
+            "municipio": "SÃO PAULO",
+            "evento": "Morte por intervenção de Agente do Estado",
+            "data_referencia": 45901,
+            "agente": "Polícia Militar",
+            "arma": "",
+            "faixa_etaria": "",
+            "feminino": 0,
+            "masculino": 13,
+            "nao_informado": 0,
+            "total_vitima": 13,
+            "total": 0,
+            "total_peso": 0,
+            "abrangencia": ""
         },
     ]
 
@@ -88,7 +176,7 @@ async def test_ingest_official_violence_data_single_municipality(async_session):
 
     # Check individual indicators
     homicidio = next(c for c in counts if c.indicator == "homicidio_doloso")
-    assert homicidio.victim_count == 53
+    assert homicidio.victim_count == 53  # 30 + 23 from disaggregated rows
 
     feminicidio = next(c for c in counts if c.indicator == "feminicidio")
     assert feminicidio.victim_count == 3
@@ -108,7 +196,7 @@ async def test_ingest_official_violence_data_single_municipality(async_session):
     assert total.is_total is True
 
 @pytest.mark.asyncio
-async def test_ingest_idempotence(async_session):
+async def test_ingest_idempotence(async_session, setup_ibge_data):
     """
     Test that re-ingesting the same month overwrites (does not duplicate).
 
@@ -117,25 +205,39 @@ async def test_ingest_idempotence(async_session):
     """
     vde_fixture_v1 = [
         {
-            "ano": "2025",
-            "mes": "9",
             "uf": "RJ",
-            "municipio": "Rio de Janeiro",
-            "cod_municipio": "3304557",
-            "tipo_crime": "Homicídio Doloso",
-            "vitimas": "23",
+            "municipio": "RIO DE JANEIRO",
+            "evento": "Homicídio doloso",
+            "data_referencia": 45901,  # 2025-09-01
+            "agente": "",
+            "arma": "",
+            "faixa_etaria": "",
+            "feminino": 0,
+            "masculino": 23,
+            "nao_informado": 0,
+            "total_vitima": 23,
+            "total": 0,
+            "total_peso": 0,
+            "abrangencia": ""
         },
     ]
 
     vde_fixture_v2 = [
         {
-            "ano": "2025",
-            "mes": "9",
             "uf": "RJ",
-            "municipio": "Rio de Janeiro",
-            "cod_municipio": "3304557",
-            "tipo_crime": "Homicídio Doloso",
-            "vitimas": "30",  # Updated count
+            "municipio": "RIO DE JANEIRO",
+            "evento": "Homicídio doloso",
+            "data_referencia": 45901,
+            "agente": "",
+            "arma": "",
+            "faixa_etaria": "",
+            "feminino": 0,
+            "masculino": 30,
+            "nao_informado": 0,
+            "total_vitima": 30,  # Updated count
+            "total": 0,
+            "total_peso": 0,
+            "abrangencia": ""
         },
     ]
 
@@ -160,7 +262,7 @@ async def test_ingest_idempotence(async_session):
     assert counts[0].victim_count == 30
 
 @pytest.mark.asyncio
-async def test_get_official_violence_totals_window_filter(async_session):
+async def test_get_official_violence_totals_window_filter(async_session, setup_ibge_data):
     """
     Test that querying official totals respects the v1 window (>= 2025-09).
 
@@ -171,25 +273,39 @@ async def test_get_official_violence_totals_window_filter(async_session):
     # Fixture: data before and after the window cutoff
     fixture_before_window = [
         {
-            "ano": "2025",
-            "mes": "8",  # Before window
             "uf": "SP",
-            "municipio": "São Paulo",
-            "cod_municipio": "3550308",
-            "tipo_crime": "Homicídio Doloso",
-            "vitimas": "60",
+            "municipio": "SÃO PAULO",
+            "evento": "Homicídio doloso",
+            "data_referencia": 45870,  # 2025-08-01 (before window)
+            "agente": "",
+            "arma": "",
+            "faixa_etaria": "",
+            "feminino": 0,
+            "masculino": 60,
+            "nao_informado": 0,
+            "total_vitima": 60,
+            "total": 0,
+            "total_peso": 0,
+            "abrangencia": ""
         },
     ]
 
     fixture_in_window = [
         {
-            "ano": "2025",
-            "mes": "9",  # In window
             "uf": "SP",
-            "municipio": "São Paulo",
-            "cod_municipio": "3550308",
-            "tipo_crime": "Homicídio Doloso",
-            "vitimas": "53",
+            "municipio": "SÃO PAULO",
+            "evento": "Homicídio doloso",
+            "data_referencia": 45901,  # 2025-09-01 (in window)
+            "agente": "",
+            "arma": "",
+            "faixa_etaria": "",
+            "feminino": 0,
+            "masculino": 53,
+            "nao_informado": 0,
+            "total_vitima": 53,
+            "total": 0,
+            "total_peso": 0,
+            "abrangencia": ""
         },
     ]
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements issue #175: Store official monthly victim counts from Ministry of Justice VDE (Validador de Dados Estatísticos) data.

This PR adds:
- SQLModel `OfficialViolenceCount` table with unique constraint on (code_muni, year_month, indicator)
- Service layer for ingesting bancovde-YYYY.xlsx data and querying official totals
- Municipality name resolution via `ibge_population` table (file has no IBGE codes)
- Alembic migration for table creation
- Load script to download and ingest data from gov.br
- Comprehensive test suite (3 seams: sum, idempotence, window filter)

## Data Source

**File format**: `bancovde-YYYY.xlsx` from Ministry of Justice
**URL**: https://www.gov.br/mj/pt-br/assuntos/sua-seguranca/seguranca-publica/estatistica/download/dnsp-base-de-dados/bancovde-2025.xlsx/@@download/file

**Sheet**: "2025" (year-specific sheet name)
**Rows**: ~832k per year
**Columns**: 14

### Headers from bancovde-2025.xlsx

```
["uf","municipio","evento","data_referencia","agente","arma","faixa_etaria","feminino","masculino","nao_informado","total_vitima","total","total_peso","abrangencia"]
```

## Key Implementation Details

1. **No IBGE codes in file**: Municipality resolution via `(uf, municipio)` lookup in `ibge_population` table. Unmatched rows are dropped.

2. **Excel serial dates**: `data_referencia` column uses Excel serial dates (e.g. 45901 = 2025-09-01). Converted to YYYY-MM format.

3. **Disaggregated rows**: Data is sliced by `agente`, `arma`, `faixa_etaria`. Service sums `total_vitima` for same `(uf, municipio, year_month, evento)` before storing.

4. **Five MVI indicators**: Stores individual counts for:
   - Homicídio doloso
   - Feminicídio
   - Roubo seguido de morte (latrocínio)
   - Lesão corporal seguida de morte
   - Morte por intervenção de Agente do Estado

5. **Summed total**: Also stores calculated "mortes violentas intencionais" total (sum of all 5 indicators).

6. **Idempotent ingestion**: Re-running ingest for same month overwrites existing data (explicit select + update/insert logic).

7. **Window filter**: v1 table data starts at 2025-09 (first full month after Arquivo start date 2025-08-26). Query function defaults to this window.

## Testing

Three seam tests all pass:
- ✅ **Sum test**: Correctly sums disaggregated rows by (code_muni, year_month, indicator)
- ✅ **Idempotence test**: Re-ingestion overwrites, does not duplicate
- ✅ **Window test**: Query respects `min_year_month` filter (>= 2025-09)

## Next Steps (Out of Scope)

- Issue #176: Calculate coverage metrics (compare our counts vs official counts)
- Issue #174: Tag system implementation (dependencies, not started)

---

Closes #175
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-07f8d1a8-0cf6-490d-ae36-15a38230a358?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-07f8d1a8-0cf6-490d-ae36-15a38230a358&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

