### PR TITLE
fix: Extract dates from Argentina/Bolivia/Colombia/Ecuador stories (issue #203)

### DIFF
--- a/backend/app/services/extraction_heuristics.py
+++ b/backend/app/services/extraction_heuristics.py
@@ -338,12 +338,80 @@ def fix_same_day_relative_weekday(
     return fixed
 
 
+def extract_explicit_calendar_date(content: str) -> str | None:
+    """
+    Fallback: extract explicit calendar dates from text when extraction left date NULL.
+    
+    Matches patterns like:
+    - "15 de agosto de 2026" (Spanish/Portuguese long form)
+    - "15/08/2026", "15-08-2026" (numeric)
+    
+    Returns YYYY-MM-DD string or None.
+    """
+    import re
+    from datetime import datetime
+    
+    # Month names (Spanish and Portuguese)
+    months = {
+        # Spanish
+        "enero": 1, "febrero": 2, "marzo": 3, "abril": 4,
+        "mayo": 5, "junio": 6, "julio": 7, "agosto": 8,
+        "septiembre": 9, "setiembre": 9, "octubre": 10, "noviembre": 11, "diciembre": 12,
+        # Portuguese
+        "janeiro": 1, "fevereiro": 2, "março": 3, "abril": 4,
+        "maio": 5, "junho": 6, "julho": 7, "agosto": 8,
+        "setembro": 9, "outubro": 10, "novembro": 11, "dezembro": 12,
+    }
+    
+    content_lower = content.lower()
+    
+    # Pattern 1: "15 de agosto de 2026" (Spanish/Portuguese)
+    # Matches: "el 15 de agosto de 2026", "15 de agosto de 2026"
+    month_names = "|".join(months.keys())
+    pattern_long = re.compile(
+        rf"\b(\d{{1,2}})\s+de\s+({month_names})\s+de\s+(\d{{4}})\b",
+        re.IGNORECASE
+    )
+    match = pattern_long.search(content_lower)
+    if match:
+        day = int(match.group(1))
+        month = months[match.group(2)]
+        year = int(match.group(3))
+        try:
+            date_obj = datetime(year, month, day)
+            return date_obj.strftime("%Y-%m-%d")
+        except ValueError:
+            pass
+    
+    # Pattern 2: "15/08/2026" or "15-08-2026" (numeric)
+    pattern_numeric = re.compile(r"\b(\d{1,2})[/-](\d{1,2})[/-](\d{4})\b")
+    match = pattern_numeric.search(content)
+    if match:
+        day = int(match.group(1))
+        month = int(match.group(2))
+        year = int(match.group(3))
+        try:
+            date_obj = datetime(year, month, day)
+            return date_obj.strftime("%Y-%m-%d")
+        except ValueError:
+            pass
+    
+    return None
+
+
 def infer_date_from_source(
     content: str,
     metadata: dict | None,
     current_date: str | None,
 ) -> str | None:
     """Apply deterministic date fixes from article text + publication metadata."""
+    # If current_date is None, try to extract explicit calendar date from text
+    if current_date is None:
+        extracted = extract_explicit_calendar_date(content)
+        if extracted:
+            return extracted
+    
+    # Otherwise try existing heuristics (only work when current_date exists)
     return fix_weekday_paren_day(content, metadata, current_date) or fix_same_day_relative_weekday(
         content, metadata, current_date
     )

--- a/backend/tests/test_issue_203_date_fallback.py
+++ b/backend/tests/test_issue_203_date_fallback.py
@@ -26,12 +26,12 @@ from app.services.extraction_schemas import (
 )
 
 
-def test_argentina_null_date_with_explicit_date_in_text_red():
+def test_argentina_null_date_with_explicit_date_in_text():
     """
-    RED: Argentina event where extraction left date NULL,
+    GREEN: Argentina event where extraction left date NULL,
     but story contains explicit date "15 de agosto de 2026".
     
-    Heuristic should recover the date from text.
+    Heuristic recovers the date from text.
     """
     # Story with explicit Spanish date
     content = """
@@ -84,7 +84,7 @@ def test_argentina_null_date_with_explicit_date_in_text_red():
     # Apply heuristics - should recover date from text
     fixed_event = apply_extraction_heuristics(event, content, metadata)
     
-    # RED: This will fail because no heuristic recovers explicit dates from text
+    # GREEN: Heuristic recovers explicit date from text
     assert fixed_event.date_time.date is not None, \
         "Heuristic should recover explicit date '15 de agosto de 2026' from text"
     
@@ -97,9 +97,9 @@ def test_argentina_null_date_with_explicit_date_in_text_red():
         "event_date should be 2026-08-15 after heuristic recovery"
 
 
-def test_argentina_slash_format_date_red():
+def test_argentina_slash_format_date():
     """
-    RED: Argentina event with numeric date format "15/08/2026".
+    GREEN: Argentina event with numeric date format "15/08/2026".
     """
     content = """
     Un hombre fue asesinado a tiros el 15/08/2026 en Buenos Aires.
@@ -143,15 +143,15 @@ def test_argentina_slash_format_date_red():
     
     fixed_event = apply_extraction_heuristics(event, content, metadata)
     
-    # RED: Should recover numeric date
+    # GREEN: Recovers numeric date
     assert fixed_event.date_time.date == "2026-08-15", \
         "Should recover date from '15/08/2026' format"
 
 
 @pytest.mark.asyncio
-async def test_recovered_date_appears_in_rankings_red(app, async_session):
+async def test_recovered_date_appears_in_rankings(app, async_session):
     """
-    RED: After heuristic recovers date, event should appear in rankings.
+    GREEN: After heuristic recovers date, event should appear in rankings.
     """
     # Simulate: extraction left date NULL, heuristic recovered it
     now = datetime.utcnow()

--- a/backend/tests/test_issue_203_date_fallback.py
+++ b/backend/tests/test_issue_203_date_fallback.py
@@ -1,0 +1,247 @@
+"""
+TDD RED test for issue #203: Date fallback when extraction leaves date NULL.
+
+Production symptom: date_time.date = None, date_precision = "não informada"
+But story text contains explicit calendar dates like "15 de agosto de 2026".
+
+The heuristic should recover these explicit dates as a fallback.
+"""
+
+import pytest
+from datetime import datetime, timedelta
+from httpx import AsyncClient, ASGITransport
+from decimal import Decimal
+
+from app.models.unique_event import UniqueEvent
+from app.services.extraction import raw_event_fields_from_event
+from app.services.extraction_heuristics import apply_extraction_heuristics
+from app.services.extraction_schemas import (
+    DateTime,
+    DateVerification,
+    HomicideDynamic,
+    IdentifiableVictim,
+    Location,
+    Victims,
+    ViolentDeathEvent,
+)
+
+
+def test_argentina_null_date_with_explicit_date_in_text_red():
+    """
+    RED: Argentina event where extraction left date NULL,
+    but story contains explicit date "15 de agosto de 2026".
+    
+    Heuristic should recover the date from text.
+    """
+    # Story with explicit Spanish date
+    content = """
+    Un hombre de 35 años fue asesinado a tiros el viernes 15 de agosto de 2026
+    en el barrio de San Telmo, Buenos Aires. La víctima recibió múltiples
+    disparos cuando salía de su domicilio alrededor de las 22h.
+    """
+    
+    metadata = {
+        "headline": "Hombre asesinado a tiros en San Telmo",
+        "publisher": "Clarín",
+        "url": "https://clarin.com/policiales/hombre-asesinado.html",
+        "published_at": "2026-08-17T10:00:00Z",
+    }
+    
+    # Extraction failed to get date (production symptom)
+    event = ViolentDeathEvent(
+        event_family="homicidio",
+        event_subtype="simples",
+        content_class="incident",
+        location_info=Location(
+            city="Buenos Aires",
+            state="Buenos Aires",
+            neighborhood="San Telmo",
+            country="AR",
+        ),
+        date_time=DateTime(
+            date=None,  # NULL - extraction failed
+            date_precision="não informada",  # Production value
+            time_of_day="noite",
+            date_verification=DateVerification(
+                has_explicit_date=False,
+                date_source="none",
+                year_explicitly_mentioned=False,
+                verification_reasoning="LLM did not extract date",
+            ),
+        ),
+        victims=Victims(
+            identifiable_victims=[IdentifiableVictim(name="Carlos Rodríguez")],
+            number_of_identifiable_victims=1,
+            number_of_victims=1,
+        ),
+        homicide_dynamic=HomicideDynamic(
+            title="HOMICÍDIO - SAN TELMO",
+            method="Arma de fogo",
+            chronological_description="Vítima foi morta a tiros.",
+        ),
+    )
+    
+    # Apply heuristics - should recover date from text
+    fixed_event = apply_extraction_heuristics(event, content, metadata)
+    
+    # RED: This will fail because no heuristic recovers explicit dates from text
+    assert fixed_event.date_time.date is not None, \
+        "Heuristic should recover explicit date '15 de agosto de 2026' from text"
+    
+    assert fixed_event.date_time.date == "2026-08-15", \
+        f"Expected 2026-08-15, got {fixed_event.date_time.date}"
+    
+    # Persist should work
+    raw_fields = raw_event_fields_from_event(fixed_event)
+    assert raw_fields["event_date"] == datetime(2026, 8, 15), \
+        "event_date should be 2026-08-15 after heuristic recovery"
+
+
+def test_argentina_slash_format_date_red():
+    """
+    RED: Argentina event with numeric date format "15/08/2026".
+    """
+    content = """
+    Un hombre fue asesinado a tiros el 15/08/2026 en Buenos Aires.
+    La víctima recibió múltiples disparos en el barrio de Palermo.
+    """
+    
+    metadata = {
+        "published_at": "2026-08-17T10:00:00Z",
+    }
+    
+    event = ViolentDeathEvent(
+        event_family="homicidio",
+        event_subtype="simples",
+        content_class="incident",
+        location_info=Location(
+            city="Buenos Aires",
+            state="Buenos Aires",
+            country="AR",
+        ),
+        date_time=DateTime(
+            date=None,  # NULL
+            date_precision="não informada",
+            date_verification=DateVerification(
+                has_explicit_date=False,
+                date_source="none",
+                year_explicitly_mentioned=False,
+                verification_reasoning="LLM did not extract",
+            ),
+        ),
+        victims=Victims(
+            identifiable_victims=[],
+            number_of_identifiable_victims=0,
+            number_of_victims=1,
+        ),
+        homicide_dynamic=HomicideDynamic(
+            title="HOMICÍDIO - PALERMO",
+            method="Arma de fogo",
+            chronological_description="Vítima foi morta a tiros.",
+        ),
+    )
+    
+    fixed_event = apply_extraction_heuristics(event, content, metadata)
+    
+    # RED: Should recover numeric date
+    assert fixed_event.date_time.date == "2026-08-15", \
+        "Should recover date from '15/08/2026' format"
+
+
+@pytest.mark.asyncio
+async def test_recovered_date_appears_in_rankings_red(app, async_session):
+    """
+    RED: After heuristic recovers date, event should appear in rankings.
+    """
+    # Simulate: extraction left date NULL, heuristic recovered it
+    now = datetime.utcnow()
+    event_date = now - timedelta(days=30)
+    
+    ar_event = UniqueEvent(
+        title="HOMICÍDIO - SAN TELMO - 15 AGOSTO",
+        event_date=event_date,  # Recovered by heuristic
+        country="AR",
+        state="Buenos Aires",
+        city="Buenos Aires",
+        neighborhood="San Telmo",
+        event_family="homicidio",
+        event_subtype="simples",
+        content_class="incident",
+        homicide_type="Homicídio simples",
+        method_of_death="Arma de fogo",
+        victim_count=1,
+        latitude=Decimal("-34.6037"),
+        longitude=Decimal("-58.3816"),
+        source_count=1,
+    )
+    
+    async_session.add(ar_event)
+    await async_session.commit()
+    
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test"
+    ) as client:
+        response = await client.get("/api/public/stats/rankings?days=365&country=AR")
+        assert response.status_code == 200
+        data = response.json()
+        
+        assert data["total_events"] >= 1, \
+            "Argentina event with recovered date should appear in rankings"
+        
+        city_names = [city["city"] for city in data["cities"]]
+        assert "Buenos Aires" in city_names
+
+
+def test_chile_dated_event_unchanged_regression():
+    """
+    Regression: Chile events with dates should stay unchanged.
+    """
+    content = """
+    Un hombre fue asesinado a tiros el 16 de agosto de 2026 en Santiago.
+    """
+    
+    metadata = {
+        "published_at": "2026-08-17T10:00:00Z",
+    }
+    
+    # Chile event with date already present
+    event = ViolentDeathEvent(
+        event_family="homicidio",
+        event_subtype="simples",
+        content_class="incident",
+        location_info=Location(
+            city="Santiago",
+            state="Metropolitana",
+            country="CL",
+        ),
+        date_time=DateTime(
+            date="2026-08-16",  # Already has date
+            date_precision="exata",
+            date_verification=DateVerification(
+                has_explicit_date=True,
+                date_source="explicit",
+                year_explicitly_mentioned=True,
+                verification_reasoning="Extracted correctly",
+            ),
+        ),
+        victims=Victims(
+            identifiable_victims=[IdentifiableVictim(name="Juan Contreras")],
+            number_of_identifiable_victims=1,
+            number_of_victims=1,
+        ),
+        homicide_dynamic=HomicideDynamic(
+            title="HOMICÍDIO - SANTIAGO",
+            method="Arma de fogo",
+            chronological_description="Vítima foi morta a tiros.",
+        ),
+    )
+    
+    # Heuristics should not break existing correct date
+    fixed_event = apply_extraction_heuristics(event, content, metadata)
+    
+    assert fixed_event.date_time.date == "2026-08-16", \
+        "Chile date should remain unchanged (regression)"
+    
+    raw_fields = raw_event_fields_from_event(fixed_event)
+    assert raw_fields["event_date"] == datetime(2026, 8, 16)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

**Adds date fallback heuristic to recover explicit calendar dates when extraction leaves date NULL.**

Addresses issue #203: Argentina, Bolivia, Colombia, and Ecuador events have `event_date NULL` and `date_precision = 'não informada'`, blocking them from rankings and map.

## Production Symptom

**12 events (AR 7, BO 3, CO 1, EC 1)**:
- `event_date = NULL`
- `date_precision = 'não informada'`
- Extraction returned `date_time.date = None`
- But stories likely contain explicit calendar dates
- **Blocked from rankings**: 365-day window requires non-NULL `event_date`

## Root Cause

Extraction (LLM) failed to extract dates, returning `date_time.date = None`. No existing heuristic could recover dates when extraction left them NULL - heuristics only **fixed** existing dates, they didn't **create** dates from scratch.

## Solution

Added `extract_explicit_calendar_date()` heuristic that recovers dates from story text as a fallback when extraction leaves date NULL.

**Patterns matched**:
- **Spanish/Portuguese long form**: "15 de agosto de 2026", "el viernes 15 de agosto de 2026"
- **Numeric formats**: "15/08/2026", "15-08-2026"

**Returns**: `YYYY-MM-DD` string or `None`

## Changes

### `backend/app/services/extraction_heuristics.py`

**1. New function: `extract_explicit_calendar_date(content)`**
```python
# Matches explicit calendar dates in text
# Spanish months: enero, febrero, marzo, abril, mayo, junio, julio, agosto, ...
# Portuguese months: janeiro, fevereiro, março, abril, maio, junho, julho, agosto, ...
# Numeric: DD/MM/YYYY or DD-MM-YYYY
```

**2. Updated: `infer_date_from_source()`**
```python
# If current_date is None, try to extract explicit calendar date from text
if current_date is None:
    extracted = extract_explicit_calendar_date(content)
    if extracted:
        return extracted

# Otherwise try existing heuristics (only work when current_date exists)
return fix_weekday_paren_day(...) or fix_same_day_relative_weekday(...)
```

## Tests (All Pass, No Live Model)

### Core TDD Tests (`test_issue_203_date_fallback.py`)

✅ **`test_argentina_null_date_with_explicit_date_in_text()`**
- **Setup**: Extraction left `date = None`, story has "el viernes 15 de agosto de 2026"
- **Result**: Heuristic recovers `2026-08-15`
- **Persist**: `event_date = datetime(2026, 8, 15)` ✓

✅ **`test_argentina_slash_format_date()`**
- **Setup**: Extraction left `date = None`, story has "15/08/2026"
- **Result**: Heuristic recovers `2026-08-15` ✓

✅ **`test_recovered_date_appears_in_rankings()`**
- **Setup**: UniqueEvent with recovered date
- **Result**: Appears in `GET /api/public/stats/rankings?country=AR&days=365` ✓

✅ **`test_chile_dated_event_unchanged_regression()`**
- **Setup**: Chile event already has date
- **Result**: Date stays unchanged (regression protected) ✓

## What This Fixes

**New events** (after deploy):
- ✅ Argentina/Bolivia/Colombia/Ecuador story with explicit date like "15 de agosto de 2026" or "15/08/2026"
- ✅ Extraction fails (returns `date = None`)
- ✅ Heuristic recovers date from text
- ✅ `event_date = 2026-08-15` persists
- ✅ Event appears in `GET /api/public/stats/rankings?country=AR`

**Chile**:
- ✅ No regression - events with dates stay unchanged

## What About the Existing 12 Events?

**Cannot backfill without re-extraction**:
- The 12 events have `date_time.date = None` in their `extraction_data` JSON
- Heuristics run during extraction, not after
- To apply the new heuristic to the 12 events, would need to re-extract from source

**Recommended approach**:
1. Deploy this fix → **new** events will get dates
2. Existing 12 stay date-less (count: 12)
3. If needed later, re-extract the 12 using the updated code

**Do NOT**:
- Run production re-extract now (risky, 3-day ingest)
- Add backfill script (not the persist path)

## Acceptance Criteria

- ✅ New Argentina incident with explicit date in story → non-NULL `event_date`
- ✅ That row appears in `GET /api/public/stats/rankings?country=AR` when within 365 days
- ✅ Same for Bolivia, Colombia, Ecuador
- ✅ Chile stays green (regression protected)
- ⚠️ **Existing 12 events**: Stay date-less until re-extracted (count: 12)

## Files Changed

```
backend/app/services/extraction_heuristics.py       | 68 ++++
backend/tests/test_issue_203_date_fallback.py       | 247 ++++
```

Total: 2 files, 315 lines

## Branch and PR

- **Branch**: `cursor/fix-south-american-dates-594b`
- **Base**: `develop` (not master)
- **Status**: Ready for review
- **Target**: Deploy to staging → test → promote to prod

## Example

**Before**:
```python
# Story: "Un hombre fue asesinado el 15 de agosto de 2026"
event.date_time.date = None  # LLM failed to extract
event.date_time.date_precision = "não informada"
# After heuristics: still None
# UniqueEvent.event_date = NULL → blocked from rankings
```

**After**:
```python
# Story: "Un hombre fue asesinado el 15 de agosto de 2026"
event.date_time.date = None  # LLM failed to extract
event.date_time.date_precision = "não informada"
# After heuristics: extract_explicit_calendar_date() finds "15 de agosto de 2026"
# → returns "2026-08-15"
# UniqueEvent.event_date = 2026-08-15 → appears in rankings ✓
```

**PR URL**: https://github.com/JoaoCarabetta/arquivo-da-violencia/pull/204
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e8617a90-e669-4b91-934a-af5b1b60594b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e8617a90-e669-4b91-934a-af5b1b60594b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

