### PR TITLE
Cherry-pick: pipeline health script (issue #193 / PR #201) to master

### DIFF
--- a/backend/app/services/pipeline_health.py
+++ b/backend/app/services/pipeline_health.py
@@ -1,0 +1,186 @@
+"""Pipeline health check and remediation logic."""
+
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Optional
+
+
+@dataclass
+class InProgressJob:
+    """Represents an ARQ in-progress job from Redis."""
+    
+    key: str
+    job_name: str
+    enqueued_at: Optional[datetime] = None
+    
+    @classmethod
+    def from_redis_key(cls, key: str) -> "InProgressJob":
+        """
+        Parse an ARQ in-progress key to extract job information.
+        
+        Example keys:
+        - arq:in-progress:abc123
+        - arq:in-progress:cron:ingest_cities_hourly:1724594700
+        """
+        # Extract job name from the key
+        parts = key.split(":")
+        
+        # For cron jobs: arq:in-progress:cron:JOB_NAME:TIMESTAMP
+        if len(parts) >= 4 and parts[2] == "cron":
+            job_name = parts[3]
+            # Try to parse timestamp if present
+            if len(parts) >= 5 and parts[4].isdigit():
+                enqueued_at = datetime.fromtimestamp(int(parts[4]), tz=timezone.utc)
+            else:
+                enqueued_at = None
+        else:
+            # Non-cron job: arq:in-progress:JOB_ID
+            job_name = "unknown"
+            enqueued_at = None
+        
+        return cls(key=key, job_name=job_name, enqueued_at=enqueued_at)
+
+
+@dataclass
+class WorkerLogs:
+    """Represents worker logs for progress analysis."""
+    
+    logs: str
+    
+    def has_multi_country_ingest_progress(self, lookback_minutes: int = 30) -> bool:
+        """
+        Check if logs show recent progress for multi-country ingestion.
+        
+        Progress indicators:
+        - Country-specific ingest completion logs
+        - Source creation logs
+        - Per-country statistics
+        
+        Args:
+            lookback_minutes: How far back to look for progress (unused, for future timestamp parsing)
+        
+        Returns:
+            True if there's evidence of progress in multi-country ingestion
+        """
+        # Look for country-level completion markers
+        # Format: "Country X complete: Y sources in Zs"
+        country_completion_pattern = r"Country \w{2} complete:|Brasil complete:|Chile complete:"
+        if re.search(country_completion_pattern, self.logs):
+            return True
+        
+        # Look for country ingestion start markers
+        country_start_pattern = r"Starting ingestion for country \w{2}|Ingesting \d+ cities for \w{2}"
+        if re.search(country_start_pattern, self.logs):
+            return True
+        
+        # Look for per-country source creation
+        if "total_sources_created" in self.logs and "country" in self.logs.lower():
+            return True
+        
+        return False
+
+
+def should_treat_lock_as_stale(
+    in_progress_jobs: list[InProgressJob],
+    worker_logs: WorkerLogs,
+    stale_threshold_minutes: int = 15,
+) -> tuple[bool, str]:
+    """
+    Determine if ARQ in-progress locks should be treated as stale.
+    
+    Core logic: If the lock is held by a long-running ingest job (like
+    ingest_all_countries or ingest_cities_hourly) and the worker is making
+    progress, do NOT treat it as stale even if it exceeds the threshold.
+    
+    Args:
+        in_progress_jobs: List of in-progress jobs from Redis
+        worker_logs: Worker logs to check for progress
+        stale_threshold_minutes: How long before a lock is considered stale (unused for ingest jobs)
+    
+    Returns:
+        Tuple of (is_stale, reason)
+    """
+    if not in_progress_jobs:
+        return False, "no_locks"
+    
+    # Check if any job is a long-running ingest
+    ingest_job_names = {
+        "ingest_cities_hourly",
+        "ingest_cities_full_pipeline",
+        "process_cities_backlog",
+    }
+    
+    has_ingest_lock = False
+    for job in in_progress_jobs:
+        if job.job_name in ingest_job_names:
+            has_ingest_lock = True
+            break
+    
+    if not has_ingest_lock:
+        # Not an ingest job, use normal stale detection
+        return True, "non_ingest_lock_present"
+    
+    # It's an ingest job - check for progress
+    if worker_logs.has_multi_country_ingest_progress():
+        # Making progress, not stale
+        return False, "ingest_lock_with_progress"
+    
+    # No progress detected, treat as stale
+    return True, "ingest_lock_without_progress"
+
+
+def should_enqueue_classify_during_remediation(
+    had_queue_jam: bool,
+    had_no_pipeline: bool,
+    had_recent_ingest: bool,
+    in_progress_jobs: list[InProgressJob],
+    worker_logs: WorkerLogs,
+) -> tuple[bool, str]:
+    """
+    Determine if classify_pending should be enqueued during remediation.
+    
+    Core logic: Do NOT enqueue classify if a multi-country ingest is still
+    the active hourly task, even if there's a queue jam. The ingest needs
+    to complete and log "MULTI-COUNTRY COMPLETE" before classify should run.
+    
+    Args:
+        had_queue_jam: Whether a queue jam was detected
+        had_no_pipeline: Whether no recent pipeline run was detected
+        had_recent_ingest: Whether a recent ingest start was detected
+        in_progress_jobs: List of in-progress jobs from Redis
+        worker_logs: Worker logs to check for ingest state
+    
+    Returns:
+        Tuple of (should_enqueue, reason)
+    """
+    # Check if ingest is currently active
+    ingest_job_names = {
+        "ingest_cities_hourly",
+        "ingest_cities_full_pipeline",
+    }
+    
+    active_ingest = False
+    for job in in_progress_jobs:
+        if job.job_name in ingest_job_names:
+            active_ingest = True
+            break
+    
+    # If there's an active ingest lock, don't enqueue classify
+    # (even if queue appears jammed - it's just the long-running ingest)
+    if active_ingest:
+        # Check if it's making progress
+        if worker_logs.has_multi_country_ingest_progress():
+            return False, "active_ingest_with_progress"
+        # No progress, but still has the lock - let other remediation handle it
+        return False, "active_ingest_lock_present"
+    
+    # Original logic from the bash script:
+    # Enqueue classify when queue is jammed OR when no pipeline but recent ingest
+    if had_queue_jam:
+        return True, "queue_jammed"
+    
+    if had_no_pipeline and had_recent_ingest:
+        return True, "no_pipeline_with_recent_ingest"
+    
+    return False, "no_condition_met"

--- a/backend/app/services/pipeline_health.py
+++ b/backend/app/services/pipeline_health.py
@@ -52,10 +52,12 @@ class WorkerLogs:
         """
         Check if logs show recent progress for multi-country ingestion.
         
-        Progress indicators:
-        - Country-specific ingest completion logs
-        - Source creation logs
-        - Per-country statistics
+        Progress indicators (actual patterns from ingestion.py):
+        - Starting multi-country ingestion (N countries)
+        - Starting PARALLEL city ingestion for N cities in COUNTRY
+        - [CityName] Starting...
+        - [CityName] Done: N entries, M new
+        - INGESTION COMPLETE (COUNTRY)
         
         Args:
             lookback_minutes: How far back to look for progress (unused, for future timestamp parsing)
@@ -63,19 +65,22 @@ class WorkerLogs:
         Returns:
             True if there's evidence of progress in multi-country ingestion
         """
-        # Look for country-level completion markers
-        # Format: "Country X complete: Y sources in Zs"
-        country_completion_pattern = r"Country \w{2} complete:|Brasil complete:|Chile complete:"
-        if re.search(country_completion_pattern, self.logs):
+        # Look for multi-country ingest start
+        if "Starting multi-country ingestion" in self.logs:
             return True
         
-        # Look for country ingestion start markers
-        country_start_pattern = r"Starting ingestion for country \w{2}|Ingesting \d+ cities for \w{2}"
-        if re.search(country_start_pattern, self.logs):
+        # Look for parallel city ingestion start (per-country)
+        if "Starting PARALLEL city ingestion" in self.logs:
             return True
         
-        # Look for per-country source creation
-        if "total_sources_created" in self.logs and "country" in self.logs.lower():
+        # Look for individual city progress
+        # Format: [CityName] Done: 40 entries, 12 new
+        if re.search(r"\[.+?\] Done: \d+ entries, \d+ new", self.logs):
+            return True
+        
+        # Look for country-level completion
+        # Format: INGESTION COMPLETE (BR)
+        if re.search(r"INGESTION COMPLETE \(\w{2}\)", self.logs):
             return True
         
         return False

--- a/backend/tests/test_pipeline_health.py
+++ b/backend/tests/test_pipeline_health.py
@@ -43,30 +43,36 @@ class TestInProgressJob:
 
 
 class TestWorkerLogs:
-    """Tests for WorkerLogs progress detection."""
+    """Tests for WorkerLogs progress detection using ACTUAL log patterns."""
+    
+    def test_detects_multi_country_start(self):
+        """Detect multi-country ingestion start (actual pattern)."""
+        logs = WorkerLogs("""
+        [2026-08-25 15:05:00] Starting multi-country ingestion (12 countries)
+        """)
+        
+        assert logs.has_multi_country_ingest_progress()
+    
+    def test_detects_parallel_city_ingestion(self):
+        """Detect parallel city ingestion start (actual pattern)."""
+        logs = WorkerLogs("""
+        [2026-08-25 15:06:00] Starting PARALLEL city ingestion for 150 cities in BR
+        """)
+        
+        assert logs.has_multi_country_ingest_progress()
+    
+    def test_detects_city_done(self):
+        """Detect individual city completion (actual pattern)."""
+        logs = WorkerLogs("""
+        [2026-08-25 15:10:00] [São Paulo] Done: 40 entries, 12 new
+        """)
+        
+        assert logs.has_multi_country_ingest_progress()
     
     def test_detects_country_completion(self):
-        """Detect country-level completion logs."""
+        """Detect country-level completion (actual pattern)."""
         logs = WorkerLogs("""
-        [2026-08-25 15:10:00] Country BR complete: 150 sources in 180s
-        [2026-08-25 15:12:00] Processing continues...
-        """)
-        
-        assert logs.has_multi_country_ingest_progress()
-    
-    def test_detects_country_start(self):
-        """Detect country ingestion start logs."""
-        logs = WorkerLogs("""
-        [2026-08-25 15:08:00] Starting ingestion for country CL
-        [2026-08-25 15:09:00] Ingesting 45 cities for CL
-        """)
-        
-        assert logs.has_multi_country_ingest_progress()
-    
-    def test_detects_per_country_source_creation(self):
-        """Detect per-country source creation logs."""
-        logs = WorkerLogs("""
-        [2026-08-25 15:10:00] {"country": "BR", "total_sources_created": 150}
+        [2026-08-25 15:12:00] INGESTION COMPLETE (BR)
         """)
         
         assert logs.has_multi_country_ingest_progress()
@@ -123,10 +129,14 @@ class TestShouldTreatLockAsStale:
         job = InProgressJob.from_redis_key(
             "arq:in-progress:cron:ingest_cities_hourly:1724594700"
         )
+        # REAL patterns from actual logs
         logs = WorkerLogs("""
-        [2026-08-25 15:10:00] Country BR complete: 150 sources in 180s
-        [2026-08-25 15:12:00] Country CL complete: 45 sources in 120s
-        [2026-08-25 15:14:00] Starting ingestion for country AR
+        [2026-08-25 15:05:00] Starting multi-country ingestion (12 countries)
+        [2026-08-25 15:06:00] Starting PARALLEL city ingestion for 150 cities in BR
+        [2026-08-25 15:10:00] [São Paulo] Done: 40 entries, 12 new
+        [2026-08-25 15:12:00] INGESTION COMPLETE (BR)
+        [2026-08-25 15:13:00] Starting PARALLEL city ingestion for 45 cities in CL
+        [2026-08-25 15:14:00] [Santiago] Done: 22 entries, 6 new
         """)
         
         is_stale, reason = should_treat_lock_as_stale(
@@ -166,7 +176,8 @@ class TestShouldTreatLockAsStale:
         job = InProgressJob.from_redis_key(
             "arq:in-progress:cron:ingest_cities_full_pipeline:1724594700"
         )
-        logs = WorkerLogs("Country BR complete: 150 sources in 180s")
+        # REAL pattern: city completion
+        logs = WorkerLogs("[Porto Alegre] Done: 18 entries, 4 new")
         
         is_stale, reason = should_treat_lock_as_stale(
             in_progress_jobs=[job],
@@ -182,7 +193,8 @@ class TestShouldTreatLockAsStale:
         job = InProgressJob.from_redis_key(
             "arq:in-progress:cron:process_cities_backlog:1724594700"
         )
-        logs = WorkerLogs("Starting ingestion for country CL")
+        # REAL pattern: multi-country start
+        logs = WorkerLogs("Starting multi-country ingestion (12 countries)")
         
         is_stale, reason = should_treat_lock_as_stale(
             in_progress_jobs=[job],
@@ -206,12 +218,13 @@ class TestShouldEnqueueClassifyDuringRemediation:
         CRITICAL: Do NOT enqueue classify when ingest is active and making progress.
         
         This prevents the issue where remediate enqueued classify_pending while
-        ingest_all_countries was still the active hourly task.
+        ingest_cities_hourly was still the active hourly task.
         """
         job = InProgressJob.from_redis_key(
             "arq:in-progress:cron:ingest_cities_hourly:1724594700"
         )
-        logs = WorkerLogs("Country BR complete: 150 sources in 180s")
+        # REAL pattern: parallel city ingestion
+        logs = WorkerLogs("Starting PARALLEL city ingestion for 150 cities in BR")
         
         should_enqueue, reason = should_enqueue_classify_during_remediation(
             had_queue_jam=True,  # Even with queue jam
@@ -290,7 +303,8 @@ class TestShouldEnqueueClassifyDuringRemediation:
         job = InProgressJob.from_redis_key(
             "arq:in-progress:cron:ingest_cities_full_pipeline:1724594700"
         )
-        logs = WorkerLogs("Starting ingestion for country AR")
+        # REAL pattern: country completion
+        logs = WorkerLogs("INGESTION COMPLETE (AR)")
         
         should_enqueue, reason = should_enqueue_classify_during_remediation(
             had_queue_jam=True,

--- a/backend/tests/test_pipeline_health.py
+++ b/backend/tests/test_pipeline_health.py
@@ -1,0 +1,304 @@
+"""Tests for pipeline health check and remediation logic."""
+
+import pytest
+from datetime import datetime, timezone
+
+from app.services.pipeline_health import (
+    InProgressJob,
+    WorkerLogs,
+    should_treat_lock_as_stale,
+    should_enqueue_classify_during_remediation,
+)
+
+
+class TestInProgressJob:
+    """Tests for InProgressJob parsing."""
+    
+    def test_parse_cron_job_key_with_timestamp(self):
+        """Parse a cron job key with timestamp."""
+        key = "arq:in-progress:cron:ingest_cities_hourly:1724594700"
+        job = InProgressJob.from_redis_key(key)
+        
+        assert job.key == key
+        assert job.job_name == "ingest_cities_hourly"
+        assert job.enqueued_at == datetime.fromtimestamp(1724594700, tz=timezone.utc)
+    
+    def test_parse_cron_job_key_without_timestamp(self):
+        """Parse a cron job key without timestamp."""
+        key = "arq:in-progress:cron:process_cities_backlog"
+        job = InProgressJob.from_redis_key(key)
+        
+        assert job.key == key
+        assert job.job_name == "process_cities_backlog"
+        assert job.enqueued_at is None
+    
+    def test_parse_non_cron_job_key(self):
+        """Parse a non-cron job key."""
+        key = "arq:in-progress:abc123def456"
+        job = InProgressJob.from_redis_key(key)
+        
+        assert job.key == key
+        assert job.job_name == "unknown"
+        assert job.enqueued_at is None
+
+
+class TestWorkerLogs:
+    """Tests for WorkerLogs progress detection."""
+    
+    def test_detects_country_completion(self):
+        """Detect country-level completion logs."""
+        logs = WorkerLogs("""
+        [2026-08-25 15:10:00] Country BR complete: 150 sources in 180s
+        [2026-08-25 15:12:00] Processing continues...
+        """)
+        
+        assert logs.has_multi_country_ingest_progress()
+    
+    def test_detects_country_start(self):
+        """Detect country ingestion start logs."""
+        logs = WorkerLogs("""
+        [2026-08-25 15:08:00] Starting ingestion for country CL
+        [2026-08-25 15:09:00] Ingesting 45 cities for CL
+        """)
+        
+        assert logs.has_multi_country_ingest_progress()
+    
+    def test_detects_per_country_source_creation(self):
+        """Detect per-country source creation logs."""
+        logs = WorkerLogs("""
+        [2026-08-25 15:10:00] {"country": "BR", "total_sources_created": 150}
+        """)
+        
+        assert logs.has_multi_country_ingest_progress()
+    
+    def test_no_progress_in_generic_logs(self):
+        """No progress detected in generic worker logs."""
+        logs = WorkerLogs("""
+        [2026-08-25 15:08:00] Worker health check OK
+        [2026-08-25 15:09:00] Heartbeat sent
+        """)
+        
+        assert not logs.has_multi_country_ingest_progress()
+
+
+class TestShouldTreatLockAsStale:
+    """
+    Tests for stale lock detection.
+    
+    CRITICAL: These tests verify the fix for issue #193.
+    """
+    
+    def test_no_locks_not_stale(self):
+        """No locks means nothing is stale."""
+        is_stale, reason = should_treat_lock_as_stale(
+            in_progress_jobs=[],
+            worker_logs=WorkerLogs(""),
+            stale_threshold_minutes=15,
+        )
+        
+        assert not is_stale
+        assert reason == "no_locks"
+    
+    def test_non_ingest_lock_is_stale(self):
+        """Non-ingest locks are treated as stale."""
+        job = InProgressJob.from_redis_key("arq:in-progress:cron:some_other_task:123")
+        logs = WorkerLogs("")
+        
+        is_stale, reason = should_treat_lock_as_stale(
+            in_progress_jobs=[job],
+            worker_logs=logs,
+            stale_threshold_minutes=15,
+        )
+        
+        assert is_stale
+        assert reason == "non_ingest_lock_present"
+    
+    def test_ingest_lock_with_progress_not_stale(self):
+        """
+        CRITICAL: Ingest lock with progress is NOT stale, even if > 15 minutes.
+        
+        This is the core fix for issue #193. A 12-country ingest that takes
+        ~1072s (~18 minutes) should not be killed if it's making progress.
+        """
+        job = InProgressJob.from_redis_key(
+            "arq:in-progress:cron:ingest_cities_hourly:1724594700"
+        )
+        logs = WorkerLogs("""
+        [2026-08-25 15:10:00] Country BR complete: 150 sources in 180s
+        [2026-08-25 15:12:00] Country CL complete: 45 sources in 120s
+        [2026-08-25 15:14:00] Starting ingestion for country AR
+        """)
+        
+        is_stale, reason = should_treat_lock_as_stale(
+            in_progress_jobs=[job],
+            worker_logs=logs,
+            stale_threshold_minutes=15,
+        )
+        
+        assert not is_stale
+        assert reason == "ingest_lock_with_progress"
+    
+    def test_ingest_lock_without_progress_is_stale(self):
+        """
+        Ingest lock without progress IS stale.
+        
+        A truly dead worker should still be remediable.
+        """
+        job = InProgressJob.from_redis_key(
+            "arq:in-progress:cron:ingest_cities_hourly:1724594700"
+        )
+        logs = WorkerLogs("""
+        [2026-08-25 14:50:00] Worker health check OK
+        [2026-08-25 14:55:00] Heartbeat sent
+        """)
+        
+        is_stale, reason = should_treat_lock_as_stale(
+            in_progress_jobs=[job],
+            worker_logs=logs,
+            stale_threshold_minutes=15,
+        )
+        
+        assert is_stale
+        assert reason == "ingest_lock_without_progress"
+    
+    def test_full_pipeline_lock_with_progress_not_stale(self):
+        """Full pipeline job with progress is not stale."""
+        job = InProgressJob.from_redis_key(
+            "arq:in-progress:cron:ingest_cities_full_pipeline:1724594700"
+        )
+        logs = WorkerLogs("Country BR complete: 150 sources in 180s")
+        
+        is_stale, reason = should_treat_lock_as_stale(
+            in_progress_jobs=[job],
+            worker_logs=logs,
+            stale_threshold_minutes=15,
+        )
+        
+        assert not is_stale
+        assert reason == "ingest_lock_with_progress"
+    
+    def test_backlog_processing_with_progress_not_stale(self):
+        """Backlog processing with progress is not stale."""
+        job = InProgressJob.from_redis_key(
+            "arq:in-progress:cron:process_cities_backlog:1724594700"
+        )
+        logs = WorkerLogs("Starting ingestion for country CL")
+        
+        is_stale, reason = should_treat_lock_as_stale(
+            in_progress_jobs=[job],
+            worker_logs=logs,
+            stale_threshold_minutes=15,
+        )
+        
+        assert not is_stale
+        assert reason == "ingest_lock_with_progress"
+
+
+class TestShouldEnqueueClassifyDuringRemediation:
+    """
+    Tests for classify enqueue decision during remediation.
+    
+    CRITICAL: These tests verify we don't enqueue classify while ingest is active.
+    """
+    
+    def test_no_enqueue_when_ingest_active_with_progress(self):
+        """
+        CRITICAL: Do NOT enqueue classify when ingest is active and making progress.
+        
+        This prevents the issue where remediate enqueued classify_pending while
+        ingest_all_countries was still the active hourly task.
+        """
+        job = InProgressJob.from_redis_key(
+            "arq:in-progress:cron:ingest_cities_hourly:1724594700"
+        )
+        logs = WorkerLogs("Country BR complete: 150 sources in 180s")
+        
+        should_enqueue, reason = should_enqueue_classify_during_remediation(
+            had_queue_jam=True,  # Even with queue jam
+            had_no_pipeline=False,
+            had_recent_ingest=True,
+            in_progress_jobs=[job],
+            worker_logs=logs,
+        )
+        
+        assert not should_enqueue
+        assert reason == "active_ingest_with_progress"
+    
+    def test_no_enqueue_when_ingest_lock_present_without_progress(self):
+        """
+        Do NOT enqueue classify when ingest lock is present, even without progress.
+        
+        Let other remediation (worker restart, lock clear) handle the stuck ingest.
+        """
+        job = InProgressJob.from_redis_key(
+            "arq:in-progress:cron:ingest_cities_hourly:1724594700"
+        )
+        logs = WorkerLogs("No progress logs here")
+        
+        should_enqueue, reason = should_enqueue_classify_during_remediation(
+            had_queue_jam=True,
+            had_no_pipeline=False,
+            had_recent_ingest=True,
+            in_progress_jobs=[job],
+            worker_logs=logs,
+        )
+        
+        assert not should_enqueue
+        assert reason == "active_ingest_lock_present"
+    
+    def test_enqueue_when_queue_jammed_without_ingest(self):
+        """Enqueue classify when queue is jammed and no ingest is active."""
+        should_enqueue, reason = should_enqueue_classify_during_remediation(
+            had_queue_jam=True,
+            had_no_pipeline=False,
+            had_recent_ingest=False,
+            in_progress_jobs=[],
+            worker_logs=WorkerLogs(""),
+        )
+        
+        assert should_enqueue
+        assert reason == "queue_jammed"
+    
+    def test_enqueue_when_no_pipeline_with_recent_ingest(self):
+        """Enqueue classify when no pipeline but recent ingest (and no active lock)."""
+        should_enqueue, reason = should_enqueue_classify_during_remediation(
+            had_queue_jam=False,
+            had_no_pipeline=True,
+            had_recent_ingest=True,
+            in_progress_jobs=[],
+            worker_logs=WorkerLogs(""),
+        )
+        
+        assert should_enqueue
+        assert reason == "no_pipeline_with_recent_ingest"
+    
+    def test_no_enqueue_when_no_conditions_met(self):
+        """Do not enqueue classify when no conditions are met."""
+        should_enqueue, reason = should_enqueue_classify_during_remediation(
+            had_queue_jam=False,
+            had_no_pipeline=False,
+            had_recent_ingest=False,
+            in_progress_jobs=[],
+            worker_logs=WorkerLogs(""),
+        )
+        
+        assert not should_enqueue
+        assert reason == "no_condition_met"
+    
+    def test_no_enqueue_full_pipeline_with_progress(self):
+        """Do not enqueue classify when full pipeline is active with progress."""
+        job = InProgressJob.from_redis_key(
+            "arq:in-progress:cron:ingest_cities_full_pipeline:1724594700"
+        )
+        logs = WorkerLogs("Starting ingestion for country AR")
+        
+        should_enqueue, reason = should_enqueue_classify_during_remediation(
+            had_queue_jam=True,
+            had_no_pipeline=False,
+            had_recent_ingest=True,
+            in_progress_jobs=[job],
+            worker_logs=logs,
+        )
+        
+        assert not should_enqueue
+        assert reason == "active_ingest_with_progress"

--- a/backend/tests/test_pipeline_health_integration.py
+++ b/backend/tests/test_pipeline_health_integration.py
@@ -1,0 +1,216 @@
+"""
+Integration tests for pipeline health check script.
+
+These tests verify the bash script correctly uses the Python remediation logic
+to handle live long-running ingest jobs.
+"""
+
+import pytest
+from app.services.pipeline_health import (
+    InProgressJob,
+    WorkerLogs,
+    should_treat_lock_as_stale,
+    should_enqueue_classify_during_remediation,
+)
+
+
+class TestProductionScenarioIssue193:
+    """
+    Test the exact production scenario from issue #193.
+    
+    Production worker 2e675ee. 2026-08-25 15:21 UTC GitHub Actions Pipeline 
+    Health run 32865263134. The health job treated a live ingest_all_countries 
+    lock as stale. With 12 South American countries, ingest regularly holds 
+    the lock past 15 minutes (this run ~1072s).
+    """
+    
+    def test_live_ingest_not_treated_as_stale_with_progress(self):
+        """
+        A 12-country ingest running for 1072s (~18 minutes) with progress
+        should NOT be treated as stale.
+        """
+        # Simulate the in-progress lock from the production incident
+        job = InProgressJob.from_redis_key(
+            "arq:in-progress:cron:ingest_cities_hourly:1724594700"
+        )
+        
+        # Simulate worker logs showing multi-country progress
+        # This is what a healthy 12-country ingest looks like
+        logs = WorkerLogs("""
+        [2026-08-25 15:05:00] Starting multi-country ingestion (12 countries)
+        [2026-08-25 15:07:00] Country BR complete: 150 sources in 180s
+        [2026-08-25 15:09:00] Country CL complete: 45 sources in 120s
+        [2026-08-25 15:11:00] Country AR complete: 80 sources in 115s
+        [2026-08-25 15:13:00] Country UY complete: 25 sources in 90s
+        [2026-08-25 15:15:00] Country PY complete: 30 sources in 95s
+        [2026-08-25 15:17:00] Country BO complete: 20 sources in 85s
+        [2026-08-25 15:19:00] Starting ingestion for country PE
+        [2026-08-25 15:21:00] Country PE complete: 40 sources in 110s
+        """)
+        
+        # The lock is older than 15 minutes, but it's making progress
+        is_stale, reason = should_treat_lock_as_stale(
+            in_progress_jobs=[job],
+            worker_logs=logs,
+            stale_threshold_minutes=15,
+        )
+        
+        # CRITICAL: Must NOT be treated as stale
+        assert not is_stale, "Live ingest with progress must not be treated as stale"
+        assert reason == "ingest_lock_with_progress"
+    
+    def test_remediate_does_not_enqueue_classify_during_live_ingest(self):
+        """
+        Remediate should NOT enqueue classify_pending while ingest_all_countries
+        is still the active hourly task, even if queue appears jammed.
+        """
+        # Simulate the in-progress lock
+        job = InProgressJob.from_redis_key(
+            "arq:in-progress:cron:ingest_cities_hourly:1724594700"
+        )
+        
+        # Simulate worker logs showing ongoing multi-country ingestion
+        logs = WorkerLogs("""
+        [2026-08-25 15:10:00] Country BR complete: 150 sources in 180s
+        [2026-08-25 15:15:00] Starting ingestion for country AR
+        [2026-08-25 15:18:00] Country AR complete: 80 sources in 115s
+        """)
+        
+        # The health check detected a "queue jam" because the lock is old
+        # But it should NOT enqueue classify because ingest is active
+        should_enqueue, reason = should_enqueue_classify_during_remediation(
+            had_queue_jam=True,  # This was detected in the incident
+            had_no_pipeline=False,
+            had_recent_ingest=True,
+            in_progress_jobs=[job],
+            worker_logs=logs,
+        )
+        
+        # CRITICAL: Must NOT enqueue classify
+        assert not should_enqueue, "Must not enqueue classify during active ingest"
+        assert reason == "active_ingest_with_progress"
+    
+    def test_truly_dead_worker_still_remediable(self):
+        """
+        A truly dead worker with no progress should still be remediable.
+        
+        This ensures we don't break the ability to recover from actual failures.
+        """
+        # Simulate a stuck lock with the same job name
+        job = InProgressJob.from_redis_key(
+            "arq:in-progress:cron:ingest_cities_hourly:1724594700"
+        )
+        
+        # But logs show NO progress - worker is actually dead
+        logs = WorkerLogs("""
+        [2026-08-25 14:50:00] Worker health check OK
+        [2026-08-25 14:55:00] Heartbeat sent
+        [2026-08-25 15:00:00] Starting multi-country ingestion (12 countries)
+        [2026-08-25 15:01:00] Heartbeat sent
+        """)
+        
+        # No country-level progress for 20+ minutes
+        is_stale, reason = should_treat_lock_as_stale(
+            in_progress_jobs=[job],
+            worker_logs=logs,
+            stale_threshold_minutes=15,
+        )
+        
+        # This IS stale and should be remediable
+        assert is_stale, "Dead worker with no progress must be remediable"
+        assert reason == "ingest_lock_without_progress"
+    
+    def test_completed_ingest_allows_classify_enqueue(self):
+        """
+        After ingest completes (no active lock), classify can be enqueued.
+        """
+        # No in-progress locks - ingest has completed
+        logs = WorkerLogs("""
+        [2026-08-25 15:22:00] MULTI-COUNTRY INGESTION COMPLETE (12 countries)
+        [2026-08-25 15:22:00] Total sources: 550
+        """)
+        
+        # Queue is jammed with ready backlog
+        should_enqueue, reason = should_enqueue_classify_during_remediation(
+            had_queue_jam=True,
+            had_no_pipeline=False,
+            had_recent_ingest=True,
+            in_progress_jobs=[],  # No locks
+            worker_logs=logs,
+        )
+        
+        # Now it's safe to enqueue classify
+        assert should_enqueue, "Should enqueue classify after ingest completes"
+        assert reason == "queue_jammed"
+
+
+class TestEdgeCases:
+    """Test edge cases and boundary conditions."""
+    
+    def test_backlog_processing_lock_respected(self):
+        """process_cities_backlog with progress should not be treated as stale."""
+        job = InProgressJob.from_redis_key(
+            "arq:in-progress:cron:process_cities_backlog:1724594700"
+        )
+        logs = WorkerLogs("Starting ingestion for country BR")
+        
+        is_stale, reason = should_treat_lock_as_stale(
+            in_progress_jobs=[job],
+            worker_logs=logs,
+            stale_threshold_minutes=15,
+        )
+        
+        assert not is_stale
+        assert reason == "ingest_lock_with_progress"
+    
+    def test_full_pipeline_lock_respected(self):
+        """ingest_cities_full_pipeline with progress should not be treated as stale."""
+        job = InProgressJob.from_redis_key(
+            "arq:in-progress:cron:ingest_cities_full_pipeline:1724594700"
+        )
+        logs = WorkerLogs("Country CL complete: 45 sources in 120s")
+        
+        is_stale, reason = should_treat_lock_as_stale(
+            in_progress_jobs=[job],
+            worker_logs=logs,
+            stale_threshold_minutes=15,
+        )
+        
+        assert not is_stale
+        assert reason == "ingest_lock_with_progress"
+    
+    def test_multiple_locks_any_ingest_prevents_classify(self):
+        """If any lock is an ingest, don't enqueue classify."""
+        jobs = [
+            InProgressJob.from_redis_key("arq:in-progress:some_task:123"),
+            InProgressJob.from_redis_key("arq:in-progress:cron:ingest_cities_hourly:456"),
+        ]
+        logs = WorkerLogs("Country BR complete: 150 sources in 180s")
+        
+        should_enqueue, reason = should_enqueue_classify_during_remediation(
+            had_queue_jam=True,
+            had_no_pipeline=False,
+            had_recent_ingest=True,
+            in_progress_jobs=jobs,
+            worker_logs=logs,
+        )
+        
+        assert not should_enqueue
+        assert reason == "active_ingest_with_progress"
+    
+    def test_no_logs_available(self):
+        """Handle case where logs are empty or unavailable."""
+        job = InProgressJob.from_redis_key(
+            "arq:in-progress:cron:ingest_cities_hourly:1724594700"
+        )
+        logs = WorkerLogs("")
+        
+        # Without progress evidence, treat as stale
+        is_stale, reason = should_treat_lock_as_stale(
+            in_progress_jobs=[job],
+            worker_logs=logs,
+            stale_threshold_minutes=15,
+        )
+        
+        assert is_stale
+        assert reason == "ingest_lock_without_progress"

--- a/backend/tests/test_pipeline_health_integration.py
+++ b/backend/tests/test_pipeline_health_integration.py
@@ -26,29 +26,43 @@ class TestProductionScenarioIssue193:
     
     def test_live_ingest_not_treated_as_stale_with_progress(self):
         """
-        A 12-country ingest running for 1072s (~18 minutes) with progress
-        should NOT be treated as stale.
+        CRITICAL TEST per spec review: A mid-run 12-country ingest that has
+        started and is making progress (has Starting multi-country ingestion +
+        Starting PARALLEL city ingestion + city Done lines + INGESTION COMPLETE
+        for at least one country) but NOT yet MULTI-COUNTRY INGESTION COMPLETE,
+        with lock arq:in-progress:cron:ingest_cities_hourly:..., must return
+        is_stale=False.
+        
+        This is the exact scenario from the production incident (~1072s runtime,
+        never reached MULTI-COUNTRY COMPLETE before being killed).
         """
         # Simulate the in-progress lock from the production incident
         job = InProgressJob.from_redis_key(
             "arq:in-progress:cron:ingest_cities_hourly:1724594700"
         )
         
-        # Simulate worker logs showing multi-country progress
-        # This is what a healthy 12-country ingest looks like
+        # Simulate actual worker logs from a mid-run 12-country ingest
+        # Using REAL log patterns from ingestion.py
         logs = WorkerLogs("""
-        [2026-08-25 15:05:00] Starting multi-country ingestion (12 countries)
-        [2026-08-25 15:07:00] Country BR complete: 150 sources in 180s
-        [2026-08-25 15:09:00] Country CL complete: 45 sources in 120s
-        [2026-08-25 15:11:00] Country AR complete: 80 sources in 115s
-        [2026-08-25 15:13:00] Country UY complete: 25 sources in 90s
-        [2026-08-25 15:15:00] Country PY complete: 30 sources in 95s
-        [2026-08-25 15:17:00] Country BO complete: 20 sources in 85s
-        [2026-08-25 15:19:00] Starting ingestion for country PE
-        [2026-08-25 15:21:00] Country PE complete: 40 sources in 110s
+        [2026-08-25 15:05:00] [INGEST_HOURLY] Starting hourly city ingest
+        [2026-08-25 15:05:01] [INGEST_CITIES] Starting with when=1h
+        [2026-08-25 15:05:02] Starting multi-country ingestion (12 countries)
+        [2026-08-25 15:05:03] Starting PARALLEL city ingestion for 150 cities in BR
+        [2026-08-25 15:06:00] [São Paulo] Starting...
+        [2026-08-25 15:06:45] [São Paulo] Done: 40 entries, 12 new
+        [2026-08-25 15:07:00] [Rio de Janeiro] Starting...
+        [2026-08-25 15:07:30] [Rio de Janeiro] Done: 35 entries, 8 new
+        [2026-08-25 15:08:00] [Belo Horizonte] Starting...
+        [2026-08-25 15:08:25] [Belo Horizonte] Done: 28 entries, 5 new
+        [2026-08-25 15:10:00] INGESTION COMPLETE (BR)
+        [2026-08-25 15:10:05] Starting PARALLEL city ingestion for 45 cities in CL
+        [2026-08-25 15:11:00] [Santiago] Starting...
+        [2026-08-25 15:11:30] [Santiago] Done: 22 entries, 6 new
+        [2026-08-25 15:21:00] INGESTION COMPLETE (CL)
         """)
+        # NOTE: No MULTI-COUNTRY INGESTION COMPLETE yet - still processing remaining countries
         
-        # The lock is older than 15 minutes, but it's making progress
+        # The lock is older than 15 minutes, but it's making clear progress
         is_stale, reason = should_treat_lock_as_stale(
             in_progress_jobs=[job],
             worker_logs=logs,
@@ -61,7 +75,7 @@ class TestProductionScenarioIssue193:
     
     def test_remediate_does_not_enqueue_classify_during_live_ingest(self):
         """
-        Remediate should NOT enqueue classify_pending while ingest_all_countries
+        Remediate should NOT enqueue classify_pending while ingest_cities_hourly
         is still the active hourly task, even if queue appears jammed.
         """
         # Simulate the in-progress lock
@@ -69,11 +83,14 @@ class TestProductionScenarioIssue193:
             "arq:in-progress:cron:ingest_cities_hourly:1724594700"
         )
         
-        # Simulate worker logs showing ongoing multi-country ingestion
+        # Simulate worker logs showing ongoing multi-country ingestion (REAL patterns)
         logs = WorkerLogs("""
-        [2026-08-25 15:10:00] Country BR complete: 150 sources in 180s
-        [2026-08-25 15:15:00] Starting ingestion for country AR
-        [2026-08-25 15:18:00] Country AR complete: 80 sources in 115s
+        [2026-08-25 15:05:00] Starting multi-country ingestion (12 countries)
+        [2026-08-25 15:06:00] Starting PARALLEL city ingestion for 150 cities in BR
+        [2026-08-25 15:10:00] [São Paulo] Done: 40 entries, 12 new
+        [2026-08-25 15:12:00] INGESTION COMPLETE (BR)
+        [2026-08-25 15:13:00] Starting PARALLEL city ingestion for 45 cities in CL
+        [2026-08-25 15:18:00] [Santiago] Done: 22 entries, 6 new
         """)
         
         # The health check detected a "queue jam" because the lock is old
@@ -92,8 +109,10 @@ class TestProductionScenarioIssue193:
     
     def test_truly_dead_worker_still_remediable(self):
         """
-        A truly dead worker with no progress should still be remediable.
+        CRITICAL TEST per spec review: A truly dead worker with heartbeat-only
+        logs and no progress must still be remediable.
         
+        Heartbeat-only logs with the same hourly lock must still be stale.
         This ensures we don't break the ability to recover from actual failures.
         """
         # Simulate a stuck lock with the same job name
@@ -101,15 +120,20 @@ class TestProductionScenarioIssue193:
             "arq:in-progress:cron:ingest_cities_hourly:1724594700"
         )
         
-        # But logs show NO progress - worker is actually dead
+        # Heartbeat-only logs - NO actual ingestion progress
         logs = WorkerLogs("""
         [2026-08-25 14:50:00] Worker health check OK
         [2026-08-25 14:55:00] Heartbeat sent
-        [2026-08-25 15:00:00] Starting multi-country ingestion (12 countries)
+        [2026-08-25 15:00:00] [INGEST_HOURLY] Starting hourly city ingest
         [2026-08-25 15:01:00] Heartbeat sent
+        [2026-08-25 15:05:00] Heartbeat sent
+        [2026-08-25 15:10:00] Heartbeat sent
+        [2026-08-25 15:15:00] Heartbeat sent
+        [2026-08-25 15:20:00] Heartbeat sent
         """)
+        # No Starting multi-country, no Starting PARALLEL, no city Done, no INGESTION COMPLETE
         
-        # No country-level progress for 20+ minutes
+        # Lock is 20+ minutes old with NO progress - worker is stuck/dead
         is_stale, reason = should_treat_lock_as_stale(
             in_progress_jobs=[job],
             worker_logs=logs,
@@ -124,10 +148,12 @@ class TestProductionScenarioIssue193:
         """
         After ingest completes (no active lock), classify can be enqueued.
         """
-        # No in-progress locks - ingest has completed
+        # No in-progress locks - ingest has completed (REAL pattern)
         logs = WorkerLogs("""
         [2026-08-25 15:22:00] MULTI-COUNTRY INGESTION COMPLETE (12 countries)
-        [2026-08-25 15:22:00] Total sources: 550
+        [2026-08-25 15:22:01] Total entries: 1250
+        [2026-08-25 15:22:01] Total sources: 550
+        [2026-08-25 15:22:02] [INGEST_CITIES] Complete: 550 new sources
         """)
         
         # Queue is jammed with ready backlog
@@ -152,7 +178,8 @@ class TestEdgeCases:
         job = InProgressJob.from_redis_key(
             "arq:in-progress:cron:process_cities_backlog:1724594700"
         )
-        logs = WorkerLogs("Starting ingestion for country BR")
+        # REAL pattern: city ingestion progress
+        logs = WorkerLogs("[Curitiba] Done: 15 entries, 3 new")
         
         is_stale, reason = should_treat_lock_as_stale(
             in_progress_jobs=[job],
@@ -168,7 +195,8 @@ class TestEdgeCases:
         job = InProgressJob.from_redis_key(
             "arq:in-progress:cron:ingest_cities_full_pipeline:1724594700"
         )
-        logs = WorkerLogs("Country CL complete: 45 sources in 120s")
+        # REAL pattern: country completion
+        logs = WorkerLogs("INGESTION COMPLETE (CL)")
         
         is_stale, reason = should_treat_lock_as_stale(
             in_progress_jobs=[job],
@@ -185,7 +213,8 @@ class TestEdgeCases:
             InProgressJob.from_redis_key("arq:in-progress:some_task:123"),
             InProgressJob.from_redis_key("arq:in-progress:cron:ingest_cities_hourly:456"),
         ]
-        logs = WorkerLogs("Country BR complete: 150 sources in 180s")
+        # REAL pattern: parallel city ingestion
+        logs = WorkerLogs("Starting PARALLEL city ingestion for 150 cities in BR")
         
         should_enqueue, reason = should_enqueue_classify_during_remediation(
             had_queue_jam=True,

--- a/scripts/check-pipeline-health.sh
+++ b/scripts/check-pipeline-health.sh
@@ -207,13 +207,56 @@ else
     arq_in_progress_count=0
 fi
 arq_in_progress_count="${arq_in_progress_count:-0}"
+
+# Check if locks should be treated as stale (considers ingest progress)
+lock_status="ok"
+if [ "${arq_in_progress_count:-0}" -gt 0 ]; then
+    worker_logs_for_stale_check="$(docker logs "$WORKER_CONTAINER" --since "${PIPELINE_ACTIVITY_MINUTES}m" 2>&1 || true)"
+    lock_stale_result="$(docker compose $COMPOSE_PROD exec -T api python - <<PY
+import sys
+sys.path.insert(0, "/app")
+from app.services.pipeline_health import InProgressJob, WorkerLogs, should_treat_lock_as_stale
+
+# Parse in-progress keys
+in_progress_raw = """$arq_in_progress_raw"""
+jobs = []
+for line in in_progress_raw.strip().split('\n'):
+    line = line.strip()
+    if line and 'arq:in-progress:' in line:
+        jobs.append(InProgressJob.from_redis_key(line))
+
+# Get worker logs
+logs = WorkerLogs("""$worker_logs_for_stale_check""")
+
+# Check if locks are stale
+is_stale, reason = should_treat_lock_as_stale(jobs, logs, ${STUCK_SOURCE_MINUTES})
+print(f"stale={is_stale};reason={reason}")
+PY
+)" || echo "stale=error;reason=check_failed"
+    if echo "$lock_stale_result" | grep -q 'stale=True'; then
+        lock_status="stale"
+        lock_reason="$(echo "$lock_stale_result" | sed -n 's/.*reason=\([^;]*\).*/\1/p')"
+        DETAILS+=("WARN: locks_detected_as_stale(reason=${lock_reason})")
+    elif echo "$lock_stale_result" | grep -q 'stale=False'; then
+        lock_reason="$(echo "$lock_stale_result" | sed -n 's/.*reason=\([^;]*\).*/\1/p')"
+        DETAILS+=("INFO: locks_active_with_progress(reason=${lock_reason})")
+    else
+        DETAILS+=("WARN: lock_stale_check_failed")
+    fi
+fi
+
 if [ "$arq_queue_depth" = "error" ]; then
     record_warning "arq_queue_depth_query_failed"
 elif [ "${arq_queue_depth:-0}" -gt 0 ] || [ "${arq_in_progress_count:-0}" -gt 0 ]; then
     DETAILS+=("INFO: arq_queue_depth=${arq_queue_depth} in_progress=${arq_in_progress_count}")
     if [ "${arq_queue_depth:-0}" -gt 0 ] && [ "${recent_activity:-false}" != true ]; then
         if echo "$cron_enabled" | grep -q '"cron_enabled": true'; then
-            record_failure "arq_queue_jammed(depth=${arq_queue_depth},in_progress=${arq_in_progress_count})"
+            # Only treat as jammed if locks are truly stale
+            if [ "$lock_status" = "stale" ]; then
+                record_failure "arq_queue_jammed(depth=${arq_queue_depth},in_progress=${arq_in_progress_count})"
+            else
+                DETAILS+=("INFO: queue_has_depth_but_locks_active")
+            fi
         fi
     fi
 else
@@ -376,13 +419,47 @@ if [ "$REMEDIATE" = true ]; then
     elif [ "$had_queue_jam" = true ]; then
         tier_a_clear_arq_queue || true
     fi
-    # Prefer classify when ingest recently started (or queue was jammed with
-    # ready backlog). Otherwise kick a full cities pipeline when cron/ingest
-    # has gone quiet — including backlog_active_but_no_recent_ingest.
-    if [ "$had_queue_jam" = true ] || { [ "$had_no_pipeline" = true ] && [ "$had_recent_ingest" = true ]; }; then
+    # Use Python logic to decide whether to enqueue classify (considers active ingest)
+    worker_logs_for_classify_check="$(docker logs "$WORKER_CONTAINER" --since "${PIPELINE_ACTIVITY_MINUTES}m" 2>&1 || true)"
+    should_enqueue_classify="$(docker compose $COMPOSE_PROD exec -T api python - <<PY
+import sys
+sys.path.insert(0, "/app")
+from app.services.pipeline_health import InProgressJob, WorkerLogs, should_enqueue_classify_during_remediation
+
+# Parse in-progress keys
+in_progress_raw = """$arq_in_progress_raw"""
+jobs = []
+for line in in_progress_raw.strip().split('\n'):
+    line = line.strip()
+    if line and 'arq:in-progress:' in line:
+        jobs.append(InProgressJob.from_redis_key(line))
+
+# Get worker logs
+logs = WorkerLogs("""$worker_logs_for_classify_check""")
+
+# Check if we should enqueue classify
+should_enqueue, reason = should_enqueue_classify_during_remediation(
+    had_queue_jam=${had_queue_jam},
+    had_no_pipeline=${had_no_pipeline},
+    had_recent_ingest=${had_recent_ingest},
+    in_progress_jobs=jobs,
+    worker_logs=logs,
+)
+print(f"enqueue={should_enqueue};reason={reason}")
+PY
+)" || echo "enqueue=error;reason=check_failed"
+    
+    # Prefer classify when appropriate, but NOT when ingest is active
+    if echo "$should_enqueue_classify" | grep -q 'enqueue=True'; then
+        enqueue_reason="$(echo "$should_enqueue_classify" | sed -n 's/.*reason=\([^;]*\).*/\1/p')"
+        DETAILS+=("INFO: enqueue_classify_decision(reason=${enqueue_reason})")
         tier_a_enqueue_classify || true
     elif [ "$had_no_pipeline" = true ] || [ "$had_stale_ingest" = true ]; then
+        # Only enqueue pipeline if classify was not appropriate
         tier_a_enqueue_pipeline || true
+    else
+        enqueue_reason="$(echo "$should_enqueue_classify" | sed -n 's/.*reason=\([^;]*\).*/\1/p')"
+        DETAILS+=("INFO: skip_classify_enqueue(reason=${enqueue_reason})")
     fi
     if [ "$had_stuck" = true ]; then
         echo_step "🔧 Tier-A: resetting stuck transient source statuses..."


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 📝 Descrição

Cherry-pick do fix de pipeline health script de PR #201 para master, para resolver o problema crítico de falsos positivos do health check matando ingestões multi-país ativas.

Este PR contém **apenas** as mudanças do PR #201 (commits 6a33354 e bd9ed6b do develop), sem incluir qualquer outro trabalho do develop (PR #204, /estatisticas, rankings UI, etc).

## 🔗 Issue Relacionada

Fixes #193

## 🏷️ Tipo de Mudança

- [x] 🐛 Bug fix (mudança que corrige um problema)
- [ ] ✨ Nova feature (mudança que adiciona funcionalidade)
- [ ] 💥 Breaking change (fix ou feature que causaria quebra de funcionalidade existente)
- [ ] 📚 Documentação (mudança apenas em documentação)
- [ ] 🎨 Estilo (formatação, ponto e vírgula, etc - sem mudança de código)
- [ ] ♻️ Refatoração (mudança de código sem alterar funcionalidade)
- [ ] ⚡ Performance (mudança que melhora performance)
- [x] ✅ Testes (adição ou correção de testes)
- [ ] 🔧 Chore (atualizações de build, CI, etc)

## 🧪 Como Foi Testado?

- [x] Testes unitários (20 testes)
- [x] Testes de integração (8 testes)
- [ ] Testes manuais
- [x] Testado em desenvolvimento local
- [ ] Testado com Docker

**Ambiente de teste:**
- OS: Linux 6.12.94+
- Python version: 3.12.3
- Pytest version: 9.1.1

**Resultados dos testes:**
```
tests/test_pipeline_health.py: 20 passed in 0.03s
tests/test_pipeline_health_integration.py: 8 passed in 0.02s
```

## 📁 Arquivos Incluídos

Este cherry-pick contém apenas os seguintes arquivos do PR #201:
- `backend/app/services/pipeline_health.py` (novo)
- `backend/tests/test_pipeline_health.py` (novo)
- `backend/tests/test_pipeline_health_integration.py` (novo)
- `scripts/check-pipeline-health.sh` (modificado)

## 🎯 Contexto da Produção

O health check estava tratando jobs de ingestão multi-país (12 países) como stale após 15 minutos, mesmo quando eles levam ~18 minutos normalmente. Isso causava:
- Restart do worker e purge de locks
- Enqueue de classify_pending enquanto ingest ainda estava ativo
- Ingest atingindo max retries e nunca completando

Este fix adiciona lógica Python para detectar progresso em jobs de ingestão longos, verificando logs do worker por marcadores de conclusão/progresso por país.

## ✅ Checklist

- [x] Meu código segue o guia de estilo do projeto
- [x] Realizei uma auto-revisão do meu código
- [x] Comentei meu código em áreas complexas
- [ ] Atualizei a documentação correspondente
- [x] Minhas mudanças não geram novos warnings
- [x] Adicionei testes que provam que meu fix/feature funciona
- [x] Testes unitários novos e existentes passam localmente
- [x] Quaisquer mudanças dependentes foram mergeadas
- [ ] Atualizei o CHANGELOG (se aplicável)

## 📚 Documentação

- [ ] README.md
- [ ] CONTRIBUTING.md
- [x] Docstrings/comentários no código
- [ ] API documentation
- [ ] Outro: 

## 💬 Notas Adicionais

**Importante:** Este PR foi criado via cherry-pick autorizado por João. Ele contém **apenas** as mudanças do pipeline health script (PR #201), sem incluir qualquer outro trabalho do branch develop. O objetivo é deployar este fix crítico para produção imediatamente, sem esperar por outras features em desenvolvimento.

**Deploy flow:** Este PR vai direto para master → produção, pulando a etapa usual de develop → staging porque o fix já foi validado em staging via develop.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b34f94c2-d585-4507-9bb9-80718cd70262?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b34f94c2-d585-4507-9bb9-80718cd70262&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

