### PR TITLE
Clean up /estatisticas page: remove heatmap, grids, and broken components

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -34,6 +34,10 @@
       "devDependencies": {
         "@eslint/js": "^9.39.1",
         "@tailwindcss/vite": "^4.1.18",
+        "@testing-library/jest-dom": "^7.0.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.6",
+        "@types/jsdom": "^30.0.0",
         "@types/node": "^24.10.4",
         "@types/react": "^19.2.5",
         "@types/react-dom": "^19.2.3",
@@ -42,6 +46,7 @@
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.4.24",
         "globals": "^16.5.0",
+        "jsdom": "^29.1.1",
         "tailwindcss": "^4.1.18",
         "tw-animate-css": "^1.4.0",
         "typescript": "~5.9.3",
@@ -49,6 +54,13 @@
         "vite": "^7.2.4",
         "vitest": "^3.2.4"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+      "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@amcharts/amcharts5": {
       "version": "5.14.4",
@@ -145,6 +157,57 @@
       "dependencies": {
         "tslib": "^2.8.1"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
@@ -380,6 +443,16 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.27.2",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
@@ -428,6 +501,19 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
     "node_modules/@carto/api-client": {
       "version": "0.5.30",
       "resolved": "https://registry.npmjs.org/@carto/api-client/-/api-client-0.5.30.tgz",
@@ -441,6 +527,146 @@
         "h3-js": "^4.1.0",
         "jsep": "^1.4.0",
         "quadbin": "^0.4.1-alpha.0"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.1.tgz",
+      "integrity": "sha512-gLNsunvwf3mCi5u5o46/Z/JcJMnhbHSaZ69rkgPzNM3J4s8hWwpPUQB6/tt0EDFyCiWzxANlx+2LJwpYj4zS1w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.2.0.tgz",
+      "integrity": "sha512-5+5LEmFuY1AjXdYhmgjTJogtQnP1evJ1zrBZGUNZ0thkpwnnmKxcHdAMn/OtFjAb25zA+jKDVYVRl+5G7rjv1A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.1",
+        "@csstools/css-calc": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.8.tgz",
+      "integrity": "sha512-CpMLjAvwQg3BL5S0IeqsZNMH7EQrEWi0kLKOC13ZBF0ZwERiLWlibNPJr8G1kdU3Ms/r2KiNrF81pUh2HwAHdg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@deck.gl/aggregation-layers": {
@@ -1368,6 +1594,24 @@
       "peer": true,
       "bin": {
         "spriter": "bin/spriter.js"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@floating-ui/core": {
@@ -3539,6 +3783,105 @@
         "react": "^18 || ^19"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-7.0.1.tgz",
+      "integrity": "sha512-oMDTC3oA+6CXSO2JZnvOI7CA6oVub6kij5ggk9ohwye5slmkwxYDXcPOVxgMw/RQlticjtO0C1RZkR97HgrWMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=22",
+        "npm": ">=6",
+        "yarn": ">=1"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=10 <11",
+        "vitest": ">= 0.32"
+      },
+      "peerDependenciesMeta": {
+        "vitest": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.6",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.6.tgz",
+      "integrity": "sha512-Jbs9FpkkIDw8FgSc6kOVsOv8JuuqGAL7J4X1oot77JxAoDlkNn2GRkd0aYRVuQ+pVQAiHWVkE4rX/dkF5fBiCw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
     "node_modules/@turf/boolean-clockwise": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/boolean-clockwise/-/boolean-clockwise-5.1.5.tgz",
@@ -3594,6 +3937,14 @@
         "@turf/invariant": "^5.1.5",
         "@turf/meta": "^5.1.5"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -4007,6 +4358,26 @@
       "integrity": "sha512-e52bmOhGCQSNabFpL48iQlwJybq6rfns8NUVJ20MR7CdPlHQ2RmSCnPbJfrUYJfogrE4OiHQTZ4LXpop+eer1w==",
       "license": "MIT"
     },
+    "node_modules/@types/jsdom": {
+      "version": "30.0.0",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-30.0.0.tgz",
+      "integrity": "sha512-uAHGxujGE0cDaKGdK28zgDotFtNA7MKq5DXl8LrfdxdCI8VHcg15oJz+amHTChPNI5JpgEPQWc2xFdrw3em/nQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "parse5": "^8.0.0",
+        "undici-types": "^8.9.0"
+      }
+    },
+    "node_modules/@types/jsdom/node_modules/undici-types": {
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.10.0.tgz",
+      "integrity": "sha512-ibvdovq3nCFs8Msrd95BW+zUOq+aOVbT+wpHUoPWhztbHEoPc6oof51iFDB6Es8lTKvNvVW9jNSAB8dwrKTMGg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -4075,6 +4446,13 @@
       "integrity": "sha512-UNOnbTtl0nVTm8hwKaz5R5VZRvSulFMGojO5+Q7yucKxBoCaTtS4ibSQVRHo5VW5AaRo145U8p1Vfg5KrYe9Bg==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
@@ -4832,6 +5210,17 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -4896,6 +5285,16 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
       }
     },
     "node_modules/arr-union": {
@@ -4970,6 +5369,16 @@
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/brace-expansion": {
@@ -5485,6 +5894,27 @@
       "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cssfilter": {
       "version": "0.0.10",
@@ -6050,6 +6480,20 @@
         "node": ">=12"
       }
     },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -6067,6 +6511,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/decimal.js-light": {
       "version": "2.5.1",
@@ -6210,6 +6661,16 @@
         "robust-predicates": "^3.0.2"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -6230,6 +6691,14 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
       "integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
       "license": "MIT",
       "peer": true
     },
@@ -6289,6 +6758,19 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-define-property": {
@@ -7062,6 +7544,19 @@
       "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
       "license": "MIT"
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
@@ -7158,6 +7653,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/inherits": {
@@ -7275,6 +7780,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -7364,6 +7876,57 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/jsep": {
@@ -7862,6 +8425,17 @@
         "node": ">=12"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/lz4js": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/lz4js/-/lz4js-0.2.0.tgz",
@@ -7987,6 +8561,23 @@
         "charenc": "0.0.2",
         "crypt": "0.0.2",
         "is-buffer": "~1.1.6"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -8191,6 +8782,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -8389,6 +8993,44 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
@@ -8677,6 +9319,20 @@
         "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/redux": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
@@ -8711,6 +9367,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/reselect": {
@@ -8814,6 +9480,19 @@
       "peer": true,
       "engines": {
         "node": ">=11.0.0"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -9060,6 +9739,19 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -9126,6 +9818,13 @@
       "integrity": "sha512-djbJ/vZKZO+gPoSDThGNpKDO+o+bAeA4XQKovvkNCqnIS2t+S4qnLAGQhyyrulhCFRl1WWzAp0wUDV8PpTVU3g==",
       "license": "ISC",
       "peer": true
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tabbable": {
       "version": "6.5.0",
@@ -9290,6 +9989,52 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.4.11",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.11.tgz",
+      "integrity": "sha512-aBiNayCfTQxuIJBm06M+xR14cYaYlDlSXZbgsnKzKNxDKUVq7KFwTjwBSsb7m9Y5xO8WfPnBc63WaYFMTGlvqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.11"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.11",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.11.tgz",
+      "integrity": "sha512-CW3WN2rIIE/Of21mulhgnGOwoDyEFNygyIBOONSdyAuSATgMMUCpLeUlB+E8sAwA5xRV9hYPl+kyZ9citHCaKg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/ts-api-utils": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
@@ -9405,6 +10150,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -9766,6 +10521,54 @@
         }
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -9818,6 +10621,16 @@
         "node": ">=12.17"
       }
     },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/xml-naming": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
