### PR TITLE
fix: resolve TypeScript errors in Rankings.tsx

### DIFF
--- a/frontend/src/components/portal/PlaceSearch.tsx
+++ b/frontend/src/components/portal/PlaceSearch.tsx
@@ -6,6 +6,7 @@ export interface PlaceOption {
   name: string;
   type: 'country' | 'state' | 'municipality';
   uf?: string;
+  state?: string;
   displayName: string;
 }
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -339,6 +339,7 @@ export interface RankingsResponse {
   homicide_types: RankingRow[];
   methods: RankingRow[];
   population_vintage?: number;
+  last_updated?: string;
 }
 
 export interface MatrixCell {

--- a/frontend/src/pages/public/Rankings.tsx
+++ b/frontend/src/pages/public/Rankings.tsx
@@ -458,6 +458,9 @@ export function Rankings() {
     ];
     
     data.states.forEach(state => {
+      // Only add states that have a defined state field
+      if (!state.state) return;
+      
       let uf = state.state;
       if (state.state.length > 2) {
         const cityInState = data.cities.find(c => c.state === state.state);
@@ -475,11 +478,14 @@ export function Rankings() {
     });
     
     data.cities.forEach(city => {
+      // Only add cities that have a defined city name
+      if (!city.city) return;
+      
       options.push({
         name: city.city,
         type: 'municipality',
         state: city.state,
-        uf: city.state_abbrev,
+        uf: city.state_abbrev || undefined,
         displayName: city.state_abbrev ? `${city.city}, ${city.state_abbrev}` : city.city,
       });
     });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #197

## Changes

This PR fixes TypeScript compilation errors in `Rankings.tsx` that were blocking the Deploy Frontend GitHub Actions workflow (run 32868814646).

### Type System Fixes (3 files only)

1. **RankingsResponse type** (`frontend/src/lib/api.ts`) — 1 line
   - Added `last_updated?: string` field to match the API response
   - Fixes errors at lines 512, 539, 566 where code accesses `data.last_updated`

2. **PlaceOption interface** (`frontend/src/components/portal/PlaceSearch.tsx`) — 1 line
   - Added `state?: string` field to support municipality place options
   - Fixes assignment errors where code sets the `state` property

3. **Rankings.tsx null safety** (`frontend/src/pages/public/Rankings.tsx`) — 8 lines
   - Added null/undefined checks for `state.state` before using it (line ~462)
   - Converts `null` to `undefined` for `state_abbrev` to match PlaceOption's `uf?: string` type (line ~482)
   - Filters out entries with undefined required fields before adding to options array

**Diff:** +9 lines, -1 line across 3 source files. No node_modules changes.

### Testing

**TypeScript check (from Deploy Frontend workflow):**

```bash
$ cd frontend && npm run build
# Which runs: tsc -b && vite build
# Result: ✓ Build succeeds, no Rankings.tsx errors
```

Verified Rankings.tsx has no TypeScript errors:
```bash
$ cd frontend && npx tsc -b 2>&1 | grep "Rankings.tsx" | grep -v test
# Result: ✓ No errors in Rankings.tsx
```

### Impact

- ✅ Fixes Deploy Frontend workflow failures
- ✅ No behavior changes - narrow type fixes only  
- ✅ Place search, place card, coverage table, and rankings all maintain existing functionality
- ✅ No layout or UI changes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-86023fae-eb08-4e97-97b7-798cd6409850?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-86023fae-eb08-4e97-97b7-798cd6409850&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

