### PR TITLE
Add content gate for Google language picker and consent pages

### DIFF
--- a/backend/app/services/content_filters.py
+++ b/backend/app/services/content_filters.py
@@ -125,14 +125,14 @@ _NON_INCIDENT_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
     (
         "google_consent_page",
         re.compile(
-            r"\b(before\s+you\s+continue|todos\s+os\s+idiomas)\b",
+            r"\bbefore\s+you\s+continue\b",
             re.IGNORECASE,
         ),
     ),
     (
         "google_language_picker",
         re.compile(
-            r"Português\s+Brasil.*Deutsch.*English",
+            r"Português\s*Brasil.*Deutsch.*English",
             re.IGNORECASE | re.DOTALL,
         ),
     ),

--- a/backend/app/services/content_filters.py
+++ b/backend/app/services/content_filters.py
@@ -106,6 +106,7 @@ _FOREIGN_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
 )
 
 # Suicides and animal cruelty — out of scope even when violent.
+# Google interstitial pages (language picker, consent) — issue #208.
 _NON_INCIDENT_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
     (
         "suicide",
@@ -119,6 +120,20 @@ _NON_INCIDENT_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
         re.compile(
             r"\b(cachorro|gato|animal|cavalo).{0,40}\b(morto|mortos|envenenado|maltratado)\b",
             re.IGNORECASE,
+        ),
+    ),
+    (
+        "google_consent_page",
+        re.compile(
+            r"\b(before\s+you\s+continue|todos\s+os\s+idiomas)\b",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        "google_language_picker",
+        re.compile(
+            r"Português\s+Brasil.*Deutsch.*English",
+            re.IGNORECASE | re.DOTALL,
         ),
     ),
 )

--- a/backend/tests/fixtures/google_consent_page.txt
+++ b/backend/tests/fixtures/google_consent_page.txt
@@ -1,0 +1,20 @@
+Before you continue to Google News
+
+We use cookies and data to:
+• Deliver and maintain Google services
+• Track outages and protect against spam, fraud, and abuse
+• Measure audience engagement and site statistics to understand how our services are used and enhance the quality of those services
+
+If you choose to "Accept all," we will also use cookies and data to:
+• Develop and improve new services
+• Deliver and measure the effectiveness of ads
+• Show personalized content, depending on your settings
+• Show personalized ads, depending on your settings
+
+If you choose to "Reject all," we will not use cookies for these additional purposes.
+
+Non-personalized content is influenced by things like the content you're currently viewing, activity in your active Search session, and your location. Non-personalized ads are influenced by the content you're currently viewing and your general location. Personalized content and ads can also include more relevant results, recommendations, and tailored ads based on past activity from this browser, like previous Google searches. We also use cookies and data to tailor the experience to be age-appropriate, if relevant.
+
+Select "More options" to see additional information, including details about managing your privacy settings. You can also visit g.co/privacytools at any time.
+
+Todos os idiomas

