### PR TITLE
Fix #188: Replace stale 63 municipality count with live 52 cities

### DIFF
--- a/backend/app/routers/public.py
+++ b/backend/app/routers/public.py
@@ -23,7 +23,6 @@ from app.services.public_filters import (
     homicide_types_filter,
 )
 from app.geography import COUNTRY_NAMES, BRAZILIAN_STATES
-from app.country_registry import COUNTRY_CONFIGS, get_country_config
 
 router = APIRouter(prefix="/public", tags=["public"])
 
@@ -1680,17 +1679,4 @@ async def get_public_event_by_id(
     )
 
     return _format_public_event_detail(event, sources)
-
-
-@router.get("/country-metadata")
-async def get_country_metadata():
-    """Return metadata about supported countries, including city counts for testing methodology copy."""
-    metadata = {}
-    for code, config in COUNTRY_CONFIGS.items():
-        metadata[code] = {
-            "code": code,
-            "name": config.name,
-            "city_count": len(config.cities),
-        }
-    return metadata
 

--- a/backend/app/routers/public.py
+++ b/backend/app/routers/public.py
@@ -23,6 +23,7 @@ from app.services.public_filters import (
     homicide_types_filter,
 )
 from app.geography import COUNTRY_NAMES, BRAZILIAN_STATES
+from app.country_registry import COUNTRY_CONFIGS, get_country_config
 
 router = APIRouter(prefix="/public", tags=["public"])
 
@@ -1679,4 +1680,17 @@ async def get_public_event_by_id(
     )
 
     return _format_public_event_detail(event, sources)
+
+
+@router.get("/country-metadata")
+async def get_country_metadata():
+    """Return metadata about supported countries, including city counts for testing methodology copy."""
+    metadata = {}
+    for code, config in COUNTRY_CONFIGS.items():
+        metadata[code] = {
+            "code": code,
+            "name": config.name,
+            "city_count": len(config.cities),
+        }
+    return metadata
 

--- a/backend/tests/test_methodology_accuracy.py
+++ b/backend/tests/test_methodology_accuracy.py
@@ -3,36 +3,36 @@
 from app.country_registry import BRAZIL_CONFIG
 
 
