### PR TITLE
Add city size floor and state filtering for public rankings (#186)

### DIFF
--- a/backend/app/geography.py
+++ b/backend/app/geography.py
@@ -75,6 +75,38 @@ BRAZILIAN_STATE_NAMES = {
     "TO": "Tocantins",
 }
 
+# Brazilian state capitals (all 27)
+# For city size floor filter in public rankings
+BRAZILIAN_CAPITALS = {
+    "Rio Branco",      # AC
+    "Maceió",          # AL
+    "Macapá",          # AP
+    "Manaus",          # AM
+    "Salvador",        # BA
+    "Fortaleza",       # CE
+    "Brasília",        # DF
+    "Vitória",         # ES
+    "Goiânia",         # GO
+    "São Luís",        # MA
+    "Cuiabá",          # MT
+    "Campo Grande",    # MS
+    "Belo Horizonte",  # MG
+    "Belém",           # PA
+    "João Pessoa",     # PB
+    "Curitiba",        # PR
+    "Recife",          # PE
+    "Teresina",        # PI
+    "Rio de Janeiro",  # RJ
+    "Natal",           # RN
+    "Porto Velho",     # RO
+    "Boa Vista",       # RR
+    "Porto Alegre",    # RS
+    "Florianópolis",   # SC
+    "Aracaju",         # SE
+    "São Paulo",       # SP
+    "Palmas",          # TO
+}
+
 # ============================================================================
 # Chilean Geography
 # ============================================================================

--- a/backend/app/routers/public.py
+++ b/backend/app/routers/public.py
@@ -22,7 +22,7 @@ from app.services.public_filters import (
     homicide_type_filter,
     homicide_types_filter,
 )
-from app.geography import COUNTRY_NAMES, BRAZILIAN_STATES
+from app.geography import COUNTRY_NAMES, BRAZILIAN_STATES, BRAZILIAN_CAPITALS
 
 router = APIRouter(prefix="/public", tags=["public"])
 
@@ -806,9 +806,43 @@ async def get_rankings(
     # Format rankings
     cities_rankings = format_rankings(cities_current, cities_prev, include_rate=True, is_city=True)
     
+    # Apply size floor filter for public city rankings (issue #186):
+    # Only show cities that are either:
+    # 1. Brazilian capitals, OR
+    # 2. Population > 100,000, OR
+    # 3. Have Arquivo cases (already guaranteed since they're in the rankings)
+    # This prevents tiny towns like Matos Costa (pop 2,761) from appearing in top rankings
+    def passes_city_size_floor(city_row):
+        city_name = city_row.get("city")
+        if not city_name:
+            return False
+        
+        # Check if it's a capital
+        if city_name in BRAZILIAN_CAPITALS:
+            return True
+        
+        # Check if population > 100k
+        population = city_row.get("population")
+        if population is not None and population > 100_000:
+            return True
+        
+        # If no population data, include it (we can't filter without data)
+        # This handles non-BR cities or cities without IBGE matches
+        if population is None:
+            return True
+        
+        return False
+    
+    cities_rankings = [c for c in cities_rankings if passes_city_size_floor(c)]
+    
     # Apply city_limit for performance (default 50 for fast default load)
     if city_limit is not None and city_limit > 0:
         cities_rankings = cities_rankings[:city_limit]
+    
+    # Format states and filter to only include Brazilian states (issue #186)
+    # This removes foreign regions like "Síria", "Flórida", "OH", "CA", etc.
+    states_rankings = format_rankings(states_current, states_prev, "state", include_rate=True, state_pops=True)
+    states_rankings = [s for s in states_rankings if s.get("state") in BRAZILIAN_STATES]
     
     response = {
         "period_days": days,
@@ -818,7 +852,7 @@ async def get_rankings(
         "total_victims": total_victims,
         "total_events": total_events,
         "cities": cities_rankings,
-        "states": format_rankings(states_current, states_prev, "state", include_rate=True, state_pops=True),
+        "states": states_rankings,
         "countries": format_rankings(countries_current, countries_prev, "country", include_rate=True, country_pops=country_population_data),
         "homicide_types": format_rankings(types_current, types_prev, "type"),
         "methods": format_rankings(methods_current, methods_prev, "method"),

--- a/backend/app/routers/public.py
+++ b/backend/app/routers/public.py
@@ -809,28 +809,24 @@ async def get_rankings(
     # Apply size floor filter for public city rankings (issue #186):
     # Only show cities that are either:
     # 1. Brazilian capitals, OR
-    # 2. Population > 100,000, OR
-    # 3. Have Arquivo cases (already guaranteed since they're in the rankings)
+    # 2. Population > 100,000
     # This prevents tiny towns like Matos Costa (pop 2,761) from appearing in top rankings
+    # Unknown population (None) does NOT pass unless it's a capital
     def passes_city_size_floor(city_row):
         city_name = city_row.get("city")
         if not city_name:
             return False
         
-        # Check if it's a capital
+        # Check if it's a capital (always pass)
         if city_name in BRAZILIAN_CAPITALS:
             return True
         
-        # Check if population > 100k
+        # For non-capitals: only pass if population is known AND > 100k
         population = city_row.get("population")
         if population is not None and population > 100_000:
             return True
         
-        # If no population data, include it (we can't filter without data)
-        # This handles non-BR cities or cities without IBGE matches
-        if population is None:
-            return True
-        
+        # Non-capitals without population data or with pop <= 100k are excluded
         return False
     
     cities_rankings = [c for c in cities_rankings if passes_city_size_floor(c)]

--- a/backend/tests/test_rankings.py
+++ b/backend/tests/test_rankings.py
@@ -1775,3 +1775,138 @@ async def test_rankings_default_sort_by_victims(app, async_session):
         assert data["cities"][2]["victim_count"] == 2
 
 
+@pytest.mark.asyncio
+async def test_top_10_first_page_requirements(app, async_session):
+    """Test that first page of last-year Cidades shows max 10 rows and excludes non-capitals under 100k (issue #186).
+    
+    Acceptance: Top 10 + "Ver mais." No non-capital under 100k in first page.
+    """
+    from app.models.ibge_population import IBGEPopulation
+    from app.geography import BRAZILIAN_CAPITALS
+    
+    now = datetime.utcnow()
+    current_start = now - timedelta(days=365)
+    
+    # Create 15 cities with varying populations to test top 10 logic
+    events = []
+    populations = []
+    
+    # Capital cities (should pass size floor) - make them high victim count to be in top 10
+    for idx, capital in enumerate(["São Paulo", "Rio de Janeiro", "Belo Horizonte", "Salvador", "Brasília"]):
+        events.append(create_ranking_event(
+            event_date=current_start + timedelta(days=idx),
+            city=capital,
+            state=["SP", "RJ", "MG", "BA", "DF"][idx],
+            victim_count=10 - idx  # 10, 9, 8, 7, 6 victims
+        ))
+    
+    # Large non-capital cities (pop > 100k, should pass size floor)
+    for idx, (city, state, pop) in enumerate([
+        ("Guarulhos", "SP", 1391000),
+        ("Campinas", "SP", 1213792),
+        ("Duque de Caxias", "RJ", 924624),
+        ("Joinville", "SC", 597658),
+        ("Ribeirão Preto", "SP", 711825),
+    ]):
+        events.append(create_ranking_event(
+            event_date=current_start + timedelta(days=5 + idx),
+            city=city,
+            state=state,
+            victim_count=5 - idx  # 5, 4, 3, 2, 1 victims
+        ))
+        populations.append(IBGEPopulation(
+            code_muni=4200000 + idx,
+            name_muni=city,
+            abbrev_state=state,
+            population=pop,
+            year=2022
+        ))
+    
+    # Small non-capital cities (pop < 100k, should be EXCLUDED)
+    for idx, (city, state, pop) in enumerate([
+        ("Matos Costa", "SC", 2761),
+        ("Cidadezinha Pequena", "RS", 5432),
+        ("Vila Minúscula", "PR", 15000),
+        ("Povoado Diminuto", "SC", 45000),
+        ("Lugarejo Ínfimo", "RS", 89000),
+    ]):
+        events.append(create_ranking_event(
+            event_date=current_start + timedelta(days=10 + idx),
+            city=city,
+            state=state,
+            victim_count=20 + idx  # High victim count to test they're still excluded
+        ))
+        populations.append(IBGEPopulation(
+            code_muni=4300000 + idx,
+            name_muni=city,
+            abbrev_state=state,
+            population=pop,
+            year=2022
+        ))
+    
+    # Add population data for capitals (use real approximate values)
+    capital_pops = [
+        (4205407, "São Paulo", "SP", 12325232),
+        (3304557, "Rio de Janeiro", "RJ", 6747815),
+        (3106200, "Belo Horizonte", "MG", 2521564),
+        (2927408, "Salvador", "BA", 2886698),
+        (5300108, "Brasília", "DF", 3055149),
+    ]
+    for code, name, state, pop in capital_pops:
+        populations.append(IBGEPopulation(
+            code_muni=code,
+            name_muni=name,
+            abbrev_state=state,
+            population=pop,
+            year=2022
+        ))
+    
+    for event in events:
+        async_session.add(event)
+    for pop in populations:
+        async_session.add(pop)
+    await async_session.commit()
+    
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test"
+    ) as client:
+        # Test with default city_limit (50, but we expect size floor to reduce this)
+        response = await client.get("/api/public/stats/rankings?days=365&country=BR")
+        assert response.status_code == 200
+        data = response.json()
+        
+        cities = data["cities"]
+        
+        # Acceptance criterion 1: First page (default fetch) should not exceed practical display limit
+        # The API returns filtered results, frontend shows top 10 initially
+        # We're testing that the backend filtering works correctly
+        assert len(cities) >= 10, f"Should have at least 10 cities after filtering, got {len(cities)}"
+        
+        # Acceptance criterion 2: No non-capital city under 100k should appear in ANY position
+        for city in cities:
+            city_name = city["city"]
+            population = city.get("population")
+            
+            # If it's not a capital, it must have population > 100k
+            if city_name not in BRAZILIAN_CAPITALS:
+                assert population is not None, f"Non-capital {city_name} should have population data"
+                assert population > 100_000, \
+                    f"Non-capital {city_name} with population {population:,} should be excluded (size floor: capitals OR pop > 100k)"
+        
+        # Specifically verify that small towns are NOT in the results
+        city_names = [city["city"] for city in cities]
+        assert "Matos Costa" not in city_names, "Matos Costa (pop 2,761) must be excluded"
+        assert "Cidadezinha Pequena" not in city_names, "Cidadezinha Pequena (pop 5,432) must be excluded"
+        assert "Vila Minúscula" not in city_names, "Vila Minúscula (pop 15,000) must be excluded"
+        
+        # Verify that capitals ARE in the results (even if they had lower victim counts)
+        # At least some capitals should appear
+        capitals_in_result = [city for city in cities if city["city"] in BRAZILIAN_CAPITALS]
+        assert len(capitals_in_result) > 0, "Capitals should appear in rankings"
+        
+        # Verify that large non-capital cities ARE in the results
+        assert "Guarulhos" in city_names or "Campinas" in city_names or "Joinville" in city_names, \
+            "Large cities (pop > 100k) should be included"
+
+

--- a/backend/tests/test_rankings.py
+++ b/backend/tests/test_rankings.py
@@ -1544,3 +1544,234 @@ async def test_rankings_country_filter_iso_codes_issue_152(app, async_session):
         assert data_all["total_events"] == 3
 
 
+@pytest.mark.asyncio
+async def test_city_size_floor_excludes_small_towns(app, async_session):
+    """Test that small non-capital towns are excluded from rankings (issue #186).
+    
+    Size floor: capitals + population > 100k + has Arquivo cases.
+    Example: Matos Costa SC (pop 2,761, 3 victims, not a capital) must NOT appear.
+    """
+    from app.models.ibge_population import IBGEPopulation
+    
+    now = datetime.utcnow()
+    current_start = now - timedelta(days=365)
+    
+    # Create events for different city types
+    events = [
+        # Capital city (always included)
+        create_ranking_event(
+            event_date=current_start + timedelta(days=1),
+            city="Florianópolis",
+            state="SC",
+            victim_count=2
+        ),
+        # Small town (pop 2,761, NOT a capital) - should be EXCLUDED
+        create_ranking_event(
+            event_date=current_start + timedelta(days=2),
+            city="Matos Costa",
+            state="SC",
+            victim_count=3
+        ),
+        # Large city (pop > 100k, not a capital) - should be included
+        create_ranking_event(
+            event_date=current_start + timedelta(days=3),
+            city="Joinville",
+            state="SC",
+            victim_count=1
+        ),
+    ]
+    
+    # Add population data
+    # Real IBGE codes for these cities
+    populations = [
+        IBGEPopulation(code_muni=4205407, name_muni="Florianópolis", abbrev_state="SC", population=508826, year=2022),
+        IBGEPopulation(code_muni=4210803, name_muni="Matos Costa", abbrev_state="SC", population=2761, year=2022),
+        IBGEPopulation(code_muni=4209102, name_muni="Joinville", abbrev_state="SC", population=597658, year=2022),
+    ]
+    
+    for event in events:
+        async_session.add(event)
+    for pop in populations:
+        async_session.add(pop)
+    await async_session.commit()
+    
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test"
+    ) as client:
+        response = await client.get("/api/public/stats/rankings?days=365&country=BR")
+        assert response.status_code == 200
+        data = response.json()
+        
+        # Extract city names from rankings
+        city_names = [city["city"] for city in data["cities"]]
+        
+        # Florianópolis (capital) should be included
+        assert "Florianópolis" in city_names, "Capital city should be included"
+        
+        # Joinville (pop > 100k) should be included
+        assert "Joinville" in city_names, "Large city (pop > 100k) should be included"
+        
+        # Matos Costa (pop 2,761, not a capital) should be EXCLUDED
+        assert "Matos Costa" not in city_names, "Small non-capital town (pop 2,761) must be excluded from rankings"
+
+
+@pytest.mark.asyncio
+async def test_states_filter_excludes_foreign_regions(app, async_session):
+    """Test that only Brazilian states appear in states rankings (issue #186).
+    
+    Must exclude foreign regions like Síria, Flórida, OH, CA, Nova Jersey, etc.
+    """
+    now = datetime.utcnow()
+    current_start = now - timedelta(days=365)
+    
+    # Create events in various locations
+    events = [
+        # Brazilian states (should be included)
+        create_ranking_event(
+            event_date=current_start + timedelta(days=1),
+            country="BR",
+            state="RJ",
+            city="Rio de Janeiro",
+            victim_count=2
+        ),
+        create_ranking_event(
+            event_date=current_start + timedelta(days=2),
+            country="BR",
+            state="SP",
+            city="São Paulo",
+            victim_count=3
+        ),
+        # Foreign region (should be EXCLUDED)
+        create_ranking_event(
+            event_date=current_start + timedelta(days=3),
+            country="BR",
+            state="Síria",
+            city="Damasco",
+            victim_count=1,
+            latitude=Decimal("33.5138"),
+            longitude=Decimal("36.2765")
+        ),
+        # US states (should be EXCLUDED)
+        create_ranking_event(
+            event_date=current_start + timedelta(days=4),
+            country="BR",
+            state="Flórida",
+            city="Miami",
+            victim_count=1,
+            latitude=Decimal("25.7617"),
+            longitude=Decimal("-80.1918")
+        ),
+        create_ranking_event(
+            event_date=current_start + timedelta(days=5),
+            country="BR",
+            state="OH",
+            city="Cleveland",
+            victim_count=1,
+            latitude=Decimal("41.4993"),
+            longitude=Decimal("-81.6944")
+        ),
+        # Mexican state (should be EXCLUDED)
+        create_ranking_event(
+            event_date=current_start + timedelta(days=6),
+            country="BR",
+            state="Jalisco",
+            city="Guadalajara",
+            victim_count=2,
+            latitude=Decimal("20.6597"),
+            longitude=Decimal("-103.3496")
+        ),
+    ]
+    
+    for event in events:
+        async_session.add(event)
+    await async_session.commit()
+    
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test"
+    ) as client:
+        response = await client.get("/api/public/stats/rankings?days=365&country=BR")
+        assert response.status_code == 200
+        data = response.json()
+        
+        # Extract state names from rankings
+        state_names = [state["state"] for state in data["states"]]
+        
+        # Brazilian states should be included
+        assert "RJ" in state_names, "Brazilian state RJ should be included"
+        assert "SP" in state_names, "Brazilian state SP should be included"
+        
+        # Foreign regions should be EXCLUDED
+        foreign_regions = ["Síria", "Flórida", "OH", "CA", "Nova Jersey", "Jalisco", "Guatemala", "Canindeyú"]
+        for foreign in foreign_regions:
+            assert foreign not in state_names, f"Foreign region '{foreign}' must be excluded from states rankings"
+
+
+@pytest.mark.asyncio
+async def test_rankings_default_sort_by_victims(app, async_session):
+    """Test that rankings are sorted by victim count (not event count) by default (issue #186)."""
+    now = datetime.utcnow()
+    current_start = now - timedelta(days=365)
+    
+    # Create events with different victim/event ratios
+    events = [
+        # City A: 1 event, 5 victims (should be ranked #1)
+        create_ranking_event(
+            event_date=current_start + timedelta(days=1),
+            city="São Paulo",
+            state="SP",
+            victim_count=5
+        ),
+        # City B: 3 events, 3 victims (should be ranked #2)
+        create_ranking_event(
+            event_date=current_start + timedelta(days=2),
+            city="Rio de Janeiro",
+            state="RJ",
+            victim_count=1
+        ),
+        create_ranking_event(
+            event_date=current_start + timedelta(days=3),
+            city="Rio de Janeiro",
+            state="RJ",
+            victim_count=1
+        ),
+        create_ranking_event(
+            event_date=current_start + timedelta(days=4),
+            city="Rio de Janeiro",
+            state="RJ",
+            victim_count=1
+        ),
+        # City C: 1 event, 2 victims (should be ranked #3)
+        create_ranking_event(
+            event_date=current_start + timedelta(days=5),
+            city="Belo Horizonte",
+            state="MG",
+            victim_count=2
+        ),
+    ]
+    
+    for event in events:
+        async_session.add(event)
+    await async_session.commit()
+    
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test"
+    ) as client:
+        response = await client.get("/api/public/stats/rankings?days=365&country=BR")
+        assert response.status_code == 200
+        data = response.json()
+        
+        # Verify ranking order is by victim count
+        assert len(data["cities"]) >= 3
+        assert data["cities"][0]["city"] == "São Paulo", "São Paulo (5 victims) should be ranked #1"
+        assert data["cities"][0]["victim_count"] == 5
+        
+        assert data["cities"][1]["city"] == "Rio de Janeiro", "Rio de Janeiro (3 victims) should be ranked #2"
+        assert data["cities"][1]["victim_count"] == 3
+        
+        assert data["cities"][2]["city"] == "Belo Horizonte", "Belo Horizonte (2 victims) should be ranked #3"
+        assert data["cities"][2]["victim_count"] == 2
+
+

--- a/frontend/src/pages/public/Rankings.tsx
+++ b/frontend/src/pages/public/Rankings.tsx
@@ -13,9 +13,16 @@ import { useIsMobile } from '@/hooks/useMediaQuery';
 import { cn } from '@/lib/utils';
 import { formatTypeStatLabel } from '@/lib/taxonomy';
 import { translateMethod } from '@/lib/i18n';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 
 type PeriodOption = 7 | 30 | 365;
 type CountryOption = '' | 'BR' | 'CL';
+type RankingTab = 'municipios' | 'estados' | 'paises';
+
+// Portuguese number formatting (1.239 instead of 1,239)
+function formatPortugueseNumber(num: number): string {
+  return num.toLocaleString('pt-BR');
+}
 
 interface RankingTableProps {
   title: string;
@@ -41,6 +48,9 @@ function RankingTable({ title, rows, labelField, onRowClick, emptyMessage, showR
 
   const displayRows = expanded ? rows : rows.slice(0, 10);
   const hasRateData = showRateColumns && rows.some(r => r.rate_per_100k != null);
+  
+  // Helper to format numbers in Portuguese style (1.239 instead of 1,239)
+  const formatNum = (num: number) => formatPortugueseNumber(num);
 
   return (
     <div className="rounded-xl border border-stone-200 bg-white overflow-hidden">
@@ -112,21 +122,21 @@ function RankingTable({ title, rows, labelField, onRowClick, emptyMessage, showR
                       {displayLabel}
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap text-sm text-right text-stone-900">
-                      {row.victim_count.toLocaleString()}
+                      {formatNum(row.victim_count)}
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap text-sm text-right text-stone-700">
-                      {row.event_count.toLocaleString()}
+                      {formatNum(row.event_count)}
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap text-sm text-right text-stone-700">
-                      {row.victim_share.toFixed(1)}%
+                      {row.victim_share.toFixed(1).replace('.', ',')}%
                     </td>
                     {hasRateData && (
                       <>
                         <td className="px-6 py-4 whitespace-nowrap text-sm text-right text-stone-900 font-semibold">
-                          {row.rate_per_100k != null ? row.rate_per_100k.toFixed(2) : '—'}
+                          {row.rate_per_100k != null ? row.rate_per_100k.toFixed(2).replace('.', ',') : '—'}
                         </td>
                         <td className="px-6 py-4 whitespace-nowrap text-sm text-right text-stone-700">
-                          {row.population != null ? row.population.toLocaleString() : '—'}
+                          {row.population != null ? formatNum(row.population) : '—'}
                         </td>
                       </>
                     )}
@@ -157,8 +167,10 @@ export function Rankings() {
   const navigate = useNavigate();
   const isMobile = useIsMobile();
   
+  // Issue #186: Default to Brasil, last year (365 days), Municípios tab
   const [period, setPeriod] = useState<PeriodOption>(365);
-  const [country, setCountry] = useState<CountryOption>('');
+  const [country, setCountry] = useState<CountryOption>('BR');
+  const [rankingTab, setRankingTab] = useState<RankingTab>('municipios');
   const [cityLimit, setCityLimit] = useState<number>(50);
   const [aboutOpen, setAboutOpen] = useState(false);
   const [methodologyOpen, setMethodologyOpen] = useState(false);
@@ -306,45 +318,73 @@ export function Rankings() {
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <div className="rounded-xl border border-stone-200 bg-white p-6">
                   <div className="text-sm text-stone-500 mb-1">{t.rankingsVictimCount}</div>
-                  <div className="text-3xl font-bold text-stone-900">{data.total_victims.toLocaleString()}</div>
+                  <div className="text-3xl font-bold text-stone-900">{formatPortugueseNumber(data.total_victims)}</div>
                 </div>
                 <div className="rounded-xl border border-stone-200 bg-white p-6">
                   <div className="text-sm text-stone-500 mb-1">{t.rankingsEventCount}</div>
-                  <div className="text-3xl font-bold text-stone-900">{data.total_events.toLocaleString()}</div>
+                  <div className="text-3xl font-bold text-stone-900">{formatPortugueseNumber(data.total_events)}</div>
                 </div>
               </div>
 
-              {/* Cities */}
-              <RankingTable
-                title={t.rankingsCities}
-                rows={data.cities}
-                labelField="city"
-                onRowClick={handleCityClick}
-                emptyMessage="Nenhuma cidade com eventos no período selecionado."
-                showRateColumns={true}
-              />
-              
-              {/* Show More Cities button */}
-              {data.cities.length === cityLimit && cityLimit < 500 && (
-                <div className="rounded-xl border border-stone-200 bg-white p-4 text-center">
-                  <button
-                    onClick={() => setCityLimit(prev => Math.min(prev + 100, 500))}
-                    className="text-sm text-blue-600 hover:text-blue-700 font-medium"
-                  >
-                    Mostrar mais cidades ({cityLimit} de ~{cityLimit + 100}+)
-                  </button>
-                </div>
-              )}
+              {/* Rankings Tabs - Issue #186: Municípios | Estados | Países */}
+              <Tabs value={rankingTab} onValueChange={(v) => setRankingTab(v as RankingTab)} className="w-full">
+                <TabsList className="grid w-full grid-cols-3">
+                  <TabsTrigger value="municipios">Municípios</TabsTrigger>
+                  <TabsTrigger value="estados">Estados</TabsTrigger>
+                  <TabsTrigger value="paises">Países</TabsTrigger>
+                </TabsList>
 
-              {/* States/Regions */}
-              <RankingTable
-                title={t.rankingsStates}
-                rows={data.states}
-                labelField="state"
-                onRowClick={handleStateClick}
-                emptyMessage="Nenhum estado/região com eventos no período selecionado."
-                showRateColumns={true}
-              />
+                <TabsContent value="municipios" className="mt-6">
+                  <RankingTable
+                    title={t.rankingsCities}
+                    rows={data.cities}
+                    labelField="city"
+                    onRowClick={handleCityClick}
+                    emptyMessage="Nenhuma cidade com eventos no período selecionado."
+                    showRateColumns={true}
+                  />
+                  
+                  {/* Show More Cities button */}
+                  {data.cities.length === cityLimit && cityLimit < 500 && (
+                    <div className="rounded-xl border border-stone-200 bg-white p-4 text-center mt-4">
+                      <button
+                        onClick={() => setCityLimit(prev => Math.min(prev + 100, 500))}
+                        className="text-sm text-blue-600 hover:text-blue-700 font-medium"
+                      >
+                        Mostrar mais cidades ({cityLimit} de ~{cityLimit + 100}+)
+                      </button>
+                    </div>
+                  )}
+                </TabsContent>
+
+                <TabsContent value="estados" className="mt-6">
+                  <RankingTable
+                    title={t.rankingsStates}
+                    rows={data.states}
+                    labelField="state"
+                    onRowClick={handleStateClick}
+                    emptyMessage="Nenhum estado/região com eventos no período selecionado."
+                    showRateColumns={true}
+                  />
+                </TabsContent>
+
+                <TabsContent value="paises" className="mt-6">
+                  {/* Countries - only show when not filtering by country */}
+                  {!country && data.countries.length > 0 && (
+                    <RankingTable
+                      title={t.rankingsCountries}
+                      rows={data.countries}
+                      labelField="country"
+                      emptyMessage="Nenhum país com eventos no período selecionado."
+                    />
+                  )}
+                  {country && (
+                    <div className="rounded-xl border border-stone-200 bg-white p-6">
+                      <p className="text-sm text-stone-500">Filtrando por país específico. Remova o filtro para ver todos os países.</p>
+                    </div>
+                  )}
+                </TabsContent>
+              </Tabs>
 
               {/* Coverage Table */}
               {coverageData && !isCoverageLoading && (
@@ -398,10 +438,10 @@ export function Rankings() {
                                 {muni.uf}
                               </td>
                               <td className="px-4 py-3 text-right text-stone-900">
-                                {muni.official_victims.toLocaleString()}
+                                {formatPortugueseNumber(muni.official_victims)}
                               </td>
                               <td className="px-4 py-3 text-right text-stone-900">
-                                {muni.arquivo_victims.toLocaleString()}
+                                {formatPortugueseNumber(muni.arquivo_victims)}
                               </td>
                               <td className={cn('px-4 py-3 text-right font-semibold', coverageColor)}>
                                 {coveragePercent}%
@@ -413,16 +453,6 @@ export function Rankings() {
                     </table>
                   </div>
                 </div>
-              )}
-
-              {/* Countries */}
-              {!country && data.countries.length > 0 && (
-                <RankingTable
-                  title={t.rankingsCountries}
-                  rows={data.countries}
-                  labelField="country"
-                  emptyMessage="Nenhum país com eventos no período selecionado."
-                />
               )}
             </div>
           )}

--- a/frontend/src/pages/public/Rankings.tsx
+++ b/frontend/src/pages/public/Rankings.tsx
@@ -35,7 +35,8 @@ interface RankingTableProps {
 
 function RankingTable({ title, rows, labelField, onRowClick, emptyMessage, showRateColumns = false }: RankingTableProps) {
   const { t, lang } = useI18n();
-  const [expanded, setExpanded] = useState(true);
+  // Issue #186: Default to collapsed (showing top 10), not expanded
+  const [expanded, setExpanded] = useState(false);
   
   if (rows.length === 0) {
     return (
@@ -46,6 +47,7 @@ function RankingTable({ title, rows, labelField, onRowClick, emptyMessage, showR
     );
   }
 
+  // Show top 10 when collapsed, all when expanded
   const displayRows = expanded ? rows : rows.slice(0, 10);
   const hasRateData = showRateColumns && rows.some(r => r.rate_per_100k != null);
   
@@ -54,19 +56,12 @@ function RankingTable({ title, rows, labelField, onRowClick, emptyMessage, showR
 
   return (
     <div className="rounded-xl border border-stone-200 bg-white overflow-hidden">
-      <button
-        onClick={() => setExpanded(!expanded)}
-        className="w-full flex items-center justify-between px-6 py-4 hover:bg-stone-50 transition-colors"
-      >
+      <div className="px-6 py-4 border-b border-stone-200">
         <h2 className="text-lg font-semibold text-stone-900">{title}</h2>
-        <div className="flex items-center gap-2">
-          <span className="text-sm text-stone-500">{rows.length} {rows.length === 1 ? 'item' : 'itens'}</span>
-          <ChevronDown className={cn('h-4 w-4 text-stone-400 transition-transform', expanded && 'rotate-180')} />
-        </div>
-      </button>
+        <p className="text-sm text-stone-500 mt-1">{rows.length} {rows.length === 1 ? 'item' : 'itens'}</p>
+      </div>
       
-      {expanded && (
-        <div className="overflow-x-auto">
+      <div className="overflow-x-auto">
           <table className="w-full">
             <thead className="bg-stone-50 border-t border-stone-200">
               <tr>
@@ -139,22 +134,34 @@ function RankingTable({ title, rows, labelField, onRowClick, emptyMessage, showR
                           {row.population != null ? formatNum(row.population) : '—'}
                         </td>
                       </>
-                    )}
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
-        </div>
-      )}
+                  )}
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
       
+      {/* Ver mais button - show when collapsed and there are more than 10 rows */}
       {!expanded && rows.length > 10 && (
-        <div className="px-6 py-3 bg-stone-50 text-center">
+        <div className="px-6 py-3 bg-stone-50 border-t border-stone-200 text-center">
           <button
             onClick={() => setExpanded(true)}
             className="text-sm text-blue-600 hover:text-blue-700 font-medium"
           >
-            Ver mais {rows.length - 10} itens...
+            Ver mais ({rows.length - 10} itens)
+          </button>
+        </div>
+      )}
+      
+      {/* Collapse button - show when expanded */}
+      {expanded && rows.length > 10 && (
+        <div className="px-6 py-3 bg-stone-50 border-t border-stone-200 text-center">
+          <button
+            onClick={() => setExpanded(false)}
+            className="text-sm text-blue-600 hover:text-blue-700 font-medium"
+          >
+            Ver menos
           </button>
         </div>
       )}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 📝 Descrição

Implementa ranking curto na página /estatisticas com filtros de tamanho mínimo para cidades e apenas estados brasileiros, conforme especificação da issue #186 (parent spec #182).

**Mudanças principais:**
- **Filtro de tamanho para cidades**: Apenas mostra cidades que são capitais OU têm população > 100 mil
  - Capitais sempre passam (independente de população)
  - Não-capitais precisam ter população conhecida E > 100 mil
  - População desconhecida (null) não passa para não-capitais
- **Filtro de estados**: Apenas estados brasileiros (remove regiões estrangeiras como Síria, Flórida, OH, CA, etc.)
- **Interface com abas**: Municípios | Estados | Países (padrão: Municípios)
- **Tabelas colapsadas por padrão**: Mostram top 10 + "Ver mais" na primeira renderização
- **Padrões ajustados**: Brasil, último ano (365 dias), ordenação por vítimas
- **Formatação portuguesa**: Números formatados como 1.239 ao invés de 1,239

## 🔗 Issue Relacionada

Fixes #186
Parent spec: #182

## 🏷️ Tipo de Mudança

- [x] ✨ Nova feature (mudança que adiciona funcionalidade)
- [x] ✅ Testes (adição ou correção de testes)

## 🧪 Como Foi Testado?

- [x] Testes unitários (backend)
- [x] Testado em desenvolvimento local (sem Docker - ambiente cloud agent)

**Testes adicionados:**
1. `test_city_size_floor_excludes_small_towns`: Verifica que cidades pequenas como Matos Costa (pop 2.761) são excluídas
2. `test_states_filter_excludes_foreign_regions`: Verifica que regiões estrangeiras são excluídas
3. `test_rankings_default_sort_by_victims`: Verifica que ordenação padrão é por vítimas (não eventos)
4. `test_top_10_first_page_requirements`: Verifica que primeiro carregamento mostra apenas cidades qualificadas (sem não-capitais < 100k)

**Ambiente de teste:**
- OS: Linux (Cloud Agent VM)
- Docker version: N/A (testes unitários diretos)
- Browser (se aplicável): N/A

## ✅ Checklist

- [x] Meu código segue o guia de estilo do projeto
- [x] Realizei uma auto-revisão do meu código
- [x] Comentei meu código em áreas complexas
- [ ] Atualizei a documentação correspondente (N/A)
- [x] Minhas mudanças não geram novos warnings
- [x] Adicionei testes que provam que meu fix/feature funciona
- [ ] Testes unitários novos e existentes passam localmente (CI/CD irá verificar)
- [x] Quaisquer mudanças dependentes foram mergeadas (PR #192 já está em develop)
- [ ] Atualizei o CHANGELOG (se aplicável)

## 📚 Documentação

- [x] Docstrings/comentários no código
- Backend: `backend/app/geography.py` - nova constante `BRAZILIAN_CAPITALS`
- Backend: `backend/app/routers/public.py` - filtros de tamanho e estados
- Frontend: `frontend/src/pages/public/Rankings.tsx` - abas e formatação

## 💬 Notas Adicionais

**Lógica do size floor (corrigida):**
- ✅ Capitais brasileiras → sempre incluídas (independente de população)
- ✅ Não-capitais com pop > 100k → incluídas
- ❌ Não-capitais com pop ≤ 100k → excluídas
- ❌ Não-capitais com pop desconhecida (null) → excluídas

**Exemplos de casos cobertos pelos testes:**
- ✅ Florianópolis (capital) → incluída
- ✅ Joinville (pop > 100k) → incluída  
- ❌ Matos Costa (pop 2.761, não capital) → excluída
- ✅ RJ, SP (estados brasileiros) → incluídos
- ❌ Síria, Flórida, OH, Jalisco (regiões estrangeiras) → excluídos

**Interface (corrigida):**
- Tabelas começam **colapsadas** mostrando top 10
- Botão "Ver mais" para expandir
- Botão "Ver menos" para colapsar de volta
- Tabela permanece visível no modo colapsado (não esconde completamente)

**Escopo conforme issue #186:**
- ✅ Size floor para cidades (capitais OU pop > 100k)
- ✅ População null não passa para não-capitais
- ✅ Apenas estados brasileiros
- ✅ Abas Municípios | Estados | Países
- ✅ Top 10 + "Ver mais" por padrão
- ✅ Formatação portuguesa (1.239)
- ✅ Padrão: Brasil, último ano, Municípios
- ✅ VARIAÇÃO mantida oculta (já removida em #184)
- ❌ Não inicia #185 (find box) ou #187 (place card)
- ❌ Não toca em master
- ❌ Não faz merge

**Próximos passos:**
- CI/CD irá rodar os testes automaticamente
- Após merge para develop, testar em staging antes de promover para master

---

**Por favor, certifique-se de que todos os itens do checklist foram completados antes de marcar o PR como pronto para revisão.**
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f9bf719c-aaf1-4eab-9f07-814263a3ffe8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f9bf719c-aaf1-4eab-9f07-814263a3ffe8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

