### PR TITLE
Fix issue #207: Block downloads from Google News URLs when unwrap fails

### DIFF
--- a/backend/app/services/download.py
+++ b/backend/app/services/download.py
@@ -271,7 +271,7 @@ async def download_source_content(source_id: int) -> DownloadOutcome:
         google_news_url = row[1]
         headline = row[2]
     
-    # Issue #171: If resolved_url is NULL but google_news_url exists,
+    # Issue #171 & #207: If resolved_url is NULL but google_news_url exists,
     # try to resolve it now (handles decoder failures during ingest)
     if not resolved_url and google_news_url:
         logger.info(f"Source {source_id}: resolved_url is NULL, attempting late resolution")
@@ -288,10 +288,36 @@ async def download_source_content(source_id: int) -> DownloadOutcome:
                 )
                 await session.commit()
         else:
-            logger.warning(f"Source {source_id}: late resolution failed, will use google_news_url")
+            # Issue #207: If late resolution also failed, do NOT fetch from Google News URL.
+            # Mark as failed instead of downloading the Google language picker page.
+            logger.warning(
+                f"Source {source_id}: late resolution failed, cannot download from Google News URL"
+            )
+            async with async_session_maker() as session:
+                await session.execute(
+                    text("""
+                        UPDATE source_google_news 
+                        SET status = 'failed_in_download', updated_at = CURRENT_TIMESTAMP
+                        WHERE id = :id
+                    """),
+                    {"id": source_id}
+                )
+                await session.commit()
+            await diagnostics.record_attempt(
+                stage=diagnostics.STAGE_DOWNLOAD,
+                outcome=diagnostics.OUTCOME_FAILURE,
+                source_google_news_id=source_id,
+                failure_reason=diagnostics.NO_URL,
+                failure_detail="Unwrap failed: cannot resolve Google News URL to newspaper URL",
+                http_status=None,
+                url_domain=None,
+                duration_ms=0,
+                attempt_number=await diagnostics.count_attempts(source_id, diagnostics.STAGE_DOWNLOAD) + 1,
+            )
+            return DownloadOutcome.failed
     
-    # Use resolved URL if available, otherwise fall back to Google News URL
-    target_url = resolved_url or google_news_url
+    # Use resolved URL (newspaper URL only, never Google News URL)
+    target_url = resolved_url
     
     if not target_url:
         async with async_session_maker() as session:

--- a/backend/tests/test_download_null_resolved_url.py
+++ b/backend/tests/test_download_null_resolved_url.py
@@ -113,7 +113,10 @@ async def test_download_processes_null_resolved_url_with_late_resolution_success
 @pytest.mark.asyncio
 async def test_download_processes_null_resolved_url_with_late_resolution_failure(test_db):
     """
-    Test that sources with NULL resolved_url are still processed when late resolution fails.
+    Test that sources with NULL resolved_url are NOT downloaded when late resolution fails.
+    
+    Issue #207: When unwrap fails both at ingest and at download time, do NOT fetch
+    from the Google News URL. Mark the source as failed instead.
     
     When a source has:
     - status = ready_for_download
@@ -121,8 +124,8 @@ async def test_download_processes_null_resolved_url_with_late_resolution_failure
     - google_news_url present
     
     And late resolution ALSO fails (returns None), the source should:
-    - Still be processed (processed==1) via fallback to google_news_url
-    - NOT skip the source
+    - Be processed but marked FAILED (not downloaded from Google News URL)
+    - NOT reach ready_for_extraction status
     """
     source = SourceGoogleNews(
         google_news_id="test-null-resolved-failure",
@@ -138,32 +141,33 @@ async def test_download_processes_null_resolved_url_with_late_resolution_failure
     await test_db.refresh(source)
     
     maker = _TestSessionMaker(test_db)
-    html = "<html><body>Dois mortos em tiroteio.</body></html>"
-    content = "Dois mortos em tiroteio."
+    mock_fetch = AsyncMock()
     
     with (
         patch("app.services.download.async_session_maker", maker),
         patch("app.services.diagnostics.async_session_maker", maker),
-        patch("app.services.ingestion.resolve_google_news_url", return_value=None) as mock_resolve,  # Late resolution also fails
-        patch("app.services.download._fetch_html", new=AsyncMock(return_value=(200, html))),
-        patch("app.services.download.extract_content_and_metadata", return_value=(content, None)),
-        patch("app.services.download.classify_article_content", new=AsyncMock()),
-        patch("app.services.download.passes_content_gate", return_value=True),
+        patch("app.services.ingestion.resolve_google_news_url", return_value=None),  # Late resolution also fails
+        patch("app.services.download._fetch_html", new=mock_fetch),  # Should NOT be called
         patch("app.services.diagnostics.record_attempt", new=AsyncMock()),
     ):
         result = await download_classified_sources(limit=10)
     
-    # Should still process 1 source (fallback to google_news_url)
-    assert result["processed"] == 1, (
-        f"Expected 1 processed via fallback to google_news_url, got {result['processed']}"
-    )
-    assert result["successful"] == 1, f"Expected 1 successful, got {result['successful']}"
+    # Should be processed but failed (NOT downloaded from Google News URL)
+    assert result["processed"] == 1, f"Expected 1 processed, got {result['processed']}"
+    assert result["successful"] == 0, f"Expected 0 successful, got {result['successful']}"
+    assert result["failed"] == 1, f"Expected 1 failed, got {result['failed']}"
     
-    # Verify resolved_url is still NULL (late resolution failed)
+    # HTTP fetch should NOT have been called
+    mock_fetch.assert_not_called()
+    
+    # Verify source is marked failed and resolved_url is still NULL
     await test_db.refresh(source)
     assert source.resolved_url is None, (
         f"Expected resolved_url to remain NULL when late resolution fails, "
         f"but got {source.resolved_url}"
+    )
+    assert source.status == SourceStatus.failed_in_download, (
+        f"Expected status failed_in_download, got {source.status}"
     )
 
 

--- a/backend/tests/test_issue_207_block_google_downloads.py
+++ b/backend/tests/test_issue_207_block_google_downloads.py
@@ -1,0 +1,292 @@
+"""Test issue #207: Block downloads from Google News URLs when unwrap fails.
+
+When unwrap cannot produce a newspaper URL (both at ingest and at download),
+the source must not be fetched from the Google News URL. It stays failed or waiting.
+Extract never runs on a Google page. Late unwrap still allowed if it succeeds.
+
+Fixtures only - no live Google calls.
+"""
+
+from unittest.mock import AsyncMock, patch, call
+
+import pytest
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlmodel import SQLModel
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.models.source_google_news import SourceGoogleNews, SourceStatus
+from app.services.download import download_classified_sources, download_source_content
+
+
+class _TestSessionMaker:
+    """Test session maker for mocking."""
+    
+    def __init__(self, session):
+        self._session = session
+    
+    def __call__(self):
+        return self
+    
+    async def __aenter__(self):
+        return self._session
+    
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+@pytest.fixture
+async def test_db():
+    """Create an in-memory test database."""
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        echo=False,
+        future=True,
+    )
+    
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    
+    async with AsyncSession(engine) as session:
+        yield session
+    
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_no_download_from_google_when_unwrap_fails(test_db):
+    """
+    Acceptance 1: A source with empty newspaper URL and only a Google News URL
+    is not downloaded from news.google.com.
+    
+    When a source has:
+    - status = ready_for_download
+    - resolved_url = NULL (initial unwrap failed)
+    - google_news_url = a news.google.com URL
+    
+    And late unwrap also fails (returns None), the source should:
+    - NOT fetch HTTP from the Google News URL
+    - Be marked as failed (not extracted)
+    - NOT reach status ready_for_extraction
+    """
+    source = SourceGoogleNews(
+        google_news_id="test-unwrap-fails",
+        google_news_url="https://news.google.com/articles/CBMabcdef",
+        resolved_url=None,  # Initial unwrap failed
+        headline="Homem é morto em tiroteio",
+        status=SourceStatus.ready_for_download,
+        is_violent_death=True,
+    )
+    
+    test_db.add(source)
+    await test_db.commit()
+    await test_db.refresh(source)
+    
+    maker = _TestSessionMaker(test_db)
+    
+    mock_fetch = AsyncMock()
+    
+    with (
+        patch("app.services.download.async_session_maker", maker),
+        patch("app.services.diagnostics.async_session_maker", maker),
+        # Late unwrap also fails
+        patch("app.services.ingestion.resolve_google_news_url", return_value=None),
+        # HTTP fetch should NOT be called
+        patch("app.services.download._fetch_html", new=mock_fetch),
+        patch("app.services.diagnostics.record_attempt", new=AsyncMock()),
+    ):
+        result = await download_classified_sources(limit=10)
+    
+    # Should process but not succeed
+    assert result["processed"] == 1, f"Expected 1 processed, got {result['processed']}"
+    assert result["successful"] == 0, f"Expected 0 successful, got {result['successful']}"
+    assert result["failed"] == 1, f"Expected 1 failed, got {result['failed']}"
+    
+    # HTTP fetch should NOT have been called with the Google News URL
+    mock_fetch.assert_not_called()
+    
+    # Source should be marked failed, not ready_for_extraction
+    await test_db.refresh(source)
+    assert source.status == SourceStatus.failed_in_download, (
+        f"Expected status failed_in_download, got {source.status}"
+    )
+    assert source.content is None, "Content should not be set when download blocked"
+
+
+@pytest.mark.asyncio
+async def test_late_unwrap_success_downloads_from_newspaper(test_db):
+    """
+    Acceptance 2: Late unwrap still runs once; success persists the newspaper URL
+    and download proceeds as today.
+    
+    When a source has:
+    - status = ready_for_download
+    - resolved_url = NULL (initial unwrap failed)
+    - google_news_url present
+    
+    And late unwrap succeeds, the source should:
+    - Have the newspaper URL persisted to resolved_url
+    - Download from the newspaper URL (NOT Google)
+    - Reach ready_for_extraction status
+    """
+    source = SourceGoogleNews(
+        google_news_id="test-late-unwrap-success",
+        google_news_url="https://news.google.com/articles/CBMxyz789",
+        resolved_url=None,  # Initial unwrap failed
+        headline="Tiroteio deixa dois mortos",
+        status=SourceStatus.ready_for_download,
+        is_violent_death=True,
+    )
+    
+    test_db.add(source)
+    await test_db.commit()
+    await test_db.refresh(source)
+    
+    maker = _TestSessionMaker(test_db)
+    newspaper_url = "https://g1.globo.com/rj/rio-de-janeiro/noticia/2024/tiroteio.html"
+    html = "<html><body>Tiroteio deixa dois mortos na Zona Norte.</body></html>"
+    content = "Tiroteio deixa dois mortos na Zona Norte."
+    
+    mock_fetch = AsyncMock(return_value=(200, html))
+    
+    with (
+        patch("app.services.download.async_session_maker", maker),
+        patch("app.services.diagnostics.async_session_maker", maker),
+        # Late unwrap succeeds
+        patch("app.services.ingestion.resolve_google_news_url", return_value=newspaper_url),
+        # HTTP fetch called with newspaper URL
+        patch("app.services.download._fetch_html", new=mock_fetch),
+        patch("app.services.download.extract_content_and_metadata", return_value=(content, None)),
+        patch("app.services.download.classify_article_content", new=AsyncMock()),
+        patch("app.services.download.passes_content_gate", return_value=True),
+        patch("app.services.diagnostics.record_attempt", new=AsyncMock()),
+    ):
+        result = await download_classified_sources(limit=10)
+    
+    # Should succeed
+    assert result["processed"] == 1
+    assert result["successful"] == 1
+    assert result["failed"] == 0
+    
+    # HTTP fetch should be called with the newspaper URL, NOT the Google URL
+    mock_fetch.assert_called_once()
+    called_url = mock_fetch.call_args[0][0]
+    assert called_url == newspaper_url, (
+        f"Expected fetch to be called with newspaper URL {newspaper_url}, "
+        f"but was called with {called_url}"
+    )
+    assert "news.google.com" not in called_url, "Should not fetch from Google News URL"
+    
+    # Newspaper URL should be persisted
+    await test_db.refresh(source)
+    assert source.resolved_url == newspaper_url, (
+        f"Expected resolved_url to be persisted as {newspaper_url}, "
+        f"got {source.resolved_url}"
+    )
+    assert source.status == SourceStatus.ready_for_extraction
+    assert source.content == content
+
+
+@pytest.mark.asyncio
+async def test_existing_newspaper_url_unchanged(test_db):
+    """
+    Acceptance 3: Existing rows that already have a newspaper URL are unchanged.
+    
+    This is a regression test. Sources that have resolved_url already set
+    should continue to work normally (Chile/Brazil).
+    """
+    newspaper_url = "https://g1.globo.com/rj/rio-de-janeiro/noticia/2024/article.html"
+    source = SourceGoogleNews(
+        google_news_id="test-existing-url",
+        google_news_url="https://news.google.com/articles/CBMabc123",
+        resolved_url=newspaper_url,  # Already has newspaper URL
+        headline="Operação policial termina em confronto",
+        status=SourceStatus.ready_for_download,
+        is_violent_death=True,
+    )
+    
+    test_db.add(source)
+    await test_db.commit()
+    await test_db.refresh(source)
+    
+    maker = _TestSessionMaker(test_db)
+    html = "<html><body>Operação policial termina em confronto.</body></html>"
+    content = "Operação policial termina em confronto."
+    
+    mock_fetch = AsyncMock(return_value=(200, html))
+    mock_resolve = AsyncMock()
+    
+    with (
+        patch("app.services.download.async_session_maker", maker),
+        patch("app.services.diagnostics.async_session_maker", maker),
+        # Late unwrap should NOT be called (already have resolved_url)
+        patch("app.services.ingestion.resolve_google_news_url", new=mock_resolve),
+        patch("app.services.download._fetch_html", new=mock_fetch),
+        patch("app.services.download.extract_content_and_metadata", return_value=(content, None)),
+        patch("app.services.download.classify_article_content", new=AsyncMock()),
+        patch("app.services.download.passes_content_gate", return_value=True),
+        patch("app.services.diagnostics.record_attempt", new=AsyncMock()),
+    ):
+        result = await download_classified_sources(limit=10)
+    
+    # Should succeed normally
+    assert result["processed"] == 1
+    assert result["successful"] == 1
+    assert result["failed"] == 0
+    
+    # Late unwrap should NOT be called (already have URL)
+    mock_resolve.assert_not_called()
+    
+    # Should fetch from the existing newspaper URL
+    mock_fetch.assert_called_once()
+    called_url = mock_fetch.call_args[0][0]
+    assert called_url == newspaper_url, (
+        f"Expected fetch with existing newspaper URL {newspaper_url}, "
+        f"got {called_url}"
+    )
+    
+    # URL should remain unchanged
+    await test_db.refresh(source)
+    assert source.resolved_url == newspaper_url
+    assert source.status == SourceStatus.ready_for_extraction
+
+
+@pytest.mark.asyncio
+async def test_no_urls_marks_failed(test_db):
+    """
+    Edge case: Source with no resolved_url AND no google_news_url
+    should be marked failed immediately.
+    """
+    source = SourceGoogleNews(
+        google_news_id="test-no-urls",
+        google_news_url="",  # Empty Google URL (NOT NULL constraint)
+        resolved_url=None,  # No newspaper URL
+        headline="Test article",
+        status=SourceStatus.ready_for_download,
+        is_violent_death=True,
+    )
+    
+    test_db.add(source)
+    await test_db.commit()
+    await test_db.refresh(source)
+    
+    maker = _TestSessionMaker(test_db)
+    mock_fetch = AsyncMock()
+    
+    with (
+        patch("app.services.download.async_session_maker", maker),
+        patch("app.services.diagnostics.async_session_maker", maker),
+        patch("app.services.download._fetch_html", new=mock_fetch),
+        patch("app.services.diagnostics.record_attempt", new=AsyncMock()),
+    ):
+        result = await download_classified_sources(limit=10)
+    
+    # Should be marked failed
+    assert result["processed"] == 1
+    assert result["failed"] == 1
+    
+    # No HTTP fetch
+    mock_fetch.assert_not_called()
+    
+    # Should be failed
+    await test_db.refresh(source)
+    assert source.status == SourceStatus.failed_in_download


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 📝 Descrição