--- a/backend/tests/fixtures/google_language_picker.txt
+++ b/backend/tests/fixtures/google_language_picker.txt
@@ -1,0 +1,274 @@
+Português Brasil
+Deutsch
+English
+Español Latinoamérica
+Français
+Italiano
+Nederlands
+Polski
+Русский
+Türkçe
+العربية
+中文（简体）
+中文（繁體）
+日本語
+한국어
+Afrikaans
+Bahasa Indonesia
+Bahasa Melayu
+Català
+Čeština
+Dansk
+Eesti
+English UK
+English US
+Español España
+Euskara
+Filipino
+Galego
+Hrvatski
+Íslenska
+Kiswahili
+Latviešu
+Lietuvių
+Magyar
+Norsk
+Română
+Slovenčina
+Slovenščina
+Srpski
+Suomi
+Svenska
+Tiếng Việt
+Українська
+עברית
+हिन्दी
+ไทย
+Ελληνικά
+Български
+Македонски
+Монгол
+অসমীয়া
+বাংলা
+ગુજરાતી
+ಕನ್ನಡ
+മലയാളം
+मराठी
+ଓଡ଼ିଆ
+ਪੰਜਾਬੀ
+தமிழ்
+తెలుగు
+اردو
+Azərbaycan
+Bosanski
+Español US
+Gaeilge
+Latviešu valoda
+Lietuvių kalba
+Lëtzebuergesch
+Malti
+Norsk bokmål
+O'zbek
+Qaraqalpaqsha
+Qırımtatarca
+Slovenský jazyk
+Shqip
+አማርኛ
+Հայերեն
+ქართული
+Қазақ тілі
+Кыргызча
+ភាសាខ្មែរ
+လူမျိုး
+नेपाली
+සිංහල
+ትግርኛ
+Кыргыз тили
+Монгол хэл
+ລາວ
+မြန်မာ
+ਪੰਜਾਬੀ (ਭਾਰਤ)
+پښتو
+فارسی
+සිංහල (ශ්‍රී ලංකා)
+Afaan Oromoo
+አማርኛ (ኢትዮጵያ)
+ትግርኛ (ኤርትራ)
+Hausa
+Igbo
+Kiswahili (Kenya)
+Yorùbá
+isiXhosa
+isiZulu
+Sesotho
+Setswana
+Español Argentina
+Español Bolivia
+Español Chile
+Español Colombia
+Español Costa Rica
+Español Cuba
+Español Ecuador
+Español El Salvador
+Español Guatemala
+Español Honduras
+Español México
+Español Nicaragua
+Español Panamá
+Español Paraguay
+Español Perú
+Español Puerto Rico
+Español República Dominicana
+Español Uruguay
+Español Venezuela
+Français Belgique
+Français Canada
+Français France
+Français Luxembourg
+Français Suisse
+Português Portugal
+English Australia
+English Canada
+English India
+English Ireland
+English New Zealand
+English Singapore
+English South Africa
+Deutsch Deutschland
+Deutsch Österreich
+Deutsch Schweiz
+Italiano Italia
+Italiano Svizzera
+Nederlands België
+Nederlands Nederland
+Svenska Sverige
+Norsk Norge
+Dansk Danmark
+Suomi Suomi
+Polski Polska
+Čeština Česká republika
+Slovenčina Slovensko
+Magyar Magyarország
+Română România
+Български България
+Ελληνικά Ελλάδα
+Українська Україна
+Türkçe Türkiye
+עברית ישראל
+العربية السعودية
+العربية الإمارات
+العربية مصر
+فارسی ایران
+हिन्दी भारत
+বাংলা বাংলাদেশ
+தமிழ் இந்தியா
+తెలుగు భారతదేశం
+ಕನ್ನಡ ಭಾರತ
+മലയാളം ഇന്ത്യ
+ไทย ประเทศไทย
+Tiếng Việt Việt Nam
+Bahasa Indonesia Indonesia
+Bahasa Melayu Malaysia
+Filipino Pilipinas
+中文（简体）中国
+中文（繁體）台灣
+中文（繁體）香港
+日本語 日本
+한국어 대한민국
+Català Espanya
+Euskara Espainia
+Galego España
+Bosanski Bosna i Hercegovina
+Hrvatski Hrvatska
+Српски Србија
+Slovenščina Slovenija
+Latviešu Latvija
+Lietuvių Lietuva
+Eesti Eesti
+Íslenska Ísland
+Gaeilge Éire
+Malti Malta
+Lëtzebuergesch Lëtzebuerg
+Română Moldova
+Azərbaycan Azərbaycan
+Қазақ тілі Қазақстан
+O'zbek O'zbekiston
+Кыргызча Кыргызстан
+Монгол Монгол улс
+አማርኛ ኢትዮጵያ
+Kiswahili Tanzania
+Afrikaans Suid-Afrika
+isiZulu iNingizimu Afrika
+Español Andorra
+Français Monaco
+Italiano San Marino
+Español Guinea Ecuatorial
+Português Angola
+Português Cabo Verde
+Português Guiné-Bissau
+Português Moçambique
+Português São Tomé e Príncipe
+Português Timor-Leste
+English Bahamas
+English Barbados
+English Belize
+English Botswana
+English Cameroon
+English Fiji
+English Gambia
+English Ghana
+English Guyana
+English Jamaica
+English Kenya
+English Kiribati
+English Lesotho
+English Liberia
+English Malawi
+English Malta
+English Mauritius
+English Namibia
+English Nauru
+English Nigeria
+English Pakistan
+English Papua New Guinea
+English Philippines
+English Rwanda
+English Saint Lucia
+English Samoa
+English Seychelles
+English Sierra Leone
+English Solomon Islands
+English Sudan
+English Eswatini
+English Tanzania
+English Tonga
+English Trinidad and Tobago
+English Tuvalu
+English Uganda
+English Vanuatu
+English Zambia
+English Zimbabwe
+Français Bénin
+Français Burkina Faso
+Français Burundi
+Français Cameroun
+Français Centrafrique
+Français Comores
+Français Congo
+Français Congo-Kinshasa
+Français Côte d'Ivoire
+Français Djibouti
+Français Gabon
+Français Guinée
+Français Haïti
+Français Madagascar
+Français Mali
+Français Mauritanie
+Français Maurice
+Français Niger
+Français Rwanda
+Français Sénégal
+Français Seychelles
+Français Tchad
+Français Togo
+Français Vanuatu

