### PR TITLE
feat: Add place search and card to /estatisticas (issue #185)

### DIFF
--- a/frontend/src/components/portal/PlaceCard.tsx
+++ b/frontend/src/components/portal/PlaceCard.tsx
@@ -1,0 +1,128 @@
+import { useNavigate } from 'react-router-dom';
+import { useI18n } from '@/contexts/I18nContext';
+
+export interface PlaceData {
+  name: string;
+  type: 'country' | 'state' | 'municipality';
+  arquivoVictims: number;
+  officialVictims?: number | null;
+  officialAvailable: boolean;
+  lastUpdated: string;
+  period: 7 | 30 | 365;
+  officialWindowStart?: string;
+}
+
+interface PlaceCardProps {
+  placeData: PlaceData;
+}
+
+function formatTimeAgo(dateStr: string): string {
+  const date = new Date(dateStr);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffMins = Math.floor(diffMs / 60000);
+  const diffHours = Math.floor(diffMs / 3600000);
+  const diffDays = Math.floor(diffMs / 86400000);
+  
+  if (diffMins < 1) return 'agora mesmo';
+  if (diffMins < 60) return `há ${diffMins} minuto${diffMins > 1 ? 's' : ''}`;
+  if (diffHours < 24) return `há ${diffHours} hora${diffHours > 1 ? 's' : ''}`;
+  if (diffDays < 30) return `há ${diffDays} dia${diffDays > 1 ? 's' : ''}`;
+  return date.toLocaleDateString('pt-BR');
+}
+
+export function PlaceCard({ placeData }: PlaceCardProps) {
+  const { t } = useI18n();
+  const navigate = useNavigate();
+  
+  const periodLabels = {
+    7: 'Últimos 7 dias',
+    30: 'Últimos 30 dias',
+    365: 'Último ano',
+  };
+  
+  const lastUpdateFormatted = formatTimeAgo(placeData.lastUpdated);
+
+  return (
+    <div data-testid="place-card" className="rounded-xl border border-stone-200 bg-white p-6 space-y-6">
+      {/* Place Name */}
+      <div>
+        <h2 className="text-2xl font-bold text-stone-900">{placeData.name}</h2>
+        <p className="text-sm text-stone-500 mt-1">
+          {placeData.type === 'country' && 'País'}
+          {placeData.type === 'state' && 'Estado'}
+          {placeData.type === 'municipality' && 'Município'}
+        </p>
+      </div>
+
+      {/* Arquivo Count - Large */}
+      <div>
+        <div className="text-sm text-stone-500 mb-1">
+          Vítimas (Arquivo da Violência)
+        </div>
+        <div data-testid="arquivo-count" className="text-5xl font-bold text-blue-600 mb-2">
+          {placeData.arquivoVictims.toLocaleString('pt-BR')}
+        </div>
+        <div className="text-sm text-stone-600">
+          {periodLabels[placeData.period]} · Última atualização {lastUpdateFormatted}
+        </div>
+      </div>
+
+      {/* Official Count - Smaller */}
+      {placeData.officialAvailable && placeData.officialVictims != null ? (
+        <div className="border-t border-stone-200 pt-4">
+          <div className="text-sm text-stone-500 mb-1">
+            Vítimas (Oficial)
+          </div>
+          <div data-testid="official-count" className="text-3xl font-semibold text-stone-700 mb-2">
+            {placeData.officialVictims.toLocaleString('pt-BR')}
+          </div>
+          <div className="text-xs text-stone-500">
+            Ministério da Justiça e Segurança Pública, Formulário 1
+            {placeData.officialWindowStart && ` (desde ${placeData.officialWindowStart})`}
+          </div>
+        </div>
+      ) : (
+        <div className="border-t border-stone-200 pt-4">
+          <div className="text-sm text-stone-500 mb-1">
+            Vítimas (Oficial)
+          </div>
+          <div className="text-sm text-stone-600 italic">
+            Dados oficiais não publicados neste período
+          </div>
+        </div>
+      )}
+
+      {/* Counts are not the same sentence */}
+      <div className="border-t border-stone-200 pt-4">
+        <p className="text-sm text-stone-700">
+          As contagens não são iguais devido a diferentes metodologias de coleta e janelas temporais.
+        </p>
+      </div>
+
+      {/* Methodology Link */}
+      <div>
+        <a
+          href="/metodologia"
+          onClick={(e) => {
+            e.preventDefault();
+            navigate('/metodologia');
+          }}
+          className="text-sm text-blue-600 hover:text-blue-700 font-medium underline"
+        >
+          Como contamos
+        </a>
+      </div>
+
+      {/* Scope Line */}
+      {placeData.type === 'country' && placeData.name === 'Brasil' && (
+        <div className="border-t border-stone-200 pt-4">
+          <p className="text-xs text-stone-500">
+            Busca em notícias cobre 52 capitais e grandes regiões metropolitanas do Brasil.
+            Não cobre os 5.563 municípios nem apenas 63 cidades.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/portal/PlaceSearch.tsx
+++ b/frontend/src/components/portal/PlaceSearch.tsx
@@ -1,0 +1,169 @@
+import { useState, useRef, useEffect } from 'react';
+import { Search, X } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+export interface PlaceOption {
+  name: string;
+  type: 'country' | 'state' | 'municipality';
+  uf?: string;
+  displayName: string;
+}
+
+interface PlaceSearchProps {
+  places: PlaceOption[];
+  selectedPlace: PlaceOption | null;
+  onSelectPlace: (place: PlaceOption) => void;
+  placeholder?: string;
+}
+
+export function PlaceSearch({
+  places,
+  selectedPlace,
+  onSelectPlace,
+  placeholder = 'Busque um município ou estado',
+}: PlaceSearchProps) {
+  const [query, setQuery] = useState('');
+  const [isOpen, setIsOpen] = useState(false);
+  const [highlightedIndex, setHighlightedIndex] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  const filteredPlaces = query.trim() === ''
+    ? []
+    : places.filter(place =>
+        place.name.toLowerCase().includes(query.toLowerCase()) ||
+        place.displayName.toLowerCase().includes(query.toLowerCase())
+      ).slice(0, 10);
+
+  const handleSelectPlace = (place: PlaceOption) => {
+    onSelectPlace(place);
+    setQuery('');
+    setIsOpen(false);
+    inputRef.current?.blur();
+  };
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(event.target as Node) &&
+        inputRef.current &&
+        !inputRef.current.contains(event.target as Node)
+      ) {
+        setIsOpen(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (!isOpen || filteredPlaces.length === 0) {
+      if (e.key === 'ArrowDown' && query.trim() !== '') {
+        setIsOpen(true);
+      }
+      return;
+    }
+
+    switch (e.key) {
+      case 'ArrowDown':
+        e.preventDefault();
+        setHighlightedIndex(prev =>
+          prev < filteredPlaces.length - 1 ? prev + 1 : prev
+        );
+        break;
+      case 'ArrowUp':
+        e.preventDefault();
+        setHighlightedIndex(prev => (prev > 0 ? prev - 1 : 0));
+        break;
+      case 'Enter':
+        e.preventDefault();
+        if (filteredPlaces[highlightedIndex]) {
+          handleSelectPlace(filteredPlaces[highlightedIndex]);
+        }
+        break;
+      case 'Escape':
+        setIsOpen(false);
+        inputRef.current?.blur();
+        break;
+    }
+  };
+
+  useEffect(() => {
+    setHighlightedIndex(0);
+  }, [query]);
+
+  return (
+    <div className="relative">
+      <div className="relative">
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-5 w-5 text-stone-400" />
+        <input
+          ref={inputRef}
+          type="text"
+          value={query}
+          onChange={e => {
+            setQuery(e.target.value);
+            setIsOpen(true);
+          }}
+          onFocus={() => {
+            if (query.trim() !== '') {
+              setIsOpen(true);
+            }
+          }}
+          onKeyDown={handleKeyDown}
+          placeholder={placeholder}
+          className="w-full pl-10 pr-10 py-3 rounded-lg border border-stone-300 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+        />
+        {query && (
+          <button
+            onClick={() => {
+              setQuery('');
+              setIsOpen(false);
+              inputRef.current?.focus();
+            }}
+            className="absolute right-3 top-1/2 -translate-y-1/2 text-stone-400 hover:text-stone-600"
+          >
+            <X className="h-5 w-5" />
+          </button>
+        )}
+      </div>
+
+      {isOpen && filteredPlaces.length > 0 && (
+        <div
+          ref={dropdownRef}
+          className="absolute z-50 w-full mt-2 bg-white rounded-lg border border-stone-200 shadow-lg max-h-80 overflow-y-auto"
+        >
+          {filteredPlaces.map((place, index) => (
+            <button
+              key={`${place.type}-${place.displayName}`}
+              onClick={() => handleSelectPlace(place)}
+              className={cn(
+                'w-full px-4 py-3 text-left hover:bg-stone-50 transition-colors',
+                index === highlightedIndex && 'bg-stone-100',
+                index === 0 && 'rounded-t-lg',
+                index === filteredPlaces.length - 1 && 'rounded-b-lg'
+              )}
+            >
+              <div className="font-medium text-stone-900">{place.displayName}</div>
+              <div className="text-xs text-stone-500 mt-0.5">
+                {place.type === 'country' && 'País'}
+                {place.type === 'state' && 'Estado'}
+                {place.type === 'municipality' && 'Município'}
+              </div>
+            </button>
+          ))}
+        </div>
+      )}
+
+      {isOpen && query.trim() !== '' && filteredPlaces.length === 0 && (
+        <div
+          ref={dropdownRef}
+          className="absolute z-50 w-full mt-2 bg-white rounded-lg border border-stone-200 shadow-lg p-4 text-center text-sm text-stone-500"
+        >
+          Nenhum município ou estado encontrado
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/public/Rankings.issue185.test.tsx
+++ b/frontend/src/pages/public/Rankings.issue185.test.tsx
@@ -325,7 +325,7 @@ describe('Rankings Page - Issue #185: Place Search and Card', () => {
       
       // Brasil card should show BR-only Arquivo count (1234), not including Chile (300)
       const arquivoCount = within(placeCard).getByTestId('arquivo-count');
-      expect(arquivoCount).toHaveTextContent('1,234');
+      expect(arquivoCount).toHaveTextContent('1.234');
       
       // Official should still be BR-only (450 + 320 = 770)
       const officialCount = within(placeCard).getByTestId('official-count');

--- a/frontend/src/pages/public/Rankings.issue185.test.tsx
+++ b/frontend/src/pages/public/Rankings.issue185.test.tsx
@@ -24,6 +24,7 @@ const mockRankingsDataBR = {
   cities: [
     {
       city: 'São Paulo',
+      state: 'São Paulo',
       state_abbrev: 'SP',
       victim_count: 250,
       event_count: 125,
@@ -34,6 +35,7 @@ const mockRankingsDataBR = {
     },
     {
       city: 'Rio de Janeiro',
+      state: 'Rio de Janeiro',
       state_abbrev: 'RJ',
       victim_count: 180,
       event_count: 90,
@@ -61,6 +63,80 @@ const mockRankingsDataBR = {
       victim_delta: 0,
       rate_per_100k: 1.7,
       population: 17463349,
+    },
+  ],
+  countries: [],
+  homicide_types: [],
+  methods: [],
+  population_vintage: 'Censo 2022',
+};
+
+const mockRankingsDataWithChile = {
+  total_victims: 1534, // BR 1234 + CL 300
+  total_events: 667,
+  last_updated: '2026-08-20T10:30:00Z',
+  cities: [
+    {
+      city: 'São Paulo',
+      state: 'São Paulo',
+      state_abbrev: 'SP',
+      victim_count: 250,
+      event_count: 125,
+      victim_share: 16.3,
+      victim_delta: 0,
+      rate_per_100k: 2.1,
+      population: 12000000,
+    },
+    {
+      city: 'Rio de Janeiro',
+      state: 'Rio de Janeiro',
+      state_abbrev: 'RJ',
+      victim_count: 180,
+      event_count: 90,
+      victim_share: 11.7,
+      victim_delta: 0,
+      rate_per_100k: 2.7,
+      population: 6747815,
+    },
+    {
+      city: 'Santiago',
+      state: 'Región Metropolitana',
+      state_abbrev: 'RM',
+      victim_count: 300,
+      event_count: 100,
+      victim_share: 19.6,
+      victim_delta: 0,
+      rate_per_100k: 5.0,
+      population: 6000000,
+    },
+  ],
+  states: [
+    {
+      state: 'São Paulo',
+      victim_count: 450,
+      event_count: 225,
+      victim_share: 29.3,
+      victim_delta: 0,
+      rate_per_100k: 1.0,
+      population: 46289333,
+    },
+    {
+      state: 'Rio de Janeiro',
+      victim_count: 300,
+      event_count: 150,
+      victim_share: 19.6,
+      victim_delta: 0,
+      rate_per_100k: 1.7,
+      population: 17463349,
+    },
+    {
+      state: 'Región Metropolitana',
+      victim_count: 300,
+      event_count: 100,
+      victim_share: 19.6,
+      victim_delta: 0,
+      rate_per_100k: 5.0,
+      population: 6000000,
     },
   ],
   countries: [],
@@ -233,6 +309,23 @@ describe('Rankings Page - Issue #185: Place Search and Card', () => {
       const hasChileMunicipalities = allMunicipalities.some(m => m.uf === 'CL' || m.uf.startsWith('CL'));
       expect(hasChileMunicipalities).toBe(false);
     });
+
+    it('should not include Chile victims in Brasil Arquivo count when Chile is in the rankings', async () => {
+      // Mock with Chile data in the response
+      (api.fetchRankings as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(mockRankingsDataWithChile);
+      
+      renderWithProviders(<Rankings />);
+      
+      const placeCard = await screen.findByTestId('place-card', {}, { timeout: 3000 });
+      
+      // Brasil card should show BR-only Arquivo count (1234), not including Chile (300)
+      const arquivoCount = within(placeCard).getByTestId('arquivo-count');
+      expect(arquivoCount).toHaveTextContent('1,234');
+      
+      // Official should still be BR-only (450 + 320 = 770)
+      const officialCount = within(placeCard).getByTestId('official-count');
+      expect(officialCount).toHaveTextContent('770');
+    });
   });
 
   describe('Test 6: No 5563-row dump above the fold', () => {
@@ -258,7 +351,9 @@ describe('Rankings Page - Issue #185: Place Search and Card', () => {
       
       expect(within(placeCard).getByText(/Último ano/i)).toBeInTheDocument();
       
+      // Should show last update from data (2026-08-20), not "agora mesmo"
       expect(within(placeCard).getByText(/Última atualização/i)).toBeInTheDocument();
+      expect(within(placeCard).queryByText(/agora mesmo/i)).not.toBeInTheDocument();
     });
 
     it('should display official count with full citation when available', async () => {
@@ -309,6 +404,46 @@ describe('Rankings Page - Issue #185: Place Search and Card', () => {
       
       const searchInput = screen.getByPlaceholderText('Busque um município ou estado');
       expect(searchInput).toBeInTheDocument();
+    });
+
+    it('should show state official data as sum of municipalities in that state', async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<Rankings />);
+      
+      await screen.findByTestId('place-card', {}, { timeout: 3000 });
+      const searchInput = await screen.findByPlaceholderText('Busque um município ou estado');
+      
+      // Search and select São Paulo state
+      await user.type(searchInput, 'São Paulo');
+      
+      await waitFor(() => {
+        const options = screen.getAllByText(/São Paulo/i);
+        expect(options.length).toBeGreaterThan(0);
+      }, { timeout: 2000 });
+      
+      // Find the state option (not the municipality)
+      const stateOption = screen.getAllByText('São Paulo').find(el => {
+        const button = el.closest('button');
+        if (!button) return false;
+        const type = within(button).queryByText('Estado');
+        return type !== null;
+      });
+      expect(stateOption).toBeDefined();
+      await user.click(stateOption!);
+      
+      // Verify state card shows correct data
+      const placeCard = screen.getByTestId('place-card');
+      
+      // Arquivo count for São Paulo state
+      const arquivoCount = within(placeCard).getByTestId('arquivo-count');
+      expect(arquivoCount).toHaveTextContent('450');
+      
+      // Official should be sum of SP municipalities (only São Paulo city = 450 in fixture)
+      const officialCount = within(placeCard).getByTestId('official-count');
+      expect(officialCount).toHaveTextContent('450');
+      
+      // Should show it's a state
+      expect(within(placeCard).getByText('Estado')).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/pages/public/Rankings.issue185.test.tsx
+++ b/frontend/src/pages/public/Rankings.issue185.test.tsx
@@ -1,0 +1,314 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { BrowserRouter } from 'react-router-dom';
+import { Rankings } from '@/pages/public/Rankings';
+import { I18nProvider } from '@/contexts/I18nContext';
+import * as api from '@/lib/api';
+
+vi.mock('@/lib/api', () => ({
+  fetchRankings: vi.fn(),
+  fetchStatsMatrix: vi.fn(),
+  fetchCoverageStats: vi.fn(),
+}));
+
+vi.mock('@/hooks/useMediaQuery', () => ({
+  useIsMobile: () => false,
+}));
+
+const mockRankingsDataBR = {
+  total_victims: 1234,
+  total_events: 567,
+  last_updated: '2026-08-20T10:30:00Z',
+  cities: [
+    {
+      city: 'São Paulo',
+      state_abbrev: 'SP',
+      victim_count: 250,
+      event_count: 125,
+      victim_share: 20.3,
+      victim_delta: 0,
+      rate_per_100k: 2.1,
+      population: 12000000,
+    },
+    {
+      city: 'Rio de Janeiro',
+      state_abbrev: 'RJ',
+      victim_count: 180,
+      event_count: 90,
+      victim_share: 14.6,
+      victim_delta: 0,
+      rate_per_100k: 2.7,
+      population: 6747815,
+    },
+  ],
+  states: [
+    {
+      state: 'São Paulo',
+      victim_count: 450,
+      event_count: 225,
+      victim_share: 36.5,
+      victim_delta: 0,
+      rate_per_100k: 1.0,
+      population: 46289333,
+    },
+    {
+      state: 'Rio de Janeiro',
+      victim_count: 300,
+      event_count: 150,
+      victim_share: 24.3,
+      victim_delta: 0,
+      rate_per_100k: 1.7,
+      population: 17463349,
+    },
+  ],
+  countries: [],
+  homicide_types: [],
+  methods: [],
+  population_vintage: 'Censo 2022',
+};
+
+const mockCoverageDataBR = {
+  window_start: '2025-09',
+  methodology: {
+    official_bag: 'homicídio doloso + feminicídio + roubo seguido de morte (latrocínio) + lesão corporal seguida de morte',
+    arquivo_filter: 'homicidio, incident, victim_count <= 10, country=BR, date >= 2025-09-01',
+    coverage_calculation: 'Arquivo victims / official victims (not capped, None when official=0)',
+  },
+  municipalities: [
+    {
+      code: 3550308,
+      name: 'São Paulo',
+      uf: 'SP',
+      official_victims: 450,
+      arquivo_victims: 250,
+      coverage: 0.56,
+    },
+    {
+      code: 3304557,
+      name: 'Rio de Janeiro',
+      uf: 'RJ',
+      official_victims: 320,
+      arquivo_victims: 180,
+      coverage: 0.56,
+    },
+  ],
+};
+
+function renderWithProviders(component: React.ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <BrowserRouter>
+        <I18nProvider>
+          {component}
+        </I18nProvider>
+      </BrowserRouter>
+    </QueryClientProvider>
+  );
+}
+
+describe('Rankings Page - Issue #185: Place Search and Card', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (api.fetchRankings as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(mockRankingsDataBR);
+    (api.fetchCoverageStats as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(mockCoverageDataBR);
+  });
+
+  describe('Test 1: Default place is Brasil', () => {
+    it('should display Brasil as the default selected place on first load', async () => {
+      renderWithProviders(<Rankings />);
+      
+      const placeCard = await screen.findByTestId('place-card', {}, { timeout: 3000 });
+      expect(placeCard).toBeInTheDocument();
+      
+      expect(within(placeCard).getByRole('heading', { name: /Brasil/i })).toBeInTheDocument();
+    });
+  });
+
+  describe('Test 2: Typeahead search for municipality', () => {
+    it('should open place card when typing and selecting a municipality name', async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<Rankings />);
+      
+      await screen.findByTestId('place-card', {}, { timeout: 3000 });
+      const searchInput = await screen.findByPlaceholderText('Busque um município ou estado');
+      expect(searchInput).toBeInTheDocument();
+      
+      await user.type(searchInput, 'São Paulo');
+      
+      await waitFor(() => {
+        const options = screen.getAllByText(/São Paulo/i);
+        expect(options.length).toBeGreaterThan(0);
+      }, { timeout: 2000 });
+      
+      const allOptions = screen.getAllByText('São Paulo, SP');
+      const muniOption = allOptions.find(el => el.closest('button'));
+      expect(muniOption).toBeDefined();
+      await user.click(muniOption!);
+      
+      const placeCard = screen.getByTestId('place-card');
+      expect(within(placeCard).getByText(/São Paulo/i)).toBeInTheDocument();
+      
+      const arquivoCount = within(placeCard).getByTestId('arquivo-count');
+      expect(arquivoCount).toHaveTextContent('250');
+      
+      const officialCount = within(placeCard).getByTestId('official-count');
+      expect(officialCount).toHaveTextContent('450');
+    });
+  });
+
+  describe('Test 3: Official not shown as 0 when unpublished', () => {
+    it('should say official is not published when data is unavailable for the period', async () => {
+      (api.fetchCoverageStats as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+        ...mockCoverageDataBR,
+        municipalities: [],
+      });
+      
+      renderWithProviders(<Rankings />);
+      
+      const placeCard = await screen.findByTestId('place-card', {}, { timeout: 3000 });
+      
+      expect(within(placeCard).queryByTestId('official-count')).not.toBeInTheDocument();
+      
+      expect(within(placeCard).getByText(/Dados oficiais não publicados neste período/i)).toBeInTheDocument();
+    });
+  });
+
+  describe('Test 4: 7-day period shows Arquivo only, no fake official 0', () => {
+    it('should not show official count as 0 when 7-day period is selected', async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<Rankings />);
+      
+      await screen.findByTestId('place-card', {}, { timeout: 3000 });
+      
+      const sevenDayChip = screen.getByText(/Últimos 7 dias/i);
+      await user.click(sevenDayChip);
+      
+      await waitFor(() => {
+        expect(api.fetchRankings).toHaveBeenCalledWith(
+          expect.objectContaining({ days: 7 })
+        );
+      }, { timeout: 2000 });
+      
+      const placeCard = screen.getByTestId('place-card');
+      expect(within(placeCard).queryByTestId('official-count')).not.toBeInTheDocument();
+      
+      expect(within(placeCard).getByText(/Dados oficiais não publicados neste período/i)).toBeInTheDocument();
+    });
+  });
+
+  describe('Test 5: Chile is not default and not in Brazil official', () => {
+    it('should not select Chile as default', async () => {
+      renderWithProviders(<Rankings />);
+      
+      const placeCard = await screen.findByTestId('place-card', {}, { timeout: 3000 });
+      
+      expect(within(placeCard).getByRole('heading', { name: /Brasil/i })).toBeInTheDocument();
+      expect(within(placeCard).queryByRole('heading', { name: /Chile/i })).not.toBeInTheDocument();
+    });
+
+    it('should not include Chile victims in Brazil official figures', async () => {
+      renderWithProviders(<Rankings />);
+      
+      const placeCard = await screen.findByTestId('place-card', {}, { timeout: 3000 });
+      
+      // Brasil official count should be sum of BR municipalities only (450 + 320 = 770)
+      const officialCount = within(placeCard).getByTestId('official-count');
+      expect(officialCount).toHaveTextContent('770');
+      
+      // Verify the official count does NOT include any Chile data
+      // The mock only has BR municipalities, so this verifies Chile is excluded
+      expect(api.fetchCoverageStats).toHaveBeenCalled();
+      const coverageData = mockCoverageDataBR;
+      const allMunicipalities = coverageData.municipalities;
+      const hasChileMunicipalities = allMunicipalities.some(m => m.uf === 'CL' || m.uf.startsWith('CL'));
+      expect(hasChileMunicipalities).toBe(false);
+    });
+  });
+
+  describe('Test 6: No 5563-row dump above the fold', () => {
+    it('should not display a 5563-row municipality table above the fold', async () => {
+      renderWithProviders(<Rankings />);
+      
+      const placeCard = await screen.findByTestId('place-card', {}, { timeout: 3000 });
+      expect(placeCard).toBeInTheDocument();
+      
+      const placeCardContent = within(placeCard);
+      expect(placeCardContent.queryByRole('table')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Place Card Copy Requirements', () => {
+    it('should display Arquivo count large with period and last update', async () => {
+      renderWithProviders(<Rankings />);
+      
+      const placeCard = await screen.findByTestId('place-card', {}, { timeout: 3000 });
+      
+      const arquivoCount = within(placeCard).getByTestId('arquivo-count');
+      expect(arquivoCount).toBeInTheDocument();
+      
+      expect(within(placeCard).getByText(/Último ano/i)).toBeInTheDocument();
+      
+      expect(within(placeCard).getByText(/Última atualização/i)).toBeInTheDocument();
+    });
+
+    it('should display official count with full citation when available', async () => {
+      renderWithProviders(<Rankings />);
+      
+      const placeCard = await screen.findByTestId('place-card', {}, { timeout: 3000 });
+      
+      expect(within(placeCard).getByText(/Ministério da Justiça e Segurança Pública/i)).toBeInTheDocument();
+      
+      expect(within(placeCard).getByText(/Formulário 1/i)).toBeInTheDocument();
+      
+      expect(within(placeCard).getByText(/desde.*2025-09/i)).toBeInTheDocument();
+    });
+
+    it('should display sentence that counts are not the same', async () => {
+      renderWithProviders(<Rankings />);
+      
+      const placeCard = await screen.findByTestId('place-card', {}, { timeout: 3000 });
+      
+      expect(within(placeCard).getByText(/contagens não são iguais/i)).toBeInTheDocument();
+    });
+
+    it('should display "Como contamos" as a real link to methodology page', async () => {
+      renderWithProviders(<Rankings />);
+      
+      const placeCard = await screen.findByTestId('place-card', {}, { timeout: 3000 });
+      
+      const methodologyLink = within(placeCard).getByText(/Como contamos/i);
+      expect(methodologyLink).toBeInTheDocument();
+      expect(methodologyLink.tagName).toBe('A');
+      expect(methodologyLink).toHaveAttribute('href', '/metodologia');
+    });
+
+    it('should display scope line about 52 cities', async () => {
+      renderWithProviders(<Rankings />);
+      
+      const placeCard = await screen.findByTestId('place-card', {}, { timeout: 3000 });
+      
+      expect(within(placeCard).getByText(/52.*capitais.*grandes.*regiões.*metropolitanas/i)).toBeInTheDocument();
+      
+      expect(within(placeCard).getByText(/Não cobre os 5\.563 municípios nem apenas 63 cidades/i)).toBeInTheDocument();
+    });
+
+    it('should have exact placeholder text', async () => {
+      renderWithProviders(<Rankings />);
+      
+      await screen.findByTestId('place-card', {}, { timeout: 3000 });
+      
+      const searchInput = screen.getByPlaceholderText('Busque um município ou estado');
+      expect(searchInput).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/pages/public/Rankings.issue185.test.tsx
+++ b/frontend/src/pages/public/Rankings.issue185.test.tsx
@@ -311,8 +311,13 @@ describe('Rankings Page - Issue #185: Place Search and Card', () => {
     });
 
     it('should not include Chile victims in Brasil Arquivo count when Chile is in the rankings', async () => {
-      // Mock with Chile data in the response
-      (api.fetchRankings as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(mockRankingsDataWithChile);
+      // Mock fetchRankings to return BR-only data when country='BR'
+      (api.fetchRankings as unknown as ReturnType<typeof vi.fn>).mockImplementation((params: any) => {
+        if (params.country === 'BR') {
+          return Promise.resolve(mockRankingsDataBR);
+        }
+        return Promise.resolve(mockRankingsDataWithChile);
+      });
       
       renderWithProviders(<Rankings />);
       
@@ -325,6 +330,11 @@ describe('Rankings Page - Issue #185: Place Search and Card', () => {
       // Official should still be BR-only (450 + 320 = 770)
       const officialCount = within(placeCard).getByTestId('official-count');
       expect(officialCount).toHaveTextContent('770');
+      
+      // Verify fetchRankings was called with country='BR'
+      expect(api.fetchRankings).toHaveBeenCalledWith(
+        expect.objectContaining({ country: 'BR' })
+      );
     });
   });
 

--- a/frontend/src/pages/public/Rankings.tsx
+++ b/frontend/src/pages/public/Rankings.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { ChevronDown, ArrowLeft } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
@@ -14,6 +14,8 @@ import { cn } from '@/lib/utils';
 import { formatTypeStatLabel } from '@/lib/taxonomy';
 import { translateMethod } from '@/lib/i18n';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { PlaceSearch, type PlaceOption } from '@/components/portal/PlaceSearch';
+import { PlaceCard, type PlaceData } from '@/components/portal/PlaceCard';
 
 type PeriodOption = 7 | 30 | 365;
 type CountryOption = '' | 'BR' | 'CL';
@@ -182,6 +184,13 @@ export function Rankings() {
   const [aboutOpen, setAboutOpen] = useState(false);
   const [methodologyOpen, setMethodologyOpen] = useState(false);
   
+  // Issue #185: Place search state (default to Brasil)
+  const [selectedPlace, setSelectedPlace] = useState<PlaceOption>({
+    name: 'Brasil',
+    type: 'country',
+    displayName: 'Brasil',
+  });
+  
   // Reset city limit when period or country changes
   const handlePeriodChange = (newPeriod: PeriodOption) => {
     setPeriod(newPeriod);
@@ -214,6 +223,129 @@ export function Rankings() {
     { value: 'BR', label: 'Brasil' },
     { value: 'CL', label: 'Chile' },
   ];
+
+  // Issue #185: Build place options for typeahead
+  const placeOptions = useMemo((): PlaceOption[] => {
+    if (!data) return [];
+    
+    const options: PlaceOption[] = [
+      { name: 'Brasil', type: 'country', displayName: 'Brasil' },
+    ];
+    
+    data.states.forEach(state => {
+      let uf = state.state;
+      if (state.state.length > 2) {
+        const cityInState = data.cities.find(c => c.state === state.state);
+        if (cityInState?.state_abbrev) {
+          uf = cityInState.state_abbrev;
+        }
+      }
+      
+      options.push({
+        name: state.state,
+        type: 'state',
+        uf,
+        displayName: state.state,
+      });
+    });
+    
+    data.cities.forEach(city => {
+      options.push({
+        name: city.city,
+        type: 'municipality',
+        state: city.state,
+        uf: city.state_abbrev,
+        displayName: city.state_abbrev ? `${city.city}, ${city.state_abbrev}` : city.city,
+      });
+    });
+    
+    return options;
+  }, [data]);
+
+  // Issue #185: Build place data for the selected place card
+  const placeData = useMemo((): PlaceData | null => {
+    if (!data) return null;
+    
+    if (selectedPlace.type === 'country' && selectedPlace.name === 'Brasil') {
+      let officialVictims: number | null = null;
+      let officialAvailable = false;
+      
+      if (period === 365 && coverageData) {
+        officialVictims = coverageData.municipalities.reduce(
+          (sum, muni) => sum + muni.official_victims,
+          0
+        );
+        officialAvailable = true;
+      }
+      
+      return {
+        name: 'Brasil',
+        type: 'country',
+        arquivoVictims: data.total_victims,
+        officialVictims: officialAvailable ? officialVictims : null,
+        officialAvailable,
+        lastUpdated: data.last_updated || new Date().toISOString(),
+        period,
+        officialWindowStart: coverageData?.start_month,
+      };
+    } else if (selectedPlace.type === 'state') {
+      const stateRow = data.states.find(s => s.state === selectedPlace.name);
+      if (!stateRow) return null;
+      
+      let officialVictims: number | null = null;
+      let officialAvailable = false;
+      
+      if (period === 365 && coverageData && selectedPlace.uf) {
+        const stateMunis = coverageData.municipalities.filter(
+          muni => muni.uf === selectedPlace.uf
+        );
+        if (stateMunis.length > 0) {
+          officialVictims = stateMunis.reduce((sum, muni) => sum + muni.official_victims, 0);
+          officialAvailable = true;
+        }
+      }
+      
+      return {
+        name: selectedPlace.name,
+        type: 'state',
+        arquivoVictims: stateRow.victim_count,
+        officialVictims: officialAvailable ? officialVictims : null,
+        officialAvailable,
+        lastUpdated: data.last_updated || new Date().toISOString(),
+        period,
+        officialWindowStart: coverageData?.start_month,
+      };
+    } else if (selectedPlace.type === 'municipality') {
+      const cityRow = data.cities.find(c => c.city === selectedPlace.name);
+      if (!cityRow) return null;
+      
+      let officialVictims: number | null = null;
+      let officialAvailable = false;
+      
+      if (period === 365 && coverageData) {
+        const muniOfficial = coverageData.municipalities.find(
+          muni => muni.name === selectedPlace.name && muni.uf === selectedPlace.uf
+        );
+        if (muniOfficial) {
+          officialVictims = muniOfficial.official_victims;
+          officialAvailable = true;
+        }
+      }
+      
+      return {
+        name: selectedPlace.displayName,
+        type: 'municipality',
+        arquivoVictims: cityRow.victim_count,
+        officialVictims: officialAvailable ? officialVictims : null,
+        officialAvailable,
+        lastUpdated: data.last_updated || new Date().toISOString(),
+        period,
+        officialWindowStart: coverageData?.start_month,
+      };
+    }
+    
+    return null;
+  }, [data, coverageData, selectedPlace, period]);
 
   const handleCityClick = (city: string) => {
     // Deep link to map filtered to this city
@@ -310,6 +442,21 @@ export function Rankings() {
               </div>
             </div>
           </div>
+
+          {/* Issue #185: Place search and card (above the fold) */}
+          {!isLoading && data && (
+            <div className="mb-8 space-y-4">
+              <PlaceSearch
+                places={placeOptions}
+                selectedPlace={selectedPlace}
+                onSelectPlace={setSelectedPlace}
+                placeholder="Busque um município ou estado"
+              />
+              {placeData && (
+                <PlaceCard placeData={placeData} />
+              )}
+            </div>
+          )}
 
           {/* Loading state */}
           {isLoading && (

--- a/frontend/src/pages/public/Rankings.tsx
+++ b/frontend/src/pages/public/Rankings.tsx
@@ -270,7 +270,7 @@ export function Rankings() {
       let officialVictims: number | null = null;
       let officialAvailable = false;
       
-      if (period === 365 && coverageData) {
+      if (period === 365 && coverageData && coverageData.municipalities.length > 0) {
         officialVictims = coverageData.municipalities.reduce(
           (sum, muni) => sum + muni.official_victims,
           0
@@ -286,7 +286,7 @@ export function Rankings() {
         officialAvailable,
         lastUpdated: data.last_updated || new Date().toISOString(),
         period,
-        officialWindowStart: coverageData?.start_month,
+        officialWindowStart: coverageData?.window_start,
       };
     } else if (selectedPlace.type === 'state') {
       const stateRow = data.states.find(s => s.state === selectedPlace.name);
@@ -313,7 +313,7 @@ export function Rankings() {
         officialAvailable,
         lastUpdated: data.last_updated || new Date().toISOString(),
         period,
-        officialWindowStart: coverageData?.start_month,
+        officialWindowStart: coverageData?.window_start,
       };
     } else if (selectedPlace.type === 'municipality') {
       const cityRow = data.cities.find(c => c.city === selectedPlace.name);
@@ -340,7 +340,7 @@ export function Rankings() {
         officialAvailable,
         lastUpdated: data.last_updated || new Date().toISOString(),
         period,
-        officialWindowStart: coverageData?.start_month,
+        officialWindowStart: coverageData?.window_start,
       };
     }
     


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Issue #185: /estatisticas place search and card

**Rebased onto `develop` at `86c6ac3`** to resolve conflicts with PR #195.

### What this PR does

Adds above-the-fold place search and place card to `/estatisticas`:
- **Place typeahead** (`PlaceSearch.tsx`): Search municipalities, states, or Brasil (default). Placeholder: "Busque um município ou estado"
- **Place card** (`PlaceCard.tsx`): Shows selected place's Arquivo victims (large, with period + last update) and official victims (smaller, Ministério da Justiça e Segurança Pública, Formulário 1, vintage) or "not published" message when unavailable
- **Card features**:
  - Arquivo count formatted with `toLocaleString('pt-BR')` (e.g. 1.234)
  - Official count shown only when `period === 365` and coverage data exists
  - Real link to `/metodologia` ("Como contamos")
  - Sentence: "As contagens não são iguais devido a diferentes metodologias de coleta e janelas temporais"
  - Scope line for Brasil: "Busca em notícias cobre 52 capitais e grandes regiões metropolitanas do Brasil"

### Acceptance criteria

All tests pass (15/15):
1. ✅ Default place is Brasil
2. ✅ Typeahead opens municipality card
3. ✅ Official not shown as 0 when unpublished
4. ✅ 7-day period: Arquivo only, no fake official 0
5. ✅ Chile not default, not in Brazil official figures
6. ✅ No 5563-row dump above the fold
7. ✅ Card copy: Arquivo large, official smaller with citation, methodology link, scope line, exact placeholder

### Changes

- `frontend/src/components/portal/PlaceCard.tsx` (new)
- `frontend/src/components/portal/PlaceSearch.tsx` (new)
- `frontend/src/pages/public/Rankings.tsx` (minimal above-the-fold integration)
- `frontend/src/pages/public/Rankings.issue185.test.tsx` (new, 15 tests)

### Testing

```bash
npm test -- Rankings.issue185.test.tsx
# ✓ 15 passed (15)
```

**Ready for review.** Frontend-only, no backend changes, no scope creep.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-69318964-d460-4b55-b19a-75722ab7736d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-69318964-d460-4b55-b19a-75722ab7736d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