@@ -9832,6 +10645,13 @@
       "engines": {
         "node": ">=16.0.0"
       }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/xmldoc": {
       "version": "2.0.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -37,6 +37,10 @@
   "devDependencies": {
     "@eslint/js": "^9.39.1",
     "@tailwindcss/vite": "^4.1.18",
+    "@testing-library/jest-dom": "^7.0.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.6",
+    "@types/jsdom": "^30.0.0",
     "@types/node": "^24.10.4",
     "@types/react": "^19.2.5",
     "@types/react-dom": "^19.2.3",
@@ -45,6 +49,7 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",
     "globals": "^16.5.0",
+    "jsdom": "^29.1.1",
     "tailwindcss": "^4.1.18",
     "tw-animate-css": "^1.4.0",
     "typescript": "~5.9.3",

--- a/frontend/src/pages/public/Rankings.test.tsx
+++ b/frontend/src/pages/public/Rankings.test.tsx
@@ -1,0 +1,280 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { BrowserRouter } from 'react-router-dom';
+import { Rankings } from '@/pages/public/Rankings';
+import { I18nProvider } from '@/contexts/I18nContext';
+import * as api from '@/lib/api';
+
+// Mock the API module
+vi.mock('@/lib/api', () => ({
+  fetchRankings: vi.fn(),
+  fetchStatsMatrix: vi.fn(),
+  fetchCoverageStats: vi.fn(),
+}));
+
+// Mock useIsMobile hook
+vi.mock('@/hooks/useMediaQuery', () => ({
+  useIsMobile: () => false,
+}));
+
+const mockRankingsData = {
+  total_victims: 1000,
+  total_events: 500,
+  cities: [
+    {
+      city: 'São Paulo',
+      state_abbrev: 'SP',
+      victim_count: 100,
+      event_count: 50,
+      victim_share: 10.0,
+      victim_delta: 0,
+      rate_per_100k: 1.5,
+      population: 12000000,
+    },
+    {
+      city: 'Rio de Janeiro',
+      state_abbrev: 'RJ',
+      victim_count: 80,
+      event_count: 40,
+      victim_share: 8.0,
+      victim_delta: 0,
+      rate_per_100k: 1.2,
+      population: 6000000,
+    },
+  ],
+  states: [
+    {
+      state: 'São Paulo',
+      victim_count: 300,
+      event_count: 150,
+      victim_share: 30.0,
+      victim_delta: 0,
+      rate_per_100k: 2.0,
+      population: 45000000,
+    },
+    {
+      state: 'Rio de Janeiro',
+      victim_count: 200,
+      event_count: 100,
+      victim_share: 20.0,
+      victim_delta: 0,
+      rate_per_100k: 1.8,
+      population: 17000000,
+    },
+  ],
+  countries: [],
+  homicide_types: [
+    {
+      type: 'Homicídio simples',
+      victim_count: 500,
+      event_count: 250,
+      victim_share: 50.0,
+      victim_delta: 0,
+    },
+  ],
+  methods: [
+    {
+      method: 'Arma de fogo',
+      victim_count: 700,
+      event_count: 350,
+      victim_share: 70.0,
+      victim_delta: 0,
+    },
+  ],
+  population_vintage: 'Censo 2022',
+};
+
+const mockCoverageData = {
+  municipalities: [
+    {
+      code: '3550308',
+      name: 'São Paulo',
+      uf: 'SP',
+      official_victims: 100,
+      arquivo_victims: 80,
+      coverage: 0.8,
+    },
+  ],
+  methodology: {
+    official_bag: 'homicídio doloso + feminicídio + latrocínio + lesão corporal seguida de morte',
+  },
+};
+
+function renderWithProviders(component: React.ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <BrowserRouter>
+        <I18nProvider>
+          {component}
+        </I18nProvider>
+      </BrowserRouter>
+    </QueryClientProvider>
+  );
+}
+
+describe('Rankings Page - Issue #184 Cleanup', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (api.fetchRankings as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(mockRankingsData);
+    (api.fetchCoverageStats as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(mockCoverageData);
+  });
+
+  describe('Removed components (should NOT be present)', () => {
+    it('should NOT display the UF heatmap title "Taxa de Homicídios por UF"', async () => {
+      renderWithProviders(<Rankings />);
+      
+      // Wait for data to load
+      await waitFor(() => {
+        expect(screen.getByText(/Cidades/i)).toBeInTheDocument();
+      });
+      
+      // Now check that the heatmap is NOT present
+      expect(screen.queryByText(/Taxa de Homicídios por UF/i)).not.toBeInTheDocument();
+    });
+
+    it('should NOT display the type month grid title "Vítimas por Tipo de Homicídio"', async () => {
+      renderWithProviders(<Rankings />);
+      
+      // Wait for data to load
+      await waitFor(() => {
+        expect(screen.getByText(/Cidades/i)).toBeInTheDocument();
+      });
+      
+      // Now check that the type month grid is NOT present
+      expect(screen.queryByText(/Vítimas por Tipo de Homicídio/i)).not.toBeInTheDocument();
+    });
+
+    it('should NOT display the Tipos de homicídio ranking table', async () => {
+      renderWithProviders(<Rankings />);
+      
+      // Wait for data to load
+      await waitFor(() => {
+        expect(screen.getByText(/Cidades/i)).toBeInTheDocument();
+      });
+      
+      // The i18n key rankingsTypes maps to "Tipos de homicídio" in PT
+      expect(screen.queryByText(/Tipos de homicídio/i)).not.toBeInTheDocument();
+    });
+
+    it('should NOT display the Métodos ranking table', async () => {
+      renderWithProviders(<Rankings />);
+      
+      // Wait for data to load
+      await waitFor(() => {
+        expect(screen.getByText(/Cidades/i)).toBeInTheDocument();
+      });
+      
+      // The i18n key rankingsMethods maps to "Métodos" in PT
+      // Use a more specific pattern to avoid matching "Método" in table headers
+      const methodsHeadings = screen.queryAllByRole('heading', { name: /^Métodos$/i });
+      expect(methodsHeadings).toHaveLength(0);
+    });
+
+    it('should NOT display the VARIAÇÃO column header', async () => {
+      renderWithProviders(<Rankings />);
+      
+      // Wait for data to load
+      await waitFor(() => {
+        expect(screen.getByText(/Cidades/i)).toBeInTheDocument();
+      });
+      
+      // The i18n key rankingsDelta maps to "Variação" in PT
+      // Look for it as a table column header
+      const variacaoHeaders = screen.queryAllByText(/^Variação$/i);
+      expect(variacaoHeaders).toHaveLength(0);
+    });
+
+    it('should NOT display the yellow methodology note about rankings', async () => {
+      renderWithProviders(<Rankings />);
+      
+      // Wait for data to load
+      await waitFor(() => {
+        expect(screen.getByText(/Cidades/i)).toBeInTheDocument();
+      });
+      
+      // Check that the amber box with rankingsMethodologyNote is not present
+      // The PT text is: "Estes rankings são baseados em dados extraídos de reportagens jornalísticas, não em estatísticas oficiais."
+      const methodologyText = screen.queryByText(/Estes rankings são baseados em dados extraídos de reportagens jornalísticas/i);
+      expect(methodologyText).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Kept components (SHOULD be present)', () => {
+    it('should display the Cidades ranking table', async () => {
+      renderWithProviders(<Rankings />);
+      
+      await waitFor(() => {
+        // The i18n key rankingsCities maps to "Cidades" in PT
+        expect(screen.getByText(/^Cidades$/i)).toBeInTheDocument();
+      });
+    });
+
+    it('should display the Estados/Regiões ranking table', async () => {
+      renderWithProviders(<Rankings />);
+      
+      await waitFor(() => {
+        // The i18n key rankingsStates maps to "Estados / Regiões" in PT
+        expect(screen.getByText(/Estados.*Regiões/i)).toBeInTheDocument();
+      });
+    });
+
+    it('should display city data from the rankings', async () => {
+      renderWithProviders(<Rankings />);
+      
+      await waitFor(() => {
+        expect(screen.getByText(/São Paulo, SP/i)).toBeInTheDocument();
+        expect(screen.getByText(/Rio de Janeiro, RJ/i)).toBeInTheDocument();
+      });
+    });
+
+    it('should display state data from the rankings', async () => {
+      renderWithProviders(<Rankings />);
+      
+      await waitFor(() => {
+        // State names should appear in the states table
+        const saoPauloStates = screen.getAllByText(/São Paulo/i);
+        expect(saoPauloStates.length).toBeGreaterThan(0);
+      });
+    });
+
+    it('should display period filter chips', async () => {
+      renderWithProviders(<Rankings />);
+      
+      await waitFor(() => {
+        expect(screen.getByText(/Últimos 7 dias/i)).toBeInTheDocument();
+        expect(screen.getByText(/Últimos 30 dias/i)).toBeInTheDocument();
+        expect(screen.getByText(/Último ano/i)).toBeInTheDocument();
+      });
+    });
+
+    it('should display country filter options', async () => {
+      renderWithProviders(<Rankings />);
+      
+      await waitFor(() => {
+        expect(screen.getByText(/Brasil/i)).toBeInTheDocument();
+        expect(screen.getByText(/Chile/i)).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Coverage table (can stay if present)', () => {
+    it('should allow the coverage table to be present', async () => {
+      renderWithProviders(<Rankings />);
+      
+      await waitFor(() => {
+        // Coverage table can stay - this is just checking it doesn't break
+        // This test just ensures the page renders without errors
+        expect(true).toBe(true);
+      });
+    });
+  });
+});

--- a/frontend/src/pages/public/Rankings.test.tsx
+++ b/frontend/src/pages/public/Rankings.test.tsx
@@ -206,6 +206,36 @@ describe('Rankings Page - Issue #184 Cleanup', () => {
       const methodologyText = screen.queryByText(/Estes rankings são baseados em dados extraídos de reportagens jornalísticas/i);
       expect(methodologyText).not.toBeInTheDocument();
     });
+
+    it('should NOT display "mortes violentas intencionais" text', async () => {
+      renderWithProviders(<Rankings />);
+      
+      // Wait for data to load
+      await waitFor(() => {
+        expect(screen.getByText(/Cidades/i)).toBeInTheDocument();
+      });
+      
+      // The five-type Mortes Violentas Intencionais one-liner should be gone
+      const mviText = screen.queryByText(/mortes violentas intencionais/i);
+      expect(mviText).not.toBeInTheDocument();
+    });
+
+    it('should NOT display the amber methodology footer under coverage table', async () => {
+      renderWithProviders(<Rankings />);
+      
+      // Wait for data to load
+      await waitFor(() => {
+        expect(screen.getByText(/Cidades/i)).toBeInTheDocument();
+      });
+      
+      // The amber footer with official_bag and "Metodologia:" should not be present
+      const metodologiaFooter = screen.queryByText(/Metodologia:.*homicídio doloso.*feminicídio/i);
+      expect(metodologiaFooter).not.toBeInTheDocument();
+      
+      // Also check that the "official_bag" text pattern is not rendered
+      const officialBagText = screen.queryByText(/Cobertura = Arquivo \/ oficial/i);
+      expect(officialBagText).not.toBeInTheDocument();
+    });
   });
 
   describe('Kept components (SHOULD be present)', () => {

--- a/frontend/src/pages/public/Rankings.tsx
+++ b/frontend/src/pages/public/Rankings.tsx
@@ -1,8 +1,8 @@
 import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { ChevronDown, TrendingUp, TrendingDown, Minus, ArrowLeft } from 'lucide-react';
+import { ChevronDown, ArrowLeft } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
-import { fetchRankings, fetchStatsMatrix, fetchCoverageStats } from '@/lib/api';
+import { fetchRankings, fetchCoverageStats } from '@/lib/api';
 import type { RankingRow, CoverageMunicipality } from '@/lib/api';
 import { useI18n } from '@/contexts/I18nContext';
 import { ArchiveLogo } from '@/components/portal/ArchiveLogo';
@@ -24,28 +24,6 @@ interface RankingTableProps {
   onRowClick?: (value: string) => void;
   emptyMessage?: string;
   showRateColumns?: boolean;
-}
-
-function DeltaBadge({ delta, label }: { delta: number; label: string }) {
-  if (delta === 0) {
-    return (
-      <span className="inline-flex items-center gap-0.5 text-stone-500" title={`${label}: sem mudança`}>
-        <Minus className="h-3 w-3" />
-        <span className="text-xs">0</span>
-      </span>
-    );
-  }
-  
-  const isPositive = delta > 0;
-  return (
-    <span
-      className={cn('inline-flex items-center gap-0.5', isPositive ? 'text-red-600' : 'text-green-600')}
-      title={`${label}: ${isPositive ? '+' : ''}${delta}`}
-    >
-      {isPositive ? <TrendingUp className="h-3 w-3" /> : <TrendingDown className="h-3 w-3" />}
-      <span className="text-xs font-semibold">{isPositive ? '+' : ''}{delta}</span>
-    </span>
-  );
 }
 
 function RankingTable({ title, rows, labelField, onRowClick, emptyMessage, showRateColumns = false }: RankingTableProps) {
@@ -97,9 +75,6 @@ function RankingTable({ title, rows, labelField, onRowClick, emptyMessage, showR
                 <th className="px-6 py-3 text-right text-xs font-medium text-stone-500 uppercase tracking-wider">
                   {t.rankingsShare}
                 </th>
-                <th className="px-6 py-3 text-right text-xs font-medium text-stone-500 uppercase tracking-wider">
-                  {t.rankingsDelta}
-                </th>
                 {hasRateData && (
                   <>
                     <th className="px-6 py-3 text-right text-xs font-medium text-stone-500 uppercase tracking-wider">
@@ -144,9 +119,6 @@ function RankingTable({ title, rows, labelField, onRowClick, emptyMessage, showR
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap text-sm text-right text-stone-700">
                       {row.victim_share.toFixed(1)}%
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm text-right">
-                      <DeltaBadge delta={row.victim_delta} label={t.rankingsVictimCount} />
                     </td>
                     {hasRateData && (
                       <>
@@ -207,11 +179,6 @@ export function Rankings() {
     queryFn: () => fetchRankings({ days: period, country: country || undefined, cityLimit }),
   });
 
-  const { data: matrixData, isLoading: isMatrixLoading } = useQuery({
-    queryKey: ['statsMatrix'],
-    queryFn: fetchStatsMatrix,
-  });
-
   const { data: coverageData, isLoading: isCoverageLoading } = useQuery({
     queryKey: ['coverageStats'],
     queryFn: fetchCoverageStats,
@@ -237,16 +204,6 @@ export function Rankings() {
   const handleStateClick = (state: string) => {
     // Deep link to map filtered to this state
     navigate(`/?state=${encodeURIComponent(state)}`);
-  };
-
-  const handleTypeClick = (type: string) => {
-    // Deep link to map filtered to this type
-    navigate(`/?type=${encodeURIComponent(type)}`);
-  };
-
-  const handleMethodClick = (method: string) => {
-    // Deep link to map filtered to this method
-    navigate(`/?method=${encodeURIComponent(method)}`);
   };
 
   const handleOpenMethodology = () => {
@@ -376,7 +333,7 @@ export function Rankings() {
                       </tr>
                     </thead>
                     <tbody className="bg-white divide-y divide-stone-200">
-                      {coverageData.municipalities.map((muni: CoverageMunicipality, idx: number) => {
+                      {coverageData.municipalities.map((muni: CoverageMunicipality) => {
                         const coveragePercent = muni.coverage != null ? (muni.coverage * 100).toFixed(0) : '—';
                         const coverageColor = 
                           muni.coverage == null ? 'text-stone-400' :
@@ -414,126 +371,6 @@ export function Rankings() {
                     <strong>Metodologia:</strong> {coverageData.methodology.official_bag}. 
                     Cobertura = Arquivo / oficial (valores acima de 100% indicam maior captura pelo Arquivo).
                   </p>
-                </div>
-              </div>
-            </div>
-          )}
-
-          {/* Matrix Grids (Hero) */}
-          {matrixData && !isMatrixLoading && (
-            <div className="space-y-6 mb-8">
-              {/* UF × Month Grid */}
-              <div className="rounded-xl border border-stone-200 bg-white overflow-hidden">
-                <div className="px-6 py-4 border-b border-stone-200">
-                  <h2 className="text-lg font-semibold text-stone-900">
-                    Taxa de Homicídios por UF (por 100 mil hab.)
-                  </h2>
-                  <p className="text-sm text-stone-500 mt-1">
-                    Dados desde julho de 2026 • Fontes: notícias + população IBGE {matrixData.ufs[0]?.population && '(Censo 2022)'}
-                  </p>
-                </div>
-                <div className="overflow-x-auto">
-                  <table className="w-full text-sm">
-                    <thead className="bg-stone-50 border-b border-stone-200">
-                      <tr>
-                        <th className="px-4 py-3 text-left text-xs font-medium text-stone-500 uppercase tracking-wider sticky left-0 bg-stone-50 z-10">
-                          UF
-                        </th>
-                        {matrixData.months.map((month) => (
-                          <th key={month} className="px-4 py-3 text-center text-xs font-medium text-stone-500 uppercase tracking-wider whitespace-nowrap">
-                            {month}
-                          </th>
-                        ))}
-                      </tr>
-                    </thead>
-                    <tbody className="bg-white divide-y divide-stone-200">
-                      {matrixData.ufs.map((uf) => (
-                        <tr key={uf.abbrev} className="hover:bg-stone-50">
-                          <td className="px-4 py-3 font-medium text-stone-900 sticky left-0 bg-white z-10 whitespace-nowrap border-r border-stone-200">
-                            {uf.abbrev}
-                          </td>
-                          {uf.cells.map((cell) => {
-                            const rate = cell.rate_per_100k || 0;
-                            const color = rate === 0 
-                              ? 'bg-stone-50' 
-                              : rate < 1 
-                                ? 'bg-green-50' 
-                                : rate < 2 
-                                  ? 'bg-yellow-50' 
-                                  : rate < 3 
-                                    ? 'bg-orange-50' 
-                                    : 'bg-red-50';
-                            return (
-                              <td 
-                                key={cell.month} 
-                                className={cn('px-4 py-3 text-center', color)}
-                                title={`${uf.name}, ${cell.month}: ${cell.victims} vítimas, taxa ${rate}/100k`}
-                              >
-                                <div className="font-medium text-stone-900">{rate.toFixed(2)}</div>
-                                <div className="text-xs text-stone-500">{cell.victims}v</div>
-                              </td>
-                            );
-                          })}
-                        </tr>
-                      ))}
-                    </tbody>
-                  </table>
-                </div>
-              </div>
-
-              {/* Type × Month Grid */}
-              <div className="rounded-xl border border-stone-200 bg-white overflow-hidden">
-                <div className="px-6 py-4 border-b border-stone-200">
-                  <h2 className="text-lg font-semibold text-stone-900">
-                    Vítimas por Tipo de Homicídio
-                  </h2>
-                  <p className="text-sm text-stone-500 mt-1">
-                    Contagem de vítimas desde julho de 2026
-                  </p>
-                </div>
-                <div className="overflow-x-auto">
-                  <table className="w-full text-sm">
-                    <thead className="bg-stone-50 border-b border-stone-200">
-                      <tr>
-                        <th className="px-4 py-3 text-left text-xs font-medium text-stone-500 uppercase tracking-wider sticky left-0 bg-stone-50 z-10 min-w-[200px]">
-                          Tipo
-                        </th>
-                        {matrixData.months.map((month) => (
-                          <th key={month} className="px-4 py-3 text-center text-xs font-medium text-stone-500 uppercase tracking-wider whitespace-nowrap">
-                            {month}
-                          </th>
-                        ))}
-                      </tr>
-                    </thead>
-                    <tbody className="bg-white divide-y divide-stone-200">
-                      {matrixData.types.map((type) => (
-                        <tr key={type.type} className="hover:bg-stone-50">
-                          <td className="px-4 py-3 font-medium text-stone-900 sticky left-0 bg-white z-10 border-r border-stone-200">
-                            {type.type}
-                          </td>
-                          {type.cells.map((cell) => {
-                            const victims = cell.victims || 0;
-                            const color = victims === 0 
-                              ? 'bg-stone-50' 
-                              : victims < 50 
-                                ? 'bg-blue-50' 
-                                : victims < 100 
-                                  ? 'bg-blue-100' 
-                                  : 'bg-blue-200';
-                            return (
-                              <td 
-                                key={cell.month} 
-                                className={cn('px-4 py-3 text-center', color)}
-                                title={`${type.type}, ${cell.month}: ${victims} vítimas`}
-                              >
-                                <div className="font-medium text-stone-900">{victims}</div>
-                              </td>
-                            );
-                          })}
-                        </tr>
-                      ))}
-                    </tbody>
-                  </table>
                 </div>
               </div>
             </div>
@@ -595,36 +432,6 @@ export function Rankings() {
                   emptyMessage="Nenhum país com eventos no período selecionado."
                 />
               )}
-
-              {/* Homicide Types */}
-              <RankingTable
-                title={t.rankingsTypes}
-                rows={data.homicide_types}
-                labelField="type"
-                onRowClick={handleTypeClick}
-                emptyMessage="Nenhum tipo de homicídio no período selecionado."
-              />
-
-              {/* Methods */}
-              <RankingTable
-                title={t.rankingsMethods}
-                rows={data.methods}
-                labelField="method"
-                onRowClick={handleMethodClick}
-                emptyMessage="Nenhum método registrado no período selecionado."
-              />
-
-              {/* Methodology note */}
-              <div className="rounded-xl border border-amber-200 bg-amber-50 p-6">
-                <p className="text-sm text-amber-900">
-                  <strong className="font-semibold">{t.disclaimerLabel}:</strong> {t.rankingsMethodologyNote}
-                </p>
-                {data.population_vintage && (
-                  <p className="text-sm text-amber-900 mt-2">
-                    <strong className="font-semibold">População:</strong> Dados populacionais do IBGE {data.population_vintage}.
-                  </p>
-                )}
-              </div>
             </div>
           )}
         </div>

--- a/frontend/src/pages/public/Rankings.tsx
+++ b/frontend/src/pages/public/Rankings.tsx
@@ -299,83 +299,6 @@ export function Rankings() {
             </div>
           )}
 
-          {/* Coverage Table */}
-          {coverageData && !isCoverageLoading && (
-            <div className="space-y-6 mb-8">
-              <div className="rounded-xl border border-stone-200 bg-white overflow-hidden">
-                <div className="px-6 py-4 border-b border-stone-200">
-                  <h2 className="text-lg font-semibold text-stone-900">
-                    Cobertura: Arquivo vs Oficial
-                  </h2>
-                  <p className="text-sm text-stone-500 mt-1">
-                    Comparação entre vítimas registradas pelo Arquivo da Violência e mortes violentas intencionais oficiais (Ministério da Justiça). Janela: desde setembro/2025.
-                  </p>
-                </div>
-                <div className="overflow-x-auto">
-                  <table className="w-full text-sm">
-                    <thead className="bg-stone-50 border-b border-stone-200">
-                      <tr>
-                        <th className="px-4 py-3 text-left text-xs font-medium text-stone-500 uppercase tracking-wider">
-                          Município
-                        </th>
-                        <th className="px-4 py-3 text-center text-xs font-medium text-stone-500 uppercase tracking-wider">
-                          UF
-                        </th>
-                        <th className="px-4 py-3 text-right text-xs font-medium text-stone-500 uppercase tracking-wider">
-                          Oficial
-                        </th>
-                        <th className="px-4 py-3 text-right text-xs font-medium text-stone-500 uppercase tracking-wider">
-                          Arquivo
-                        </th>
-                        <th className="px-4 py-3 text-right text-xs font-medium text-stone-500 uppercase tracking-wider">
-                          Cobertura
-                        </th>
-                      </tr>
-                    </thead>
-                    <tbody className="bg-white divide-y divide-stone-200">
-                      {coverageData.municipalities.map((muni: CoverageMunicipality) => {
-                        const coveragePercent = muni.coverage != null ? (muni.coverage * 100).toFixed(0) : '—';
-                        const coverageColor = 
-                          muni.coverage == null ? 'text-stone-400' :
-                          muni.coverage < 0.5 ? 'text-red-600' :
-                          muni.coverage < 0.8 ? 'text-orange-600' :
-                          muni.coverage < 1.0 ? 'text-yellow-600' :
-                          muni.coverage >= 1.0 ? 'text-green-600' :
-                          'text-stone-600';
-                        
-                        return (
-                          <tr key={muni.code} className="hover:bg-stone-50">
-                            <td className="px-4 py-3 font-medium text-stone-900">
-                              {muni.name}
-                            </td>
-                            <td className="px-4 py-3 text-center text-stone-700">
-                              {muni.uf}
-                            </td>
-                            <td className="px-4 py-3 text-right text-stone-900">
-                              {muni.official_victims.toLocaleString()}
-                            </td>
-                            <td className="px-4 py-3 text-right text-stone-900">
-                              {muni.arquivo_victims.toLocaleString()}
-                            </td>
-                            <td className={cn('px-4 py-3 text-right font-semibold', coverageColor)}>
-                              {coveragePercent}%
-                            </td>
-                          </tr>
-                        );
-                      })}
-                    </tbody>
-                  </table>
-                </div>
-                <div className="px-6 py-4 bg-amber-50 border-t border-amber-200">
-                  <p className="text-xs text-amber-900">
-                    <strong>Metodologia:</strong> {coverageData.methodology.official_bag}. 
-                    Cobertura = Arquivo / oficial (valores acima de 100% indicam maior captura pelo Arquivo).
-                  </p>
-                </div>
-              </div>
-            </div>
-          )}
-
           {/* Rankings tables */}
           {data && (
             <div className="space-y-6">
@@ -422,6 +345,75 @@ export function Rankings() {
                 emptyMessage="Nenhum estado/região com eventos no período selecionado."
                 showRateColumns={true}
               />
+
+              {/* Coverage Table */}
+              {coverageData && !isCoverageLoading && (
+                <div className="rounded-xl border border-stone-200 bg-white overflow-hidden">
+                  <div className="px-6 py-4 border-b border-stone-200">
+                    <h2 className="text-lg font-semibold text-stone-900">
+                      Cobertura: Arquivo vs Oficial
+                    </h2>
+                    <p className="text-sm text-stone-500 mt-1">
+                      Comparação entre vítimas registradas pelo Arquivo da Violência e dados oficiais do Ministério da Justiça e Segurança Pública. Janela: desde setembro/2025.
+                    </p>
+                  </div>
+                  <div className="overflow-x-auto">
+                    <table className="w-full text-sm">
+                      <thead className="bg-stone-50 border-b border-stone-200">
+                        <tr>
+                          <th className="px-4 py-3 text-left text-xs font-medium text-stone-500 uppercase tracking-wider">
+                            Município
+                          </th>
+                          <th className="px-4 py-3 text-center text-xs font-medium text-stone-500 uppercase tracking-wider">
+                            UF
+                          </th>
+                          <th className="px-4 py-3 text-right text-xs font-medium text-stone-500 uppercase tracking-wider">
+                            Oficial
+                          </th>
+                          <th className="px-4 py-3 text-right text-xs font-medium text-stone-500 uppercase tracking-wider">
+                            Arquivo
+                          </th>
+                          <th className="px-4 py-3 text-right text-xs font-medium text-stone-500 uppercase tracking-wider">
+                            Cobertura
+                          </th>
+                        </tr>
+                      </thead>
+                      <tbody className="bg-white divide-y divide-stone-200">
+                        {coverageData.municipalities.map((muni: CoverageMunicipality) => {
+                          const coveragePercent = muni.coverage != null ? (muni.coverage * 100).toFixed(0) : '—';
+                          const coverageColor = 
+                            muni.coverage == null ? 'text-stone-400' :
+                            muni.coverage < 0.5 ? 'text-red-600' :
+                            muni.coverage < 0.8 ? 'text-orange-600' :
+                            muni.coverage < 1.0 ? 'text-yellow-600' :
+                            muni.coverage >= 1.0 ? 'text-green-600' :
+                            'text-stone-600';
+                          
+                          return (
+                            <tr key={muni.code} className="hover:bg-stone-50">
+                              <td className="px-4 py-3 font-medium text-stone-900">
+                                {muni.name}
+                              </td>
+                              <td className="px-4 py-3 text-center text-stone-700">
+                                {muni.uf}
+                              </td>
+                              <td className="px-4 py-3 text-right text-stone-900">
+                                {muni.official_victims.toLocaleString()}
+                              </td>
+                              <td className="px-4 py-3 text-right text-stone-900">
+                                {muni.arquivo_victims.toLocaleString()}
+                              </td>
+                              <td className={cn('px-4 py-3 text-right font-semibold', coverageColor)}>
+                                {coveragePercent}%
+                              </td>
+                            </tr>
+                          );
+                        })}
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+              )}
 
               {/* Countries */}
               {!country && data.countries.length > 0 && (

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,0 +1,8 @@
+import '@testing-library/jest-dom/vitest';
+import { afterEach } from 'vitest';
+import { cleanup } from '@testing-library/react';
+
+// Cleanup after each test case
+afterEach(() => {
+  cleanup();
+});

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+import path from 'path';
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: ['./src/test/setup.ts'],
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Closes

Closes #184

## Summary

Cleaned up the `/estatisticas` (Rankings) page by removing broken and off-brief components as specified in issue #184. The page now focuses on the essential rankings (Cities and States) with easy access and no excessive scrolling.

## Changes

### Removed Components
- ❌ UF heatmap (Taxa de Homicídios por UF) - matrix grid showing mostly zeros
- ❌ Type month grid (Vítimas por Tipo de Homicídio) - type × month victim counts
- ❌ Tipos de homicídio ranking table - will be handled by homepage
- ❌ Métodos ranking table - will be handled by homepage
- ❌ VARIAÇÃO column - hidden until math is corrected in a future ticket
- ❌ Yellow five-type Mortes Violentas Intencionais one-liner (amber methodology footer under coverage table)
- ❌ "mortes violentas intencionais" text from coverage table subtitle

### Retained & Reorganized Components
- ✅ Cidades ranking table with population and rate data (easily accessible at top)
- ✅ Estados / Regiões ranking table (easily accessible after Cities)
- ✅ Coverage table moved BELOW rankings (was blocking access before)
- ✅ Period filter chips (7/30/365 days)
- ✅ Country filter (Brasil / Chile)
- ✅ Summary cards (total victims/events)

## Page Order (After Changes)

1. **Header & Filters** - Period chips, country selector
2. **Summary Cards** - Total victims/events
3. **Cidades Ranking** - ⭐ Now immediately accessible
4. **Estados Ranking** - ⭐ Now immediately accessible
5. **Coverage Table** - Moved below per ticket ("can stay below")

Before these changes, the coverage table appeared first, requiring a huge scroll to reach the main rankings.

## Testing

### Automated Tests
- Added vitest configuration and React Testing Library setup
- Created comprehensive test suite for Rankings component (15 tests)
- Tests verify absence of ALL removed components:
  - Heatmap and type grids
  - Tipos/Métodos tables
  - VARIAÇÃO column
  - Yellow methodology note (rankingsMethodologyNote)
  - **"mortes violentas intencionais" text**
  - **Amber methodology footer (official_bag)**
- Tests verify presence of kept components (Cidades, Estados)
- All 22 tests pass ✅

### Build Verification
- Frontend builds successfully without errors ✅
- No linting errors in modified files ✅

### Manual Testing
Manual testing should be performed in the dev Docker environment:
```bash
docker compose -f docker-compose.dev.yml -f docker-compose.dev.override.yml up -d --build
```
Then visit http://localhost/estatisticas to verify:
1. ✅ No heatmap or type grids visible
2. ✅ No Tipos/Métodos tables
3. ✅ No VARIAÇÃO column in rankings
4. ✅ No yellow methodology note
5. ✅ No "mortes violentas intencionais" text
6. ✅ No amber footer under coverage table
7. ✅ Cities and Estados rankings appear FIRST
8. ✅ Coverage table appears BELOW rankings

## Commits

1. Initial implementation: Remove heatmap, grids, Tipos/Métodos, VARIAÇÃO column, wrong methodology note
2. **Fix**: Remove correct amber methodology footer and move coverage table below rankings

## Notes

- ✅ This PR targets `develop` branch only (not `master`)
- ✅ Does NOT include new methodology copy (that's issue #188)
- ✅ Does NOT include four-type official bag changes (future work)
- ✅ Does NOT fix VARIAÇÃO math (will be addressed separately)
- ✅ Backend APIs remain unchanged
- ✅ Issue #184 acceptance criteria now fully met
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-67c54009-1ce2-4df0-b868-200b39c063f9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-67c54009-1ce2-4df0-b868-200b39c063f9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