--- a/backend/tests/test_content_filters.py
+++ b/backend/tests/test_content_filters.py
@@ -1,6 +1,10 @@
 """Tests for post-download content heuristics (AQV-32)."""
 
+from pathlib import Path
+
 from app.services.content_filters import apply_content_heuristics
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
 
 
 def test_heuristic_rejects_cvli_aggregate():
@@ -80,3 +84,57 @@ def test_heuristic_still_rejects_venezuela_earthquake():
     assert match is not None
     assert match.hint == "foreign"
     assert match.rule == "foreign_earthquake"
+
+
+def test_heuristic_rejects_google_language_picker():
+    """Google language picker page should be rejected (issue #208)."""
+    fixture_path = FIXTURES_DIR / "google_language_picker.txt"
+    content = fixture_path.read_text(encoding="utf-8")
+    headline = "Notícias"
+    
+    match = apply_content_heuristics(headline, content)
+    assert match is not None, "Language picker content should be rejected"
+    assert match.hint == "non_incident"
+    assert match.rule == "google_language_picker"
+
+
+def test_heuristic_rejects_google_consent_page():
+    """Google consent/cookie page should be rejected (issue #208)."""
+    fixture_path = FIXTURES_DIR / "google_consent_page.txt"
+    content = fixture_path.read_text(encoding="utf-8")
+    headline = ""
+    
+    match = apply_content_heuristics(headline, content)
+    assert match is not None, "Consent page content should be rejected"
+    assert match.hint == "non_incident"
+    assert match.rule == "google_consent_page"
+
+
+def test_heuristic_passes_real_article_with_language_name():
+    """Real homicide article mentioning 'English' or language names should pass (issue #208)."""
+    headline = "Homem é morto a tiros em operação no Rio"
+    content = (
+        "Um homem identificado como John English foi morto a tiros durante "
+        "uma operação policial na favela do Alemão. A vítima tinha "
+        "passagens pela polícia e era procurado por homicídio. "
+        "O caso foi registrado na delegacia local e a perícia está no local."
+    )
+    
+    # Article mentions "English" as a surname but should still pass
+    match = apply_content_heuristics(headline, content)
+    assert match is None, "Real article with language name should not be rejected"
+
+
+def test_heuristic_passes_article_mentioning_portuguese():
+    """Real article mentioning Portuguese language in context should pass (issue #208)."""
+    headline = "Tradutor é assassinado em São Paulo"
+    content = (
+        "Um tradutor que trabalhava com textos em português e inglês "
+        "foi assassinado a facadas em seu apartamento em São Paulo. "
+        "A polícia investiga o crime que teria ocorrido durante a madrugada. "
+        "Vizinhos relataram ter ouvido gritos por volta das 3h da manhã."
+    )
+    
+    # Article mentions Portuguese but is clearly a homicide report
+    match = apply_content_heuristics(headline, content)
+    assert match is None, "Real article mentioning language should not be rejected"