Implementa a correção da issue #207: quando o unwrap falha tanto no ingest quanto no download (late unwrap), o source não deve mais ser baixado da URL do Google News. Em vez disso, é marcado como `failed_in_download`.

**Problema anterior (issue #171 fallback):**
- Quando `resolved_url` era NULL após ambas as tentativas de unwrap, o código fazia fallback para `google_news_url`
- Isso resultava no download da página de seleção de idioma do Google, que depois era enviada para extract
- Produção: maioria dos rows vazio-date Argentina/Bolivia/Colombia/Ecuador nunca resolveram o jornal

**Solução implementada:**
- Se late unwrap também falhar (resolved_url ainda NULL), o source é marcado como `failed_in_download`
- Nenhum HTTP fetch é feito para a URL do Google News
- Extract nunca roda em páginas do Google
- Late unwrap ainda é executado uma vez; se tiver sucesso, persiste a newspaper URL e download prossegue normalmente
- Sources que já têm `resolved_url` preenchido continuam funcionando sem mudanças (Chile/Brasil)

## 🔗 Issue Relacionada

Fixes #207 (parent spec #206)

## 🏷️ Tipo de Mudança

- [x] 🐛 Bug fix (mudança que corrige um problema)
- [x] ✅ Testes (adição ou correção de testes)

## 🧪 Como Foi Testado?

- [x] Testes unitários
- [x] Testado em desenvolvimento local

**Testes adicionados:**
1. `test_no_download_from_google_when_unwrap_fails`: Verifica que não há HTTP fetch quando unwrap falha
2. `test_late_unwrap_success_downloads_from_newspaper`: Verifica que late unwrap bem-sucedido persiste URL e baixa do jornal
3. `test_existing_newspaper_url_unchanged`: Teste de regressão para sources com URL já preenchida
4. `test_no_urls_marks_failed`: Edge case de source sem nenhuma URL

**Teste existente atualizado:**
- `test_download_processes_null_resolved_url_with_late_resolution_failure`: Atualizado para refletir o novo comportamento correto (fail em vez de fallback para Google)

**Ambiente de teste:**
- OS: Linux
- Python: 3.12.3
- Pytest: 9.1.1
- Fixtures apenas (sem chamadas ao vivo para Google)

## ✅ Checklist

- [x] Meu código segue o guia de estilo do projeto
- [x] Realizei uma auto-revisão do meu código
- [x] Comentei meu código em áreas complexas
- [x] Minhas mudanças não geram novos warnings
- [x] Adicionei testes que provam que meu fix funciona
- [x] Testes unitários novos e existentes passam localmente (7/7 passed)
- [x] Quaisquer mudanças dependentes foram mergeadas (N/A)

## 📚 Documentação

- [x] Docstrings/comentários no código

## 💬 Notas Adicionais

**Escopo da issue #207 (implementado):**
- Bloquear downloads de Google News URLs quando unwrap falha
- Late unwrap ainda funciona se tiver sucesso
- Sources existentes com newspaper URL inalterados

**Fora de escopo (conforme issue):**
- Issue #204 (first-date-in-text extract fallback)
- Resto da spec #206 (content-gate interstitial text, Accept-Language, re-extract, browser download, frontend)

**Testes com fixtures apenas:**
- Todos os testes usam mocks e fixtures
- Nenhuma chamada ao vivo para Google ou googlenewsdecoder
- Permite testes rápidos e determinísticos

---

**Por favor, certifique-se de que todos os itens do checklist foram completados antes de marcar o PR como pronto para revisão.**
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a1ed84c1-d05a-4b2c-a8b7-db9d7bf0bfa0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a1ed84c1-d05a-4b2c-a8b7-db9d7bf0bfa0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