-def test_brazil_city_count_is_52():
-    """Verify Brazil config has exactly 52 cities as claimed in methodology."""
-    assert len(BRAZIL_CONFIG.cities) == 52, (
-        f"Methodology claims 52 Brazilian cities, but config has {len(BRAZIL_CONFIG.cities)}. "
-        f"Update frontend/src/lib/methodology.ts if the city list changed."
+def test_methodology_matches_brazil_city_count():
+    """
+    Verify methodology.ts claims the same city count as BRAZIL_CONFIG.
+    
+    This test will fail if methodology.ts becomes stale when cities are added/removed.
+    DO NOT hardcode both sides to the same number - that defeats the purpose.
+    The methodology copy must match the live config count.
+    """
+    actual_count = len(BRAZIL_CONFIG.cities)
+    
+    # Read the methodology file
+    import pathlib
+    methodology_path = pathlib.Path(__file__).parent.parent.parent / "frontend" / "src" / "lib" / "methodology.ts"
+    methodology_content = methodology_path.read_text()
+    
+    # Check that the file doesn't claim wrong counts
+    # This is a basic smoke test - the frontend tests do more thorough validation
+    assert "63 municípios" not in methodology_content.lower(), (
+        "Methodology still claims 63 municipalities (stale)"
     )
-
-
-def test_brazil_cities_includes_major_metros():
-    """Verify Brazil config includes the major metros mentioned in methodology."""
-    cities_str = " ".join(BRAZIL_CONFIG.cities)
+    assert "63 municipalities" not in methodology_content.lower(), (
+        "Methodology still claims 63 municipalities (stale)"
+    )
     
-    # Major metros (2M+) from methodology
-    assert "São Paulo" in cities_str
-    assert "Rio de Janeiro" in cities_str
-    assert "Brasília" in cities_str
-    assert "Salvador" in cities_str
-    assert "Fortaleza" in cities_str
-    assert "Belo Horizonte" in cities_str
-    assert "Manaus" in cities_str
-
-
-def test_brazil_cities_includes_smaller_capitals():
-    """Verify Brazil config includes smaller capitals mentioned in methodology."""
-    cities_str = " ".join(BRAZIL_CONFIG.cities)
+    # The actual count should appear in the cities section
+    # We check for the number in context to avoid false matches (line numbers, etc.)
+    pt_cities_section = methodology_content[methodology_content.find("id: 'cities'"):methodology_content.find("id: 'cities'")+2000]
+    en_cities_section = methodology_content[methodology_content.rfind("id: 'cities'"):methodology_content.rfind("id: 'cities'")+2000]
     
-    # Smaller capitals from methodology
-    assert "Florianópolis" in cities_str
-    assert "Vitória" in cities_str
-    assert "Macapá" in cities_str
-    assert "Boa Vista" in cities_str
-    assert "Rio Branco" in cities_str
-    assert "Palmas" in cities_str
+    assert f"{actual_count} municípios" in pt_cities_section or f"{actual_count} municipalities" in en_cities_section, (
+        f"Methodology does not claim {actual_count} municipalities (BRAZIL_CONFIG has {actual_count} cities). "
+        f"Update frontend/src/lib/methodology.ts when the city list changes."
+    )

--- a/backend/tests/test_methodology_accuracy.py
+++ b/backend/tests/test_methodology_accuracy.py
@@ -1,0 +1,38 @@
+"""Tests for methodology copy accuracy against live country registry."""
+
+from app.country_registry import BRAZIL_CONFIG
+
+
+def test_brazil_city_count_is_52():
+    """Verify Brazil config has exactly 52 cities as claimed in methodology."""
+    assert len(BRAZIL_CONFIG.cities) == 52, (
+        f"Methodology claims 52 Brazilian cities, but config has {len(BRAZIL_CONFIG.cities)}. "
+        f"Update frontend/src/lib/methodology.ts if the city list changed."
+    )
+
+
+def test_brazil_cities_includes_major_metros():
+    """Verify Brazil config includes the major metros mentioned in methodology."""
+    cities_str = " ".join(BRAZIL_CONFIG.cities)
+    
+    # Major metros (2M+) from methodology
+    assert "São Paulo" in cities_str
+    assert "Rio de Janeiro" in cities_str
+    assert "Brasília" in cities_str
+    assert "Salvador" in cities_str
+    assert "Fortaleza" in cities_str
+    assert "Belo Horizonte" in cities_str
+    assert "Manaus" in cities_str
+
+
+def test_brazil_cities_includes_smaller_capitals():
+    """Verify Brazil config includes smaller capitals mentioned in methodology."""
+    cities_str = " ".join(BRAZIL_CONFIG.cities)
+    
+    # Smaller capitals from methodology
+    assert "Florianópolis" in cities_str
+    assert "Vitória" in cities_str
+    assert "Macapá" in cities_str
+    assert "Boa Vista" in cities_str
+    assert "Rio Branco" in cities_str
+    assert "Palmas" in cities_str

--- a/frontend/src/lib/methodology.test.ts
+++ b/frontend/src/lib/methodology.test.ts
@@ -1,6 +1,15 @@
 import { describe, it, expect } from 'vitest';
 import { methodologyContent } from './methodology';
 
+/**
+ * NOTE: The city count in methodology.ts must match the live Brazil city list
+ * in backend/app/country_registry.py BRAZIL_CONFIG.cities.
+ * 
+ * These tests will fail if:
+ * - The methodology claims 63 (old stale count)
+ * - The methodology doesn't claim the current count from BRAZIL_CONFIG
+ */
+
 describe('Methodology Copy', () => {
   describe('City count accuracy', () => {
     it('should not claim 63 municipalities as current coverage in PT', () => {
@@ -21,34 +30,32 @@ describe('Methodology Copy', () => {
       expect(allText).not.toMatch(/covers\s+63\s+municipalities/);
     });
 
-    it('should claim 52 municipalities as current coverage in PT', () => {
+    it('should have cities section in PT', () => {
       const pt = methodologyContent('pt');
       const citiesSection = pt.sections.find(s => s.id === 'cities');
       expect(citiesSection).toBeDefined();
-      expect(citiesSection?.paragraphs[0]).toMatch(/52\s+municípios/i);
+      expect(citiesSection?.title).toBe('Cidades monitoradas');
     });
 
-    it('should claim 52 municipalities as current coverage in EN', () => {
+    it('should have cities section in EN', () => {
       const en = methodologyContent('en');
       const citiesSection = en.sections.find(s => s.id === 'cities');
       expect(citiesSection).toBeDefined();
-      expect(citiesSection?.paragraphs[0]).toMatch(/52\s+(brazilian\s+)?municipalities/i);
+      expect(citiesSection?.title).toBe('Monitored cities');
     });
 
-    it('should claim 52 cities in limitations section PT', () => {
+    it('should not claim 63 cities in limitations section PT', () => {
       const pt = methodologyContent('pt');
       const limitationsSection = pt.sections.find(s => s.id === 'limitations');
-      expect(limitationsSection).toBeDefined();
       const limitationsBullets = limitationsSection?.bullets?.join(' ') || '';
-      expect(limitationsBullets).toMatch(/52\s+cidades/i);
+      expect(limitationsBullets).not.toMatch(/63\s+cidades/i);
     });
 
-    it('should claim 52 cities in limitations section EN', () => {
+    it('should not claim 63 cities in limitations section EN', () => {
       const en = methodologyContent('en');
       const limitationsSection = en.sections.find(s => s.id === 'limitations');
-      expect(limitationsSection).toBeDefined();
       const limitationsBullets = limitationsSection?.bullets?.join(' ') || '';
-      expect(limitationsBullets).toMatch(/52\s+.*cities/i);
+      expect(limitationsBullets).not.toMatch(/63\s+.*cities/i);
     });
   });
 

--- a/frontend/src/lib/methodology.test.ts
+++ b/frontend/src/lib/methodology.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from 'vitest';
+import { methodologyContent } from './methodology';
+
+describe('Methodology Copy', () => {
+  describe('City count accuracy', () => {
+    it('should not claim 63 municipalities as current coverage in PT', () => {
+      const pt = methodologyContent('pt');
+      const allText = JSON.stringify(pt).toLowerCase();
+      
+      // Should not have "63 municípios" as current coverage claim
+      expect(allText).not.toMatch(/63\s+municípios/);
+      expect(allText).not.toMatch(/cobre\s+63\s+municípios/);
+    });
+
+    it('should not claim 63 municipalities as current coverage in EN', () => {
+      const en = methodologyContent('en');
+      const allText = JSON.stringify(en).toLowerCase();
+      
+      // Should not have "63 municipalities" as current coverage claim
+      expect(allText).not.toMatch(/63\s+municipalities/);
+      expect(allText).not.toMatch(/covers\s+63\s+municipalities/);
+    });
+
+    it('should claim 52 municipalities as current coverage in PT', () => {
+      const pt = methodologyContent('pt');
+      const citiesSection = pt.sections.find(s => s.id === 'cities');
+      expect(citiesSection).toBeDefined();
+      expect(citiesSection?.paragraphs[0]).toMatch(/52\s+municípios/i);
+    });
+
+    it('should claim 52 municipalities as current coverage in EN', () => {
+      const en = methodologyContent('en');
+      const citiesSection = en.sections.find(s => s.id === 'cities');
+      expect(citiesSection).toBeDefined();
+      expect(citiesSection?.paragraphs[0]).toMatch(/52\s+(brazilian\s+)?municipalities/i);
+    });
+
+    it('should claim 52 cities in limitations section PT', () => {
+      const pt = methodologyContent('pt');
+      const limitationsSection = pt.sections.find(s => s.id === 'limitations');
+      expect(limitationsSection).toBeDefined();
+      const limitationsBullets = limitationsSection?.bullets?.join(' ') || '';
+      expect(limitationsBullets).toMatch(/52\s+cidades/i);
+    });
+
+    it('should claim 52 cities in limitations section EN', () => {
+      const en = methodologyContent('en');
+      const limitationsSection = en.sections.find(s => s.id === 'limitations');
+      expect(limitationsSection).toBeDefined();
+      const limitationsBullets = limitationsSection?.bullets?.join(' ') || '';
+      expect(limitationsBullets).toMatch(/52\s+.*cities/i);
+    });
+  });
+
+  describe('Coverage section content (locked text from spec #182)', () => {
+    it('should have coverage section in PT', () => {
+      const pt = methodologyContent('pt');
+      const coverageSection = pt.sections.find(s => s.id === 'coverage');
+      expect(coverageSection).toBeDefined();
+      expect(coverageSection?.title).toBe('Cobertura: Arquivo vs Oficial');
+    });
+
+    it('should mention four Formulário 1 crime types in PT coverage section', () => {
+      const pt = methodologyContent('pt');
+      const coverageSection = pt.sections.find(s => s.id === 'coverage');
+      const coverageText = coverageSection?.paragraphs.join(' ') || '';
+      
+      // Must mention all four types from Formulário 1
+      expect(coverageText).toMatch(/homicídio doloso/i);
+      expect(coverageText).toMatch(/feminicídio/i);
+      expect(coverageText).toMatch(/roubo seguido de morte|latrocínio/i);
+      expect(coverageText).toMatch(/lesão corporal seguida de morte/i);
+    });
+
+    it('should NOT claim morte por intervenção is in municipal official column in PT', () => {
+      const pt = methodologyContent('pt');
+      const coverageSection = pt.sections.find(s => s.id === 'coverage');
+      const coverageText = coverageSection?.paragraphs.join(' ') || '';
+      
+      // Should explicitly state intervenção is NOT in the municipal table
+      expect(coverageText).toMatch(/morte.*intervenção.*não entram nesta tabela municipal/i);
+    });
+
+    it('should NOT label official bag as "Mortes Violentas Intencionais" in PT', () => {
+      const pt = methodologyContent('pt');
+      const coverageSection = pt.sections.find(s => s.id === 'coverage');
+      const coverageText = coverageSection?.paragraphs.join(' ') || '';
+      
+      // Should explicitly state MVI is NOT used
+      expect(coverageText).toMatch(/não usa.*Mortes Violentas Intencionais/i);
+    });
+
+    it('should mention Formulário 1 in PT coverage section', () => {
+      const pt = methodologyContent('pt');
+      const coverageSection = pt.sections.find(s => s.id === 'coverage');
+      const coverageText = coverageSection?.paragraphs.join(' ') || '';
+      
+      expect(coverageText).toMatch(/Formulário 1/i);
+    });
+
+    it('should mention IBGE seven-digit code in PT coverage section', () => {
+      const pt = methodologyContent('pt');
+      const coverageSection = pt.sections.find(s => s.id === 'coverage');
+      const coverageText = coverageSection?.paragraphs.join(' ') || '';
+      
+      expect(coverageText).toMatch(/código de sete dígitos/i);
+      expect(coverageText).toMatch(/Instituto Brasileiro de Geografia e Estatística/i);
+    });
+
+    it('should have coverage section in EN', () => {
+      const en = methodologyContent('en');
+      const coverageSection = en.sections.find(s => s.id === 'coverage');
+      expect(coverageSection).toBeDefined();
+      expect(coverageSection?.title).toBe('Coverage: Archive vs Official');
+    });
+
+    it('should mention four Form 1 crime types in EN coverage section', () => {
+      const en = methodologyContent('en');
+      const coverageSection = en.sections.find(s => s.id === 'coverage');
+      const coverageText = coverageSection?.paragraphs.join(' ') || '';
+      
+      // Must mention all four types from Form 1
+      expect(coverageText).toMatch(/intentional homicide/i);
+      expect(coverageText).toMatch(/femicide/i);
+      expect(coverageText).toMatch(/robbery.*death|robbery-homicide/i);
+      expect(coverageText).toMatch(/bodily injury.*death/i);
+    });
+
+    it('should NOT claim intervention deaths are in municipal official column in EN', () => {
+      const en = methodologyContent('en');
+      const coverageSection = en.sections.find(s => s.id === 'coverage');
+      const coverageText = coverageSection?.paragraphs.join(' ') || '';
+      
+      // Should explicitly state intervention is NOT in the municipal table
+      expect(coverageText).toMatch(/intervention.*not enter this municipal table/i);
+    });
+  });
+});

--- a/frontend/src/lib/methodology.ts
+++ b/frontend/src/lib/methodology.ts
@@ -44,7 +44,7 @@ const PT: MethodologyContent = {
       id: 'cities',
       title: 'Cidades monitoradas',
       paragraphs: [
-        'O monitoramento cobre 63 municípios: todas as 27 capitais estaduais mais cidades com população acima de 500 mil habitantes (IBGE 2022). A busca padrão por cidade usa a janela temporal when:1h (última hora).',
+        'O monitoramento cobre 52 municípios brasileiros: todas as 27 capitais estaduais, grandes regiões metropolitanas e cidades de médio porte. A lista inclui metrópoles de 2 milhões ou mais habitantes (São Paulo, Rio de Janeiro, Brasília, Salvador, Fortaleza, Belo Horizonte, Manaus), grandes cidades entre 1 e 2 milhões (Curitiba, Recife, Goiânia, Belém, Porto Alegre, e outras), cidades médio-grandes de 500 mil a 1 milhão de habitantes, e as capitais menores (Florianópolis, Vitória, Macapá, Boa Vista, Rio Branco, Palmas). A busca padrão por cidade usa a janela temporal when:1h (última hora).',
       ],
       bullets: [
         'Execução paralela de até 10 cidades simultâneas',
@@ -155,13 +155,25 @@ const PT: MethodologyContent = {
       ],
     },
     {
+      id: 'coverage',
+      title: 'Cobertura: Arquivo vs Oficial',
+      paragraphs: [
+        'Esta tabela compara, município a município, duas contas de vítimas no mesmo período.',
+        'O que o Ministério da Justiça e Segurança Pública conta. No sistema Violência e Delitos Estaduais, Formulário 1, cada município envia todo mês o número de vítimas de quatro crimes, contados à parte: homicídio doloso, feminicídio, roubo seguido de morte (latrocínio) e lesão corporal seguida de morte. Homens e mulheres entram juntos. A coluna oficial desta tabela é a soma dessas quatro linhas. Mortes por intervenção de agente do Estado existem no mesmo ministério, mas só no Formulário 3 e só por Unidade da Federação — por isso não entram nesta tabela municipal.',
+        'O que o Arquivo da Violência conta. Vítimas de mortes violentas noticiadas na imprensa, no mapa público do Brasil, no mesmo recorte de tempo, somadas pelo código de sete dígitos do Instituto Brasileiro de Geografia e Estatística. Evento sem esse código não entra.',
+        'Período. Todo mês oficial completo desde setembro de 2025 (primeiro mês cheio depois de 26 de agosto de 2025) até o último mês que o ministério já publicou.',
+        'Cobertura. Vítimas do Arquivo divididas pelas vítimas oficiais. Acima de 100% significa que o Arquivo achou mais vítimas do que o ministério registrou naquele município. Se o oficial é zero e o Arquivo tem vítimas, a linha existe e a cobertura fica em branco. Município sem código de sete dígitos não aparece. Município com zero oficial e zero no Arquivo não aparece.',
+        'Esta tabela não usa o Sistema de Informações sobre Mortalidade, do Ministério da Saúde. Também não usa a categoria Mortes Violentas Intencionais do Fórum Brasileiro de Segurança Pública: lá o feminicídio já está dentro do homicídio doloso, e as mortes por intervenção policial entram na soma.',
+      ],
+    },
+    {
       id: 'limitations',
       title: 'Limitações',
       paragraphs: [
         'O Arquivo da Violência deve ser utilizado como fonte de referência, não como substituto de registros oficiais (DATASUS, ISP/polícias estaduais).',
       ],
       bullets: [
-        'Cobertura limitada a 63 cidades pré-configuradas, não todo o território nacional',
+        'Cobertura limitada a 52 cidades pré-configuradas, não todo o território nacional',
         'Só captura eventos reportados pela mídia indexada pelo Google News',
         'Classificação inicial usa apenas a manchete — títulos ambíguos podem ser descartados ou aceitos incorretamente',
         'Extração depende do conteúdo da matéria; informações ausentes no texto não são inferidas',
@@ -204,7 +216,7 @@ const EN: MethodologyContent = {
     id: 'cities',
     title: 'Monitored cities',
     paragraphs: [
-      'Monitoring covers 63 municipalities: all 27 state capitals plus cities with populations above 500,000 (2022 IBGE census). The default city search uses the when:1h time window (last hour).',
+      'Monitoring covers 52 Brazilian municipalities: all 27 state capitals, major metropolitan regions, and mid-sized cities. The list includes major metros of 2 million or more inhabitants (São Paulo, Rio de Janeiro, Brasília, Salvador, Fortaleza, Belo Horizonte, Manaus), large cities between 1 and 2 million (Curitiba, Recife, Goiânia, Belém, Porto Alegre, and others), medium-large cities with 500 thousand to 1 million inhabitants, and smaller capitals (Florianópolis, Vitória, Macapá, Boa Vista, Rio Branco, Palmas). The default city search uses the when:1h time window (last hour).',
     ],
     bullets: [
       'Parallel execution of up to 10 cities simultaneously',
@@ -315,13 +327,25 @@ const EN: MethodologyContent = {
     ],
   },
   {
+    id: 'coverage',
+    title: 'Coverage: Archive vs Official',
+    paragraphs: [
+      'This table compares, municipality by municipality, two victim counts over the same period.',
+      'What the Ministry of Justice and Public Security counts. In the Violence and State Offenses system, Form 1, each municipality sends the monthly number of victims of four crimes, counted separately: intentional homicide, femicide, robbery followed by death (robbery-homicide), and bodily injury followed by death. Men and women are counted together. The official column in this table is the sum of these four lines. Deaths by intervention of state agents exist in the same ministry, but only in Form 3 and only by Federation Unit — therefore they do not enter this municipal table.',
+      'What Arquivo da Violência counts. Victims of violent deaths reported in the press, on the public map of Brazil, in the same time frame, aggregated by the seven-digit code of the Brazilian Institute of Geography and Statistics. Events without this code do not enter.',
+      'Period. Every complete official month since September 2025 (first full month after August 26, 2025) until the last month the ministry has published.',
+      'Coverage. Archive victims divided by official victims. Above 100% means the Archive found more victims than the ministry recorded in that municipality. If the official count is zero and the Archive has victims, the row exists and coverage is blank. Municipalities without a seven-digit code do not appear. Municipalities with zero official and zero Archive do not appear.',
+      'This table does not use the Mortality Information System of the Ministry of Health. It also does not use the Intentional Violent Deaths category of the Brazilian Public Security Forum: there, femicide is already included in intentional homicide, and deaths by police intervention enter the sum.',
+    ],
+  },
+  {
     id: 'limitations',
     title: 'Limitations',
     paragraphs: [
       'Arquivo da Violência should be used as a reference source, not as a substitute for official records (DATASUS, state police/ISP).',
     ],
     bullets: [
-      'Coverage limited to 63 pre-configured cities, not the entire national territory',
+      'Coverage limited to 52 pre-configured cities, not the entire national territory',
       'Only captures events reported by media indexed by Google News',
       'Initial classification uses only the headline — ambiguous titles may be discarded or accepted incorrectly',
       'Extraction depends on article content; information absent from the text is not inferred',

--- a/frontend/src/lib/methodology.ts
+++ b/frontend/src/lib/methodology.ts
@@ -44,7 +44,7 @@ const PT: MethodologyContent = {
       id: 'cities',
       title: 'Cidades monitoradas',
       paragraphs: [
-        'O monitoramento cobre 52 municípios brasileiros: todas as 27 capitais estaduais, grandes regiões metropolitanas e cidades de médio porte. A lista inclui metrópoles de 2 milhões ou mais habitantes (São Paulo, Rio de Janeiro, Brasília, Salvador, Fortaleza, Belo Horizonte, Manaus), grandes cidades entre 1 e 2 milhões (Curitiba, Recife, Goiânia, Belém, Porto Alegre, e outras), cidades médio-grandes de 500 mil a 1 milhão de habitantes, e as capitais menores (Florianópolis, Vitória, Macapá, Boa Vista, Rio Branco, Palmas). A busca padrão por cidade usa a janela temporal when:1h (última hora).',
+        'O monitoramento cobre 52 municípios: a lista brasileira de busca de notícias (capitais e grandes regiões metropolitanas). A busca padrão por cidade usa a janela temporal when:1h (última hora).',
       ],
       bullets: [
         'Execução paralela de até 10 cidades simultâneas',
@@ -216,7 +216,7 @@ const EN: MethodologyContent = {
     id: 'cities',
     title: 'Monitored cities',
     paragraphs: [
-      'Monitoring covers 52 Brazilian municipalities: all 27 state capitals, major metropolitan regions, and mid-sized cities. The list includes major metros of 2 million or more inhabitants (São Paulo, Rio de Janeiro, Brasília, Salvador, Fortaleza, Belo Horizonte, Manaus), large cities between 1 and 2 million (Curitiba, Recife, Goiânia, Belém, Porto Alegre, and others), medium-large cities with 500 thousand to 1 million inhabitants, and smaller capitals (Florianópolis, Vitória, Macapá, Boa Vista, Rio Branco, Palmas). The default city search uses the when:1h time window (last hour).',
+      'Monitoring covers 52 municipalities: the Brazilian news-search list (capitals and major metropolitan regions). The default city search uses the when:1h time window (last hour).',
     ],
     bullets: [
       'Parallel execution of up to 10 cities simultaneously',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Overview
Fixes #188 (parent spec #182)

Replaces stale "63 municípios" methodology copy with current **52 municipalities** from live `BRAZIL_CONFIG.cities` on develop. Tests enforce that methodology count matches the live config, preventing future rot.

## Changes

### Methodology Copy Updates (PT & EN)
- ✅ Replace all "63 municípios/municipalities" references with "52"
- ✅ Short recorte sentence: "52 municipalities: the Brazilian news-search list (capitals and major metropolitan regions)"
- ✅ No invented metro-size taxonomy (no "2M+", "1-2M", "500k-1M" categories)
- ✅ Update limitations section from "63 cities" to "52 cities"

### Locked Coverage Text from Spec #182
Added new "Cobertura: Arquivo vs Oficial" / "Coverage: Archive vs Official" section with locked text (verbatim):
- ✅ Explains official count uses **four Formulário 1 types**: homicídio doloso, feminicídio, roubo seguido de morte (latrocínio), lesão corporal seguida de morte
- ✅ Clarifies **morte por intervenção de agente do Estado** is NOT in municipal official table (only in Formulário 3 by UF)
- ✅ Clarifies official bag is NOT "Mortes Violentas Intencionais" (that's FBSP's five-type category)
- ✅ Explains IBGE seven-digit code requirement
- ✅ Explains coverage formula and period (since September 2025)

### Testing & Anti-Rot Protection
- ✅ Backend test reads methodology.ts and verifies count matches `len(BRAZIL_CONFIG.cities)` (not hardcoded 52 on both sides)
- ✅ 15 frontend tests detect stale "63" claims and verify coverage text structure
- ✅ Tests will fail when cities are added/removed if methodology.ts is not updated
- ✅ All tests pass, frontend builds successfully

### Cleanup
- ✅ Removed unused `/api/public/country-metadata` endpoint (deleted in commit 52485a3)
- ✅ Removed unused `COUNTRY_CONFIGS` and `get_country_config` imports
- ✅ Merged with latest develop (978fd9d) - no conflicts
- ✅ **Source-only changes** - no `node_modules` files in commits

## Out of Scope (as instructed)
- ❌ Issues #185, #186, #187 (find box, place card, ranking rewrite)
- ❌ Shipping to master / production
- ❌ Changing four-type official bag math in backend (future bag ticket)

## Testing Evidence
```bash
# Backend verification (reads methodology.ts dynamically)
✓ Methodology matches live config: 52 cities

# No dead endpoint or imports
✓ No country-metadata endpoint found
✓ No unused imports found

# Frontend tests
✓ src/lib/methodology.test.ts (15 tests pass)

# Git stats (source-only, no node_modules)
14 lines deleted in fix commit (endpoint + import)
No node_modules files in any commit
```

## Commit Structure
1. `2d6083c` - Initial methodology changes (52 cities, locked coverage text, tests)
2. `52485a3` - Remove unused endpoint and imports
3. `4bf1176` - Merge latest develop (978fd9d)

## Checklist
- ✅ Merged with latest develop (978fd9d, includes PR #190)
- ✅ No "63 municípios/municipalities" as current recorte
- ✅ Locked coverage text pasted verbatim
- ✅ Four Formulário 1 types present in coverage text
- ✅ No claim that intervenção deaths are in municipal official column
- ✅ No MVI label on official bag
- ✅ No invented metro-size taxonomy
- ✅ Tests compare live config vs methodology (not both hardcoded to 52)
- ✅ No unused endpoint or imports
- ✅ **No node_modules in commits**
- ✅ Target: develop (not master)
- ✅ Did not merge
- ✅ Did not start #185/186/187
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eb42d73f-7538-4b75-8459-9a9961441fab?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eb42d73f-7538-4b75-8459-9a9961441fab&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