--- a/backend/tests/test_content_filters.py
+++ b/backend/tests/test_content_filters.py
@@ -98,6 +98,21 @@ def test_heuristic_rejects_google_language_picker():
     assert match.rule == "google_language_picker"
 
 
+def test_heuristic_rejects_production_google_language_picker():
+    """Production Google language picker (no space in PortuguêsBrasil) must be rejected (issue #208)."""
+    # Exact production body from 32 sources: 3441 chars starting with this line
+    content = (
+        "PortuguêsBrasil - Deutsch - English - Español - Français - Italiano - "
+        "Suomi - Todos os idiomas - Afrikaans - Bahasa Indonesia"
+    )
+    headline = ""
+    
+    match = apply_content_heuristics(headline, content)
+    assert match is not None, "Production language picker must be rejected"
+    assert match.hint == "non_incident"
+    assert match.rule == "google_language_picker", f"Expected google_language_picker but got {match.rule if match else None}"
+
+
 def test_heuristic_rejects_google_consent_page():
     """Google consent/cookie page should be rejected (issue #208)."""
     fixture_path = FIXTURES_DIR / "google_consent_page.txt"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 📝 Descrição

Implementa o portão de conteúdo para descartar páginas de escolha de idioma e consentimento do Google antes da extração. Qualquer corpo salvo que seja uma página de seleção de idioma do Google ou uma página de consentimento é descartado, mesmo se algum texto foi extraído.

A implementação adiciona padrões heurísticos ao `apply_content_heuristics` em `content_filters.py` que detectam:
- Páginas de escolha de idioma do Google (sequência "Português Brasil / Deutsch / English" ou "PortuguêsBrasil" sem espaço)
- Páginas de consentimento ("Before you continue")

**⚠️ Fix Importante (PM Review):** A versão inicial tinha um bug crítico - o regex exigia espaço em "Português Brasil", mas os 32 corpos de produção têm "PortuguêsBrasil" (sem espaço). O regex foi corrigido para `\s*` (espaço opcional) e um teste com o formato exato de produção foi adicionado.

## 🔗 Issue Relacionada

Fixes #208 (parte do spec #206)

## 🏷️ Tipo de Mudança

- [x] 🐛 Bug fix (mudança que corrige um problema)
- [ ] ✨ Nova feature (mudança que adiciona funcionalidade)
- [ ] 💥 Breaking change (fix ou feature que causaria quebra de funcionalidade existente)
- [ ] 📚 Documentação (mudança apenas em documentação)
- [ ] 🎨 Estilo (formatação, ponto e vírgula, etc - sem mudança de código)
- [ ] ♻️ Refatoração (mudança de código sem alterar funcionalidade)
- [ ] ⚡ Performance (mudança que melhora performance)
- [x] ✅ Testes (adição ou correção de testes)
- [ ] 🔧 Chore (atualizações de build, CI, etc)

## 🧪 Como Foi Testado?

- [x] Testes unitários
- [ ] Testes de integração
- [ ] Testes manuais
- [x] Testado em desenvolvimento local
- [ ] Testado com Docker

**Testes adicionados:**
- `test_heuristic_rejects_google_language_picker` - Verifica que páginas de escolha de idioma (com espaço) são rejeitadas
- **`test_heuristic_rejects_production_google_language_picker`** - **Verifica que o formato exato de produção (sem espaço em "PortuguêsBrasil") é rejeitado pela regra google_language_picker**
- `test_heuristic_rejects_google_consent_page` - Verifica que páginas de consentimento são rejeitadas
- `test_heuristic_passes_real_article_with_language_name` - Verifica que artigos reais mencionando "English" como sobrenome ainda passam
- `test_heuristic_passes_article_mentioning_portuguese` - Verifica que artigos reais mencionando idiomas em contexto ainda passam

**Fixtures criados:**
- `backend/tests/fixtures/google_language_picker.txt` - Lista de idiomas (~4904 caracteres) começando com "Português Brasil / Deutsch / English"
- `backend/tests/fixtures/google_consent_page.txt` - Página de consentimento com "Before you continue"

**Ambiente de teste:**
- OS: Linux
- Python: 3.12.3
- pytest: 9.1.1

## ✅ Checklist

- [x] Meu código segue o guia de estilo do projeto
- [x] Realizei uma auto-revisão do meu código
- [x] Comentei meu código em áreas complexas
- [x] Atualizei a documentação correspondente
- [x] Minhas mudanças não geram novos warnings
- [x] Adicionei testes que provam que meu fix/feature funciona
- [x] Testes unitários novos e existentes passam localmente
- [x] Quaisquer mudanças dependentes foram mergeadas
- [ ] Atualizei o CHANGELOG (se aplicável)

## 📚 Documentação

- [ ] README.md
- [ ] CONTRIBUTING.md
- [x] Docstrings/comentários no código
- [ ] API documentation
- [ ] Outro: 

## 💬 Notas Adicionais

**Implementação:**
- Pattern de language picker: `Português\s*Brasil.*Deutsch.*English` (aceita espaço opcional)
- Pattern de consent: `before\s+you\s+continue` (removido "todos os idiomas" para evitar captura incorreta)
- Os novos padrões foram adicionados à tupla `_NON_INCIDENT_PATTERNS` no arquivo `content_filters.py`
- A função `apply_content_heuristics` já era chamada pelo fluxo de download, então a integração é automática
- Os testes de integração existentes (`test_download_content_gate.py`) continuam passando

**Correção Crítica (PM Review):**
- **Problema:** Regex original `Português\s+Brasil` (espaço obrigatório) não capturaria os 32 corpos de produção que têm `PortuguêsBrasil` (sem espaço)
- **Solução:** Alterado para `Português\s*Brasil` (espaço opcional) 
- **Teste de produção:** Adicionado teste com a primeira linha exata dos corpos de produção: "PortuguêsBrasil - Deutsch - English - Español - Français - Italiano - Suomi - Todos os idiomas - Afrikaans"
- **Verificação TDD:** Teste falha com regex antigo (capturado por google_consent_page via "Todos os idiomas"), passa com novo regex (capturado por google_language_picker)
- **"Todos os idiomas":** Removido da regra de consent para garantir que produção seja capturada pela regra correta (google_language_picker)

**Testes pré-existentes com falha:**
- Nota: Dois testes pré-existentes (`test_heuristic_rejects_foreign_earthquake` e `test_heuristic_still_rejects_venezuela_earthquake`) já estavam falhando no branch `develop` antes desta mudança. Estes testes não estão relacionados a esta implementação.

**Conformidade com os critérios de aceitação:**
- ✅ O texto de escolha de idioma de produção (PortuguêsBrasil) é descartado pelo portão de conteúdo
- ✅ Corpos de consentimento / "Before you continue" são descartados
- ✅ Um corpo de jornal real ainda passa
- ✅ Testes usam fixtures, não Google ao vivo (sem rede para news.google.com)
- ✅ Abordagem TDD: testes escritos primeiro (falharam), depois implementação (passaram)
- ✅ Teste de produção adicionado com formato exato (sem espaço)

**Escopo:**
- Este PR implementa apenas o issue #208 (content-gate discard)
- Não implementa #207 (unwrap / do-not-fetch-Google)
- Não implementa #204 (first-date-in-text)
- Não altera Accept-Language
- Não reescreve UniqueEvents existentes
- Não toca em /estatisticas

---

**Por favor, certifique-se de que todos os itens do checklist foram completados antes de marcar o PR como pronto para revisão.**
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8f69d6a8-cf5e-4db5-9025-3cf9ae2ffeb4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8f69d6a8-cf5e-4db5-9025-3cf9ae2ffeb4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

