### PR TITLE
Cherry-pick: Google language page must not become an article (207/208/209)

### DIFF
--- a/backend/app/services/content_filters.py
+++ b/backend/app/services/content_filters.py
@@ -106,6 +106,7 @@ _FOREIGN_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
 )
 
 # Suicides and animal cruelty — out of scope even when violent.
+# Google interstitial pages (language picker, consent) — issue #208.
 _NON_INCIDENT_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
     (
         "suicide",
@@ -119,6 +120,20 @@ _NON_INCIDENT_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
         re.compile(
             r"\b(cachorro|gato|animal|cavalo).{0,40}\b(morto|mortos|envenenado|maltratado)\b",
             re.IGNORECASE,
+        ),
+    ),
+    (
+        "google_consent_page",
+        re.compile(
+            r"\bbefore\s+you\s+continue\b",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        "google_language_picker",
+        re.compile(
+            r"Português\s*Brasil.*Deutsch.*English",
+            re.IGNORECASE | re.DOTALL,
         ),
     ),
 )

--- a/backend/app/services/download.py
+++ b/backend/app/services/download.py
@@ -72,28 +72,49 @@ def extract_content_and_metadata(html: str) -> tuple[str | None, dict | None]:
     return content, metadata
 
 
-async def _fetch_html(url: str) -> tuple[int, str]:
+def get_accept_language_for_country(country: str | None) -> str:
+    """Map country code to Accept-Language header (issue #209).
+
+    Args:
+        country: ISO 3166-1 alpha-2 country code (BR, AR, CL, etc.)
+
+    Returns:
+        Accept-Language header value
+
+    Language intents (issues #129, #164, #209):
+    - BR → Brazilian Portuguese
+    - AR, BO, CL, CO, EC, PY, PE, UY, VE → Spanish (es-419)
+    - GY → English
+    - SR → Dutch
+    - Default → Brazilian Portuguese
+    """
+    if not country:
+        return "pt-BR,pt;q=0.9,en;q=0.8"
+
+    spanish_countries = {"AR", "BO", "CL", "CO", "EC", "PY", "PE", "UY", "VE"}
+    if country in spanish_countries:
+        return "es,es-419;q=0.9,pt-BR;q=0.8,pt;q=0.7,en;q=0.6"
+    elif country == "GY":
+        return "en,en-US;q=0.9,es;q=0.8,pt;q=0.7"
+    elif country == "SR":
+        return "nl,nl-NL;q=0.9,en;q=0.8,pt;q=0.7"
+    else:
+        return "pt-BR,pt;q=0.9,en;q=0.8"
+
+
+async def _fetch_html(url: str, country: str | None = None) -> tuple[int, str]:
     """Fetch a URL with a browser-like client.
+
+    Args:
+        url: Target URL to fetch
+        country: ISO 3166-1 alpha-2 country code for Accept-Language (issue #209)
 
     Returns (status_code, html). Raises ``httpx.HTTPStatusError`` for non-2xx
     responses and other ``httpx`` errors for transport failures, so the caller
     can classify the reason.
     """
     settings = get_settings()
-    # Country-aware Accept-Language header (issue #129, #164)
-    # Default to Brazilian Portuguese
-    accept_language = "pt-BR,pt;q=0.9,en;q=0.8"
-    
-    # Spanish-speaking SA countries (.ar, .cl, .co, .ec, .py, .pe, .uy, .ve, .bo)
-    spanish_cctlds = [".ar", ".cl", ".co", ".ec", ".py", ".pe", ".uy", ".ve", ".bo"]
-    if any(f"{tld}/" in url or url.endswith(tld) for tld in spanish_cctlds):
-        accept_language = "es,es-419;q=0.9,pt-BR;q=0.8,pt;q=0.7,en;q=0.6"
-    # Guyana (.gy) - English
-    elif ".gy/" in url or url.endswith(".gy"):
-        accept_language = "en,en-US;q=0.9,es;q=0.8,pt;q=0.7"
-    # Suriname (.sr) - Dutch
-    elif ".sr/" in url or url.endswith(".sr"):
-        accept_language = "nl,nl-NL;q=0.9,en;q=0.8,pt;q=0.7"
+    accept_language = get_accept_language_for_country(country)
 
     headers = {
         "User-Agent": settings.download_user_agent,
@@ -251,12 +272,12 @@ async def download_source_content(source_id: int) -> DownloadOutcome:
     import time
     from sqlalchemy import text
 
-    # Step 1: read the target URL in a short-lived session, then release the
-    # connection so we don't hold it during the (slow) network fetch.
+    # Step 1: read the target URL and country in a short-lived session, then release
+    # the connection so we don't hold it during the (slow) network fetch.
     async with async_session_maker() as session:
         result = await session.execute(
             text(
-                "SELECT resolved_url, google_news_url, headline "
+                "SELECT resolved_url, google_news_url, headline, country "
                 "FROM source_google_news WHERE id = :id"
             ),
             {"id": source_id},
@@ -270,6 +291,7 @@ async def download_source_content(source_id: int) -> DownloadOutcome:
         resolved_url = row[0]
         google_news_url = row[1]
         headline = row[2]
+        country = row[3]
     
     # Issue #171 & #207: If resolved_url is NULL but google_news_url exists,
     # try to resolve it now (handles decoder failures during ingest)
@@ -375,7 +397,7 @@ async def download_source_content(source_id: int) -> DownloadOutcome:
     # step holds a DB connection.
     started = time.monotonic()
     try:
-        status_code, html = await _fetch_html(target_url)
+        status_code, html = await _fetch_html(target_url, country)
     except Exception as e:
         duration_ms = int((time.monotonic() - started) * 1000)
         reason = diagnostics.classify_download_exception(e)

--- a/backend/app/services/download.py
+++ b/backend/app/services/download.py
@@ -271,7 +271,7 @@ async def download_source_content(source_id: int) -> DownloadOutcome:
         google_news_url = row[1]
         headline = row[2]
     
-    # Issue #171: If resolved_url is NULL but google_news_url exists,
+    # Issue #171 & #207: If resolved_url is NULL but google_news_url exists,
     # try to resolve it now (handles decoder failures during ingest)
     if not resolved_url and google_news_url:
         logger.info(f"Source {source_id}: resolved_url is NULL, attempting late resolution")
@@ -288,10 +288,36 @@ async def download_source_content(source_id: int) -> DownloadOutcome:
                 )
                 await session.commit()
         else:
-            logger.warning(f"Source {source_id}: late resolution failed, will use google_news_url")
+            # Issue #207: If late resolution also failed, do NOT fetch from Google News URL.
+            # Mark as failed instead of downloading the Google language picker page.
+            logger.warning(
+                f"Source {source_id}: late resolution failed, cannot download from Google News URL"
+            )
+            async with async_session_maker() as session:
+                await session.execute(
+                    text("""
+                        UPDATE source_google_news 
+                        SET status = 'failed_in_download', updated_at = CURRENT_TIMESTAMP
+                        WHERE id = :id
+                    """),
+                    {"id": source_id}
+                )
+                await session.commit()
+            await diagnostics.record_attempt(
+                stage=diagnostics.STAGE_DOWNLOAD,
+                outcome=diagnostics.OUTCOME_FAILURE,
+                source_google_news_id=source_id,
+                failure_reason=diagnostics.NO_URL,
+                failure_detail="Unwrap failed: cannot resolve Google News URL to newspaper URL",
+                http_status=None,
+                url_domain=None,
+                duration_ms=0,
+                attempt_number=await diagnostics.count_attempts(source_id, diagnostics.STAGE_DOWNLOAD) + 1,
+            )
+            return DownloadOutcome.failed
     
-    # Use resolved URL if available, otherwise fall back to Google News URL
-    target_url = resolved_url or google_news_url
+    # Use resolved URL (newspaper URL only, never Google News URL)
+    target_url = resolved_url
     
     if not target_url:
         async with async_session_maker() as session:

--- a/backend/tests/fixtures/google_consent_page.txt
+++ b/backend/tests/fixtures/google_consent_page.txt
@@ -1,0 +1,20 @@
+Before you continue to Google News
+
+We use cookies and data to:
+• Deliver and maintain Google services
+• Track outages and protect against spam, fraud, and abuse
+• Measure audience engagement and site statistics to understand how our services are used and enhance the quality of those services
+
+If you choose to "Accept all," we will also use cookies and data to:
+• Develop and improve new services
+• Deliver and measure the effectiveness of ads
+• Show personalized content, depending on your settings
+• Show personalized ads, depending on your settings
+
+If you choose to "Reject all," we will not use cookies for these additional purposes.
+
+Non-personalized content is influenced by things like the content you're currently viewing, activity in your active Search session, and your location. Non-personalized ads are influenced by the content you're currently viewing and your general location. Personalized content and ads can also include more relevant results, recommendations, and tailored ads based on past activity from this browser, like previous Google searches. We also use cookies and data to tailor the experience to be age-appropriate, if relevant.
+
+Select "More options" to see additional information, including details about managing your privacy settings. You can also visit g.co/privacytools at any time.
+
+Todos os idiomas

--- a/backend/tests/fixtures/google_language_picker.txt
+++ b/backend/tests/fixtures/google_language_picker.txt
@@ -1,0 +1,274 @@
+Português Brasil
+Deutsch
+English
+Español Latinoamérica
+Français
+Italiano
+Nederlands
+Polski
+Русский
+Türkçe
+العربية
+中文（简体）
+中文（繁體）
+日本語
+한국어
+Afrikaans
+Bahasa Indonesia
+Bahasa Melayu
+Català
+Čeština
+Dansk
+Eesti
+English UK
+English US
+Español España
+Euskara
+Filipino
+Galego
+Hrvatski
+Íslenska
+Kiswahili
+Latviešu
+Lietuvių
+Magyar
+Norsk
+Română
+Slovenčina
+Slovenščina
+Srpski
+Suomi
+Svenska
+Tiếng Việt
+Українська
+עברית
+हिन्दी
+ไทย
+Ελληνικά
+Български
+Македонски
+Монгол
+অসমীয়া
+বাংলা
+ગુજરાતી
+ಕನ್ನಡ
+മലയാളം
+मराठी
+ଓଡ଼ିଆ
+ਪੰਜਾਬੀ
+தமிழ்
+తెలుగు
+اردو
+Azərbaycan
+Bosanski
+Español US
+Gaeilge
+Latviešu valoda
+Lietuvių kalba
+Lëtzebuergesch
+Malti
+Norsk bokmål
+O'zbek
+Qaraqalpaqsha
+Qırımtatarca
+Slovenský jazyk
+Shqip
+አማርኛ
+Հայերեն
+ქართული
+Қазақ тілі
+Кыргызча
+ភាសាខ្មែរ
+လူမျိုး
+नेपाली
+සිංහල
+ትግርኛ
+Кыргыз тили
+Монгол хэл
+ລາວ
+မြန်မာ
+ਪੰਜਾਬੀ (ਭਾਰਤ)
+پښتو
+فارسی
+සිංහල (ශ්‍රී ලංකා)
+Afaan Oromoo
+አማርኛ (ኢትዮጵያ)
+ትግርኛ (ኤርትራ)
+Hausa
+Igbo
+Kiswahili (Kenya)
+Yorùbá
+isiXhosa
+isiZulu
+Sesotho
+Setswana
+Español Argentina
+Español Bolivia
+Español Chile
+Español Colombia
+Español Costa Rica
+Español Cuba
+Español Ecuador
+Español El Salvador
+Español Guatemala
+Español Honduras
+Español México
+Español Nicaragua
+Español Panamá
+Español Paraguay
+Español Perú
+Español Puerto Rico
+Español República Dominicana
+Español Uruguay
+Español Venezuela
+Français Belgique
+Français Canada
+Français France
+Français Luxembourg
+Français Suisse
+Português Portugal
+English Australia
+English Canada
+English India
+English Ireland
+English New Zealand
+English Singapore
+English South Africa
+Deutsch Deutschland
+Deutsch Österreich
+Deutsch Schweiz
+Italiano Italia
+Italiano Svizzera
+Nederlands België
+Nederlands Nederland
+Svenska Sverige
+Norsk Norge
+Dansk Danmark
+Suomi Suomi
+Polski Polska
+Čeština Česká republika
+Slovenčina Slovensko
+Magyar Magyarország
+Română România
+Български България
+Ελληνικά Ελλάδα
+Українська Україна
+Türkçe Türkiye
+עברית ישראל
+العربية السعودية
+العربية الإمارات
+العربية مصر
+فارسی ایران
+हिन्दी भारत
+বাংলা বাংলাদেশ
+தமிழ் இந்தியா
+తెలుగు భారతదేశం
+ಕನ್ನಡ ಭಾರತ
+മലയാളം ഇന്ത്യ
+ไทย ประเทศไทย
+Tiếng Việt Việt Nam
+Bahasa Indonesia Indonesia
+Bahasa Melayu Malaysia
+Filipino Pilipinas
+中文（简体）中国
+中文（繁體）台灣
+中文（繁體）香港
+日本語 日本
+한국어 대한민국
+Català Espanya
+Euskara Espainia
+Galego España
+Bosanski Bosna i Hercegovina
+Hrvatski Hrvatska
+Српски Србија
+Slovenščina Slovenija
+Latviešu Latvija
+Lietuvių Lietuva
+Eesti Eesti
+Íslenska Ísland
+Gaeilge Éire
+Malti Malta
+Lëtzebuergesch Lëtzebuerg
+Română Moldova
+Azərbaycan Azərbaycan
+Қазақ тілі Қазақстан
+O'zbek O'zbekiston
+Кыргызча Кыргызстан
+Монгол Монгол улс
+አማርኛ ኢትዮጵያ
+Kiswahili Tanzania
+Afrikaans Suid-Afrika
+isiZulu iNingizimu Afrika
+Español Andorra
+Français Monaco
+Italiano San Marino
+Español Guinea Ecuatorial
+Português Angola
+Português Cabo Verde
+Português Guiné-Bissau
+Português Moçambique
+Português São Tomé e Príncipe
+Português Timor-Leste
+English Bahamas
+English Barbados
+English Belize
+English Botswana
+English Cameroon
+English Fiji
+English Gambia
+English Ghana
+English Guyana
+English Jamaica
+English Kenya
+English Kiribati
+English Lesotho
+English Liberia
+English Malawi
+English Malta
+English Mauritius
+English Namibia
+English Nauru
+English Nigeria
+English Pakistan
+English Papua New Guinea
+English Philippines
+English Rwanda
+English Saint Lucia
+English Samoa
+English Seychelles
+English Sierra Leone
+English Solomon Islands
+English Sudan
+English Eswatini
+English Tanzania
+English Tonga
+English Trinidad and Tobago
+English Tuvalu
+English Uganda
+English Vanuatu
+English Zambia
+English Zimbabwe
+Français Bénin
+Français Burkina Faso
+Français Burundi
+Français Cameroun
+Français Centrafrique
+Français Comores
+Français Congo
+Français Congo-Kinshasa
+Français Côte d'Ivoire
+Français Djibouti
+Français Gabon
+Français Guinée
+Français Haïti
+Français Madagascar
+Français Mali
+Français Mauritanie
+Français Maurice
+Français Niger
+Français Rwanda
+Français Sénégal
+Français Seychelles
+Français Tchad
+Français Togo
+Français Vanuatu

--- a/backend/tests/test_content_filters.py
+++ b/backend/tests/test_content_filters.py
@@ -1,6 +1,10 @@
 """Tests for post-download content heuristics (AQV-32)."""
 
+from pathlib import Path
+
 from app.services.content_filters import apply_content_heuristics
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
 
 
 def test_heuristic_rejects_cvli_aggregate():
@@ -80,3 +84,72 @@ def test_heuristic_still_rejects_venezuela_earthquake():
     assert match is not None
     assert match.hint == "foreign"
     assert match.rule == "foreign_earthquake"
+
+
+def test_heuristic_rejects_google_language_picker():
+    """Google language picker page should be rejected (issue #208)."""
+    fixture_path = FIXTURES_DIR / "google_language_picker.txt"
+    content = fixture_path.read_text(encoding="utf-8")
+    headline = "Notícias"
+    
+    match = apply_content_heuristics(headline, content)
+    assert match is not None, "Language picker content should be rejected"
+    assert match.hint == "non_incident"
+    assert match.rule == "google_language_picker"
+
+
+def test_heuristic_rejects_production_google_language_picker():
+    """Production Google language picker (no space in PortuguêsBrasil) must be rejected (issue #208)."""
+    # Exact production body from 32 sources: 3441 chars starting with this line
+    content = (
+        "PortuguêsBrasil - Deutsch - English - Español - Français - Italiano - "
+        "Suomi - Todos os idiomas - Afrikaans - Bahasa Indonesia"
+    )
+    headline = ""
+    
+    match = apply_content_heuristics(headline, content)
+    assert match is not None, "Production language picker must be rejected"
+    assert match.hint == "non_incident"
+    assert match.rule == "google_language_picker", f"Expected google_language_picker but got {match.rule if match else None}"
+
+
+def test_heuristic_rejects_google_consent_page():
+    """Google consent/cookie page should be rejected (issue #208)."""
+    fixture_path = FIXTURES_DIR / "google_consent_page.txt"
+    content = fixture_path.read_text(encoding="utf-8")
+    headline = ""
+    
+    match = apply_content_heuristics(headline, content)
+    assert match is not None, "Consent page content should be rejected"
+    assert match.hint == "non_incident"
+    assert match.rule == "google_consent_page"
+
+
+def test_heuristic_passes_real_article_with_language_name():
+    """Real homicide article mentioning 'English' or language names should pass (issue #208)."""
+    headline = "Homem é morto a tiros em operação no Rio"
+    content = (
+        "Um homem identificado como John English foi morto a tiros durante "
+        "uma operação policial na favela do Alemão. A vítima tinha "
+        "passagens pela polícia e era procurado por homicídio. "
+        "O caso foi registrado na delegacia local e a perícia está no local."
+    )
+    
+    # Article mentions "English" as a surname but should still pass
+    match = apply_content_heuristics(headline, content)
+    assert match is None, "Real article with language name should not be rejected"
+
+
+def test_heuristic_passes_article_mentioning_portuguese():
+    """Real article mentioning Portuguese language in context should pass (issue #208)."""
+    headline = "Tradutor é assassinado em São Paulo"
+    content = (
+        "Um tradutor que trabalhava com textos em português e inglês "
+        "foi assassinado a facadas em seu apartamento em São Paulo. "
+        "A polícia investiga o crime que teria ocorrido durante a madrugada. "
+        "Vizinhos relataram ter ouvido gritos por volta das 3h da manhã."
+    )
+    
+    # Article mentions Portuguese but is clearly a homicide report
+    match = apply_content_heuristics(headline, content)
+    assert match is None, "Real article mentioning language should not be rejected"

--- a/backend/tests/test_download_null_resolved_url.py
+++ b/backend/tests/test_download_null_resolved_url.py
@@ -113,7 +113,10 @@ async def test_download_processes_null_resolved_url_with_late_resolution_success
 @pytest.mark.asyncio
 async def test_download_processes_null_resolved_url_with_late_resolution_failure(test_db):
     """
-    Test that sources with NULL resolved_url are still processed when late resolution fails.
+    Test that sources with NULL resolved_url are NOT downloaded when late resolution fails.
+    
+    Issue #207: When unwrap fails both at ingest and at download time, do NOT fetch
+    from the Google News URL. Mark the source as failed instead.
     
     When a source has:
     - status = ready_for_download
@@ -121,8 +124,8 @@ async def test_download_processes_null_resolved_url_with_late_resolution_failure
     - google_news_url present
     
     And late resolution ALSO fails (returns None), the source should:
-    - Still be processed (processed==1) via fallback to google_news_url
-    - NOT skip the source
+    - Be processed but marked FAILED (not downloaded from Google News URL)
+    - NOT reach ready_for_extraction status
     """
     source = SourceGoogleNews(
         google_news_id="test-null-resolved-failure",
@@ -138,32 +141,33 @@ async def test_download_processes_null_resolved_url_with_late_resolution_failure
     await test_db.refresh(source)
     
     maker = _TestSessionMaker(test_db)
-    html = "<html><body>Dois mortos em tiroteio.</body></html>"
-    content = "Dois mortos em tiroteio."
+    mock_fetch = AsyncMock()
     
     with (
         patch("app.services.download.async_session_maker", maker),
         patch("app.services.diagnostics.async_session_maker", maker),
-        patch("app.services.ingestion.resolve_google_news_url", return_value=None) as mock_resolve,  # Late resolution also fails
-        patch("app.services.download._fetch_html", new=AsyncMock(return_value=(200, html))),
-        patch("app.services.download.extract_content_and_metadata", return_value=(content, None)),
-        patch("app.services.download.classify_article_content", new=AsyncMock()),
-        patch("app.services.download.passes_content_gate", return_value=True),
+        patch("app.services.ingestion.resolve_google_news_url", return_value=None),  # Late resolution also fails
+        patch("app.services.download._fetch_html", new=mock_fetch),  # Should NOT be called
         patch("app.services.diagnostics.record_attempt", new=AsyncMock()),
     ):
         result = await download_classified_sources(limit=10)
     
-    # Should still process 1 source (fallback to google_news_url)
-    assert result["processed"] == 1, (
-        f"Expected 1 processed via fallback to google_news_url, got {result['processed']}"
-    )
-    assert result["successful"] == 1, f"Expected 1 successful, got {result['successful']}"
+    # Should be processed but failed (NOT downloaded from Google News URL)
+    assert result["processed"] == 1, f"Expected 1 processed, got {result['processed']}"
+    assert result["successful"] == 0, f"Expected 0 successful, got {result['successful']}"
+    assert result["failed"] == 1, f"Expected 1 failed, got {result['failed']}"
     
-    # Verify resolved_url is still NULL (late resolution failed)
+    # HTTP fetch should NOT have been called
+    mock_fetch.assert_not_called()
+    
+    # Verify source is marked failed and resolved_url is still NULL
     await test_db.refresh(source)
     assert source.resolved_url is None, (
         f"Expected resolved_url to remain NULL when late resolution fails, "
         f"but got {source.resolved_url}"
+    )
+    assert source.status == SourceStatus.failed_in_download, (
+        f"Expected status failed_in_download, got {source.status}"
     )
 
 

--- a/backend/tests/test_issue_207_block_google_downloads.py
+++ b/backend/tests/test_issue_207_block_google_downloads.py
@@ -1,0 +1,292 @@
+"""Test issue #207: Block downloads from Google News URLs when unwrap fails.
+
+When unwrap cannot produce a newspaper URL (both at ingest and at download),
+the source must not be fetched from the Google News URL. It stays failed or waiting.
+Extract never runs on a Google page. Late unwrap still allowed if it succeeds.
+
+Fixtures only - no live Google calls.
+"""
+
+from unittest.mock import AsyncMock, patch, call
+
+import pytest
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlmodel import SQLModel
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.models.source_google_news import SourceGoogleNews, SourceStatus
+from app.services.download import download_classified_sources, download_source_content
+
+
+class _TestSessionMaker:
+    """Test session maker for mocking."""
+    
+    def __init__(self, session):
+        self._session = session
+    
+    def __call__(self):
+        return self
+    
+    async def __aenter__(self):
+        return self._session
+    
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+@pytest.fixture
+async def test_db():
+    """Create an in-memory test database."""
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        echo=False,
+        future=True,
+    )
+    
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    
+    async with AsyncSession(engine) as session:
+        yield session
+    
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_no_download_from_google_when_unwrap_fails(test_db):
+    """
+    Acceptance 1: A source with empty newspaper URL and only a Google News URL
+    is not downloaded from news.google.com.
+    
+    When a source has:
+    - status = ready_for_download
+    - resolved_url = NULL (initial unwrap failed)
+    - google_news_url = a news.google.com URL
+    
+    And late unwrap also fails (returns None), the source should:
+    - NOT fetch HTTP from the Google News URL
+    - Be marked as failed (not extracted)
+    - NOT reach status ready_for_extraction
+    """
+    source = SourceGoogleNews(
+        google_news_id="test-unwrap-fails",
+        google_news_url="https://news.google.com/articles/CBMabcdef",
+        resolved_url=None,  # Initial unwrap failed
+        headline="Homem é morto em tiroteio",
+        status=SourceStatus.ready_for_download,
+        is_violent_death=True,
+    )
+    
+    test_db.add(source)
+    await test_db.commit()
+    await test_db.refresh(source)
+    
+    maker = _TestSessionMaker(test_db)
+    
+    mock_fetch = AsyncMock()
+    
+    with (
+        patch("app.services.download.async_session_maker", maker),
+        patch("app.services.diagnostics.async_session_maker", maker),
+        # Late unwrap also fails
+        patch("app.services.ingestion.resolve_google_news_url", return_value=None),
+        # HTTP fetch should NOT be called
+        patch("app.services.download._fetch_html", new=mock_fetch),
+        patch("app.services.diagnostics.record_attempt", new=AsyncMock()),
+    ):
+        result = await download_classified_sources(limit=10)
+    
+    # Should process but not succeed
+    assert result["processed"] == 1, f"Expected 1 processed, got {result['processed']}"
+    assert result["successful"] == 0, f"Expected 0 successful, got {result['successful']}"
+    assert result["failed"] == 1, f"Expected 1 failed, got {result['failed']}"
+    
+    # HTTP fetch should NOT have been called with the Google News URL
+    mock_fetch.assert_not_called()
+    
+    # Source should be marked failed, not ready_for_extraction
+    await test_db.refresh(source)
+    assert source.status == SourceStatus.failed_in_download, (
+        f"Expected status failed_in_download, got {source.status}"
+    )
+    assert source.content is None, "Content should not be set when download blocked"
+
+
+@pytest.mark.asyncio
+async def test_late_unwrap_success_downloads_from_newspaper(test_db):
+    """
+    Acceptance 2: Late unwrap still runs once; success persists the newspaper URL
+    and download proceeds as today.
+    
+    When a source has:
+    - status = ready_for_download
+    - resolved_url = NULL (initial unwrap failed)
+    - google_news_url present
+    
+    And late unwrap succeeds, the source should:
+    - Have the newspaper URL persisted to resolved_url
+    - Download from the newspaper URL (NOT Google)
+    - Reach ready_for_extraction status
+    """
+    source = SourceGoogleNews(
+        google_news_id="test-late-unwrap-success",
+        google_news_url="https://news.google.com/articles/CBMxyz789",
+        resolved_url=None,  # Initial unwrap failed
+        headline="Tiroteio deixa dois mortos",
+        status=SourceStatus.ready_for_download,
+        is_violent_death=True,
+    )
+    
+    test_db.add(source)
+    await test_db.commit()
+    await test_db.refresh(source)
+    
+    maker = _TestSessionMaker(test_db)
+    newspaper_url = "https://g1.globo.com/rj/rio-de-janeiro/noticia/2024/tiroteio.html"
+    html = "<html><body>Tiroteio deixa dois mortos na Zona Norte.</body></html>"
+    content = "Tiroteio deixa dois mortos na Zona Norte."
+    
+    mock_fetch = AsyncMock(return_value=(200, html))
+    
+    with (
+        patch("app.services.download.async_session_maker", maker),
+        patch("app.services.diagnostics.async_session_maker", maker),
+        # Late unwrap succeeds
+        patch("app.services.ingestion.resolve_google_news_url", return_value=newspaper_url),
+        # HTTP fetch called with newspaper URL
+        patch("app.services.download._fetch_html", new=mock_fetch),
+        patch("app.services.download.extract_content_and_metadata", return_value=(content, None)),
+        patch("app.services.download.classify_article_content", new=AsyncMock()),
+        patch("app.services.download.passes_content_gate", return_value=True),
+        patch("app.services.diagnostics.record_attempt", new=AsyncMock()),
+    ):
+        result = await download_classified_sources(limit=10)
+    
+    # Should succeed
+    assert result["processed"] == 1
+    assert result["successful"] == 1
+    assert result["failed"] == 0
+    
+    # HTTP fetch should be called with the newspaper URL, NOT the Google URL
+    mock_fetch.assert_called_once()
+    called_url = mock_fetch.call_args[0][0]
+    assert called_url == newspaper_url, (
+        f"Expected fetch to be called with newspaper URL {newspaper_url}, "
+        f"but was called with {called_url}"
+    )
+    assert "news.google.com" not in called_url, "Should not fetch from Google News URL"
+    
+    # Newspaper URL should be persisted
+    await test_db.refresh(source)
+    assert source.resolved_url == newspaper_url, (
+        f"Expected resolved_url to be persisted as {newspaper_url}, "
+        f"got {source.resolved_url}"
+    )
+    assert source.status == SourceStatus.ready_for_extraction
+    assert source.content == content
+
+
+@pytest.mark.asyncio
+async def test_existing_newspaper_url_unchanged(test_db):
+    """
+    Acceptance 3: Existing rows that already have a newspaper URL are unchanged.
+    
+    This is a regression test. Sources that have resolved_url already set
+    should continue to work normally (Chile/Brazil).
+    """
+    newspaper_url = "https://g1.globo.com/rj/rio-de-janeiro/noticia/2024/article.html"
+    source = SourceGoogleNews(
+        google_news_id="test-existing-url",
+        google_news_url="https://news.google.com/articles/CBMabc123",
+        resolved_url=newspaper_url,  # Already has newspaper URL
+        headline="Operação policial termina em confronto",
+        status=SourceStatus.ready_for_download,
+        is_violent_death=True,
+    )
+    
+    test_db.add(source)
+    await test_db.commit()
+    await test_db.refresh(source)
+    
+    maker = _TestSessionMaker(test_db)
+    html = "<html><body>Operação policial termina em confronto.</body></html>"
+    content = "Operação policial termina em confronto."
+    
+    mock_fetch = AsyncMock(return_value=(200, html))
+    mock_resolve = AsyncMock()
+    
+    with (
+        patch("app.services.download.async_session_maker", maker),
+        patch("app.services.diagnostics.async_session_maker", maker),
+        # Late unwrap should NOT be called (already have resolved_url)
+        patch("app.services.ingestion.resolve_google_news_url", new=mock_resolve),
+        patch("app.services.download._fetch_html", new=mock_fetch),
+        patch("app.services.download.extract_content_and_metadata", return_value=(content, None)),
+        patch("app.services.download.classify_article_content", new=AsyncMock()),
+        patch("app.services.download.passes_content_gate", return_value=True),
+        patch("app.services.diagnostics.record_attempt", new=AsyncMock()),
+    ):
+        result = await download_classified_sources(limit=10)
+    
+    # Should succeed normally
+    assert result["processed"] == 1
+    assert result["successful"] == 1
+    assert result["failed"] == 0
+    
+    # Late unwrap should NOT be called (already have URL)
+    mock_resolve.assert_not_called()
+    
+    # Should fetch from the existing newspaper URL
+    mock_fetch.assert_called_once()
+    called_url = mock_fetch.call_args[0][0]
+    assert called_url == newspaper_url, (
+        f"Expected fetch with existing newspaper URL {newspaper_url}, "
+        f"got {called_url}"
+    )
+    
+    # URL should remain unchanged
+    await test_db.refresh(source)
+    assert source.resolved_url == newspaper_url
+    assert source.status == SourceStatus.ready_for_extraction
+
+
+@pytest.mark.asyncio
+async def test_no_urls_marks_failed(test_db):
+    """
+    Edge case: Source with no resolved_url AND no google_news_url
+    should be marked failed immediately.
+    """
+    source = SourceGoogleNews(
+        google_news_id="test-no-urls",
+        google_news_url="",  # Empty Google URL (NOT NULL constraint)
+        resolved_url=None,  # No newspaper URL
+        headline="Test article",
+        status=SourceStatus.ready_for_download,
+        is_violent_death=True,
+    )
+    
+    test_db.add(source)
+    await test_db.commit()
+    await test_db.refresh(source)
+    
+    maker = _TestSessionMaker(test_db)
+    mock_fetch = AsyncMock()
+    
+    with (
+        patch("app.services.download.async_session_maker", maker),
+        patch("app.services.diagnostics.async_session_maker", maker),
+        patch("app.services.download._fetch_html", new=mock_fetch),
+        patch("app.services.diagnostics.record_attempt", new=AsyncMock()),
+    ):
+        result = await download_classified_sources(limit=10)
+    
+    # Should be marked failed
+    assert result["processed"] == 1
+    assert result["failed"] == 1
+    
+    # No HTTP fetch
+    mock_fetch.assert_not_called()
+    
+    # Should be failed
+    await test_db.refresh(source)
+    assert source.status == SourceStatus.failed_in_download

--- a/backend/tests/test_issue_209_accept_language_by_country.py
+++ b/backend/tests/test_issue_209_accept_language_by_country.py
@@ -1,0 +1,529 @@
+"""Tests for Accept-Language by source country (issue #209).
+
+Accept-Language should follow source country, not URL TLD.
+When a URL has no country TLD (e.g., news.google.com), the language
+must come from the source's country field, not default to Brazilian Portuguese.
+
+Critical: Tests must verify the actual HTTP headers sent to httpx, not just
+the country argument. Mocking _fetch_html is insufficient to catch regressions
+where TLD sniffing is reintroduced inside _fetch_html.
+"""
+
+from unittest.mock import AsyncMock, patch, ANY, MagicMock
+import pytest
+
+from app.services.download import download_source_content, DownloadOutcome
+
+
+class _TestSessionMaker:
+    def __init__(self, session):
+        self._session = session
+
+    def __call__(self):
+        return self
+
+    async def __aenter__(self):
+        return self._session
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+@pytest.fixture
+def download_db(async_session):
+    maker = _TestSessionMaker(async_session)
+    with patch("app.services.download.async_session_maker", maker):
+        with patch("app.services.diagnostics.async_session_maker", maker):
+            yield async_session
+
+
+def _source(**kwargs):
+    from app.models.source_google_news import SourceGoogleNews, SourceStatus
+
+    defaults = {
+        "google_news_id": "test-id",
+        "google_news_url": "https://news.example/article",
+        "resolved_url": "https://news.example/article",
+        "headline": "Hombre muerto en tiroteo",
+        "status": SourceStatus.ready_for_download,
+        "country": "AR",  # Default to Argentina
+    }
+    defaults.update(kwargs)
+    return SourceGoogleNews(**defaults)
+
+
+@pytest.mark.asyncio
+async def test_argentina_news_google_com_sends_spanish_header_not_portuguese(download_db):
+    """
+    Integration test: Argentina source with news.google.com sends Spanish in HTTP header.
+    
+    Issue #209 acceptance: Verify the actual Accept-Language HTTP header sent to httpx
+    is Spanish (es,es-419), not Brazilian Portuguese (pt-BR), when source country is AR
+    and URL has no .ar ending.
+    
+    This test does NOT mock _fetch_html or get_accept_language_for_country.
+    It mocks httpx.AsyncClient to capture the headers actually sent.
+    
+    If someone reintroduces TLD sniffing inside _fetch_html, this test will fail.
+    """
+    from app.models.source_google_news import SourceStatus
+
+    source = _source(
+        google_news_id="ar-news-google",
+        resolved_url="https://news.google.com/articles/xyz123",
+        country="AR",
+        status=SourceStatus.ready_for_download,
+    )
+    download_db.add(source)
+    await download_db.commit()
+    await download_db.refresh(source)
+
+    html = "<html><body>Un hombre fue asesinado en Buenos Aires.</body></html>"
+    
+    # Mock httpx.AsyncClient to capture the headers
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.text = html
+    mock_response.raise_for_status = MagicMock()
+    
+    captured_headers = {}
+    
+    async def mock_get(url):
+        # Capture headers from the client's headers attribute
+        return mock_response
+    
+    mock_client = MagicMock()
+    mock_client.get = AsyncMock(side_effect=mock_get)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+    
+    def capture_client_init(follow_redirects, timeout, headers):
+        captured_headers.update(headers)
+        return mock_client
+    
+    with patch(
+        "app.services.download.httpx.AsyncClient",
+        side_effect=capture_client_init,
+    ), patch(
+        "app.services.download.extract_content_and_metadata",
+        return_value=("Un hombre fue asesinado.", None),
+    ), patch(
+        "app.services.download.classify_article_content",
+    ), patch(
+        "app.services.download.diagnostics.record_attempt",
+        new=AsyncMock(),
+    ):
+        outcome = await download_source_content(source.id)
+
+    # Assert the Accept-Language header is Spanish, not Brazilian Portuguese
+    assert "Accept-Language" in captured_headers
+    accept_lang = captured_headers["Accept-Language"]
+    
+    # Spanish must be primary (appears first)
+    assert accept_lang.startswith("es"), \
+        f"Expected Spanish (es) as primary language, got: {accept_lang}"
+    
+    # Brazilian Portuguese must NOT be primary
+    assert not accept_lang.startswith("pt-BR"), \
+        f"Brazilian Portuguese should not be primary for AR source, got: {accept_lang}"
+    
+    # Full string check
+    assert accept_lang == "es,es-419;q=0.9,pt-BR;q=0.8,pt;q=0.7,en;q=0.6", \
+        f"Expected Spanish Accept-Language, got: {accept_lang}"
+
+
+@pytest.mark.asyncio
+async def test_brazil_bare_com_url_sends_portuguese_header(download_db):
+    """
+    Integration test: Brazil source with bare .com URL sends Brazilian Portuguese header.
+    
+    Verifies that when country=BR and URL has no .br ending, the Accept-Language
+    header is Brazilian Portuguese (pt-BR), not Spanish.
+    
+    This test does NOT mock _fetch_html or get_accept_language_for_country.
+    """
+    from app.models.source_google_news import SourceStatus
+
+    source = _source(
+        google_news_id="br-bare-com",
+        resolved_url="https://example.com/article/12345",
+        country="BR",
+        status=SourceStatus.ready_for_download,
+    )
+    download_db.add(source)
+    await download_db.commit()
+    await download_db.refresh(source)
+
+    html = "<html><body>Um homem foi morto a tiros na cidade.</body></html>"
+    
+    # Mock httpx.AsyncClient to capture the headers
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.text = html
+    mock_response.raise_for_status = MagicMock()
+    
+    captured_headers = {}
+    
+    async def mock_get(url):
+        return mock_response
+    
+    mock_client = MagicMock()
+    mock_client.get = AsyncMock(side_effect=mock_get)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+    
+    def capture_client_init(follow_redirects, timeout, headers):
+        captured_headers.update(headers)
+        return mock_client
+    
+    with patch(
+        "app.services.download.httpx.AsyncClient",
+        side_effect=capture_client_init,
+    ), patch(
+        "app.services.download.extract_content_and_metadata",
+        return_value=("Um homem foi morto.", None),
+    ), patch(
+        "app.services.download.classify_article_content",
+    ), patch(
+        "app.services.download.diagnostics.record_attempt",
+        new=AsyncMock(),
+    ):
+        outcome = await download_source_content(source.id)
+
+    # Assert the Accept-Language header is Brazilian Portuguese
+    assert "Accept-Language" in captured_headers
+    accept_lang = captured_headers["Accept-Language"]
+    
+    # Brazilian Portuguese must be primary
+    assert accept_lang.startswith("pt-BR"), \
+        f"Expected Brazilian Portuguese (pt-BR) as primary, got: {accept_lang}"
+    
+    # Spanish must NOT be primary
+    assert not accept_lang.startswith("es"), \
+        f"Spanish should not be primary for BR source, got: {accept_lang}"
+    
+    # Full string check
+    assert accept_lang == "pt-BR,pt;q=0.9,en;q=0.8", \
+        f"Expected Brazilian Portuguese Accept-Language, got: {accept_lang}"
+
+
+@pytest.mark.asyncio
+async def test_argentina_source_with_google_news_url_sends_spanish(download_db):
+    """
+    Argentina source with news.google.com URL sends Spanish Accept-Language.
+    
+    Issue #209: A news.google.com URL has no .ar ending, so the old code
+    would default to Brazilian Portuguese. This test verifies the fix:
+    Accept-Language comes from country=AR, not from URL TLD.
+    """
+    source = _source(
+        google_news_id="ar-google-news",
+        resolved_url="https://news.google.com/articles/xyz",
+        country="AR",
+    )
+    download_db.add(source)
+    await download_db.commit()
+    await download_db.refresh(source)
+
+    html = "<html><body>article content</body></html>"
+    content = "Un hombre fue asesinado en la ciudad."
+
+    mock_fetch = AsyncMock(return_value=(200, html))
+    
+    with patch(
+        "app.services.download._fetch_html",
+        mock_fetch,
+    ), patch(
+        "app.services.download.extract_content_and_metadata",
+        return_value=(content, None),
+    ), patch(
+        "app.services.download.classify_article_content",
+    ), patch(
+        "app.services.download.diagnostics.record_attempt",
+        new=AsyncMock(),
+    ):
+        outcome = await download_source_content(source.id)
+
+    # Verify _fetch_html was called with AR country
+    mock_fetch.assert_called_once()
+    call_args = mock_fetch.call_args
+    assert call_args is not None, "_fetch_html should have been called"
+    # After fix, _fetch_html will accept (url, country) signature
+    assert len(call_args.args) == 2, "Should pass url and country"
+    assert call_args.args[1] == "AR", "Should pass source country to _fetch_html"
+
+
+@pytest.mark.asyncio
+async def test_brazil_source_sends_brazilian_portuguese(download_db):
+    """
+    Brazil source sends Brazilian Portuguese Accept-Language.
+    """
+    source = _source(
+        google_news_id="br-source",
+        resolved_url="https://g1.globo.com/article",
+        country="BR",
+    )
+    download_db.add(source)
+    await download_db.commit()
+    await download_db.refresh(source)
+
+    html = "<html><body>article content</body></html>"
+    content = "Um homem foi morto a tiros na cidade."
+
+    mock_fetch = AsyncMock(return_value=(200, html))
+    
+    with patch(
+        "app.services.download._fetch_html",
+        mock_fetch,
+    ), patch(
+        "app.services.download.extract_content_and_metadata",
+        return_value=(content, None),
+    ), patch(
+        "app.services.download.classify_article_content",
+    ), patch(
+        "app.services.download.diagnostics.record_attempt",
+        new=AsyncMock(),
+    ):
+        outcome = await download_source_content(source.id)
+
+    mock_fetch.assert_called_once()
+    call_args = mock_fetch.call_args
+    assert call_args is not None
+    assert len(call_args.args) == 2
+    assert call_args.args[1] == "BR"
+
+
+@pytest.mark.asyncio
+async def test_chile_source_sends_spanish(download_db):
+    """
+    Chile source sends Spanish Accept-Language.
+    """
+    source = _source(
+        google_news_id="cl-source",
+        resolved_url="https://example.com/article",
+        country="CL",
+    )
+    download_db.add(source)
+    await download_db.commit()
+    await download_db.refresh(source)
+
+    html = "<html><body>article content</body></html>"
+    content = "Hombre muerto en tiroteo."
+
+    mock_fetch = AsyncMock(return_value=(200, html))
+    
+    with patch(
+        "app.services.download._fetch_html",
+        mock_fetch,
+    ), patch(
+        "app.services.download.extract_content_and_metadata",
+        return_value=(content, None),
+    ), patch(
+        "app.services.download.classify_article_content",
+    ), patch(
+        "app.services.download.diagnostics.record_attempt",
+        new=AsyncMock(),
+    ):
+        outcome = await download_source_content(source.id)
+
+    mock_fetch.assert_called_once()
+    call_args = mock_fetch.call_args
+    assert call_args is not None
+    assert len(call_args.args) == 2
+    assert call_args.args[1] == "CL"
+
+
+@pytest.mark.asyncio
+async def test_guyana_source_sends_english(download_db):
+    """
+    Guyana source sends English Accept-Language.
+    """
+    source = _source(
+        google_news_id="gy-source",
+        resolved_url="https://example.com/article",
+        country="GY",
+    )
+    download_db.add(source)
+    await download_db.commit()
+    await download_db.refresh(source)
+
+    html = "<html><body>article content</body></html>"
+    content = "Man killed in shooting."
+
+    mock_fetch = AsyncMock(return_value=(200, html))
+    
+    with patch(
+        "app.services.download._fetch_html",
+        mock_fetch,
+    ), patch(
+        "app.services.download.extract_content_and_metadata",
+        return_value=(content, None),
+    ), patch(
+        "app.services.download.classify_article_content",
+    ), patch(
+        "app.services.download.diagnostics.record_attempt",
+        new=AsyncMock(),
+    ):
+        outcome = await download_source_content(source.id)
+
+    mock_fetch.assert_called_once()
+    call_args = mock_fetch.call_args
+    assert call_args is not None
+    assert len(call_args.args) == 2
+    assert call_args.args[1] == "GY"
+
+
+@pytest.mark.asyncio
+async def test_suriname_source_sends_dutch(download_db):
+    """
+    Suriname source sends Dutch Accept-Language.
+    """
+    source = _source(
+        google_news_id="sr-source",
+        resolved_url="https://example.com/article",
+        country="SR",
+    )
+    download_db.add(source)
+    await download_db.commit()
+    await download_db.refresh(source)
+
+    html = "<html><body>article content</body></html>"
+    content = "Man gedood in schietpartij."
+
+    mock_fetch = AsyncMock(return_value=(200, html))
+    
+    with patch(
+        "app.services.download._fetch_html",
+        mock_fetch,
+    ), patch(
+        "app.services.download.extract_content_and_metadata",
+        return_value=(content, None),
+    ), patch(
+        "app.services.download.classify_article_content",
+    ), patch(
+        "app.services.download.diagnostics.record_attempt",
+        new=AsyncMock(),
+    ):
+        outcome = await download_source_content(source.id)
+
+    mock_fetch.assert_called_once()
+    call_args = mock_fetch.call_args
+    assert call_args is not None
+    assert len(call_args.args) == 2
+    assert call_args.args[1] == "SR"
+
+
+@pytest.mark.asyncio
+async def test_bare_com_url_uses_source_country_not_default(download_db):
+    """
+    A URL with no country TLD (.com) uses source country, not default Portuguese.
+    
+    Issue #209: URLs without country endings (like news.google.com or example.com)
+    must NOT default to Brazilian Portuguese. Language comes from source country.
+    """
+    source = _source(
+        google_news_id="ar-bare-com",
+        resolved_url="https://example.com/article",
+        country="AR",  # Argentina source
+    )
+    download_db.add(source)
+    await download_db.commit()
+    await download_db.refresh(source)
+
+    html = "<html><body>article content</body></html>"
+    content = "Hombre muerto en Buenos Aires."
+
+    mock_fetch = AsyncMock(return_value=(200, html))
+    
+    with patch(
+        "app.services.download._fetch_html",
+        mock_fetch,
+    ), patch(
+        "app.services.download.extract_content_and_metadata",
+        return_value=(content, None),
+    ), patch(
+        "app.services.download.classify_article_content",
+    ), patch(
+        "app.services.download.diagnostics.record_attempt",
+        new=AsyncMock(),
+    ):
+        outcome = await download_source_content(source.id)
+
+    mock_fetch.assert_called_once()
+    call_args = mock_fetch.call_args
+    assert call_args is not None
+    assert len(call_args.args) == 2
+    # The key assertion: country comes from source, not URL
+    assert call_args.args[1] == "AR", "Should use source country AR, not default to BR"
+
+
+def test_get_accept_language_for_country_argentina():
+    """Accept-Language helper returns Spanish for Argentina."""
+    from app.services.download import get_accept_language_for_country
+    
+    result = get_accept_language_for_country("AR")
+    assert result == "es,es-419;q=0.9,pt-BR;q=0.8,pt;q=0.7,en;q=0.6"
+
+
+def test_get_accept_language_for_country_brazil():
+    """Accept-Language helper returns Brazilian Portuguese for Brazil."""
+    from app.services.download import get_accept_language_for_country
+    
+    result = get_accept_language_for_country("BR")
+    assert result == "pt-BR,pt;q=0.9,en;q=0.8"
+
+
+def test_get_accept_language_for_country_chile():
+    """Accept-Language helper returns Spanish for Chile."""
+    from app.services.download import get_accept_language_for_country
+    
+    result = get_accept_language_for_country("CL")
+    assert result == "es,es-419;q=0.9,pt-BR;q=0.8,pt;q=0.7,en;q=0.6"
+
+
+def test_get_accept_language_for_country_guyana():
+    """Accept-Language helper returns English for Guyana."""
+    from app.services.download import get_accept_language_for_country
+    
+    result = get_accept_language_for_country("GY")
+    assert result == "en,en-US;q=0.9,es;q=0.8,pt;q=0.7"
+
+
+def test_get_accept_language_for_country_suriname():
+    """Accept-Language helper returns Dutch for Suriname."""
+    from app.services.download import get_accept_language_for_country
+    
+    result = get_accept_language_for_country("SR")
+    assert result == "nl,nl-NL;q=0.9,en;q=0.8,pt;q=0.7"
+
+
+def test_get_accept_language_for_country_bolivia():
+    """Accept-Language helper returns Spanish for Bolivia."""
+    from app.services.download import get_accept_language_for_country
+    
+    result = get_accept_language_for_country("BO")
+    assert result == "es,es-419;q=0.9,pt-BR;q=0.8,pt;q=0.7,en;q=0.6"
+
+
+def test_get_accept_language_for_country_colombia():
+    """Accept-Language helper returns Spanish for Colombia."""
+    from app.services.download import get_accept_language_for_country
+    
+    result = get_accept_language_for_country("CO")
+    assert result == "es,es-419;q=0.9,pt-BR;q=0.8,pt;q=0.7,en;q=0.6"
+
+
+def test_get_accept_language_for_country_ecuador():
+    """Accept-Language helper returns Spanish for Ecuador."""
+    from app.services.download import get_accept_language_for_country
+    
+    result = get_accept_language_for_country("EC")
+    assert result == "es,es-419;q=0.9,pt-BR;q=0.8,pt;q=0.7,en;q=0.6"
+
+
+def test_get_accept_language_for_country_null_defaults_to_brazil():
+    """Accept-Language helper defaults to Brazilian Portuguese when country is None."""
+    from app.services.download import get_accept_language_for_country
+    
+    result = get_accept_language_for_country(None)
+    assert result == "pt-BR,pt;q=0.9,en;q=0.8"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 📝 Descrição

Cherry-pick **only** the three spec-206 tracer fixes from `develop` onto `master`. Does **not** merge `develop`.

Master HEAD at branch point: `47c6f80` (pipeline health / PR 205).

Cherry-picked merge commits in order (`-m 1`, no conflicts):

1. **PR 210 / issue 207** — `b29b25fa754b5a4ca030a095f4d824cb851bcb40` — do not download `news.google.com` when unwrap fails (`download.py` + tests)
2. **PR 211 / issue 208** — `1bc3ece4d9d0798445b15fd9ca14554fc2c715c4` — content gate discards Google language picker including `PortuguêsBrasil` (`content_filters.py` + fixtures + tests)
3. **PR 212 / issue 209** — `e1413897918d1332418fbfe177e65cb34bbadbaa` — `Accept-Language` from source country, not URL TLD (`download.py` + tests)

**Explicitly excluded:**
- PR 204 (date fallback / `extract_explicit_calendar_date`)
- `/estatisticas`, `Rankings.tsx`, coverage table, any frontend
- Any other `develop` commits

**Diff vs master (8 files):**
- `backend/app/services/download.py`
- `backend/app/services/content_filters.py`
- `backend/tests/fixtures/google_consent_page.txt`
- `backend/tests/fixtures/google_language_picker.txt`
- `backend/tests/test_content_filters.py`
- `backend/tests/test_download_null_resolved_url.py`
- `backend/tests/test_issue_207_block_google_downloads.py`
- `backend/tests/test_issue_209_accept_language_by_country.py`

## 🔗 Issue Relacionada

Fixes #207
Fixes #208
Fixes #209

## 🏷️ Tipo de Mudança

- [x] 🐛 Bug fix (mudança que corrige um problema)
- [x] ✅ Testes (adição ou correção de testes)

## 🧪 Como Foi Testado?

- [x] Testes unitários via `uv run pytest` in `backend/` (Docker was not available in this environment)

**Related tests (this cherry-pick):** 34 passed

- issue 207 (`test_issue_207_block_google_downloads.py`) — 4/4 passed
- issue 208 language picker / consent (`test_content_filters.py` google_* tests) — 3/3 passed
- issue 209 (`test_issue_209_accept_language_by_country.py`) — 17/17 passed
- download null resolved_url — 3/3 passed
- remaining content_filters tests added/kept by this work — passed

**Pre-existing on master (not introduced here):** 2 failed

- `test_heuristic_rejects_foreign_earthquake`
- `test_heuristic_still_rejects_venezuela_earthquake`

These already fail on `47c6f80` because Venezuela is in-scope South America and is not in `_FOREIGN_PATTERNS`. Left untouched so this PR’s diff stays only 207/208/209.

## ✅ Checklist

- [x] Diff vs master is only the three tracer changes
- [x] No `/estatisticas` / frontend / PR 204 files
- [x] Did not merge `develop` into `master`
- [ ] Do not merge this PR automatically — human review / João to merge

## 💬 Notas Adicionais

Authorized production cherry-pick of spec 206 tracers only. Leave unmerged until reviewed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-983abb6b-c767-49c1-8a0d-fa65c6a5aeef?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-983abb6b-c767-49c1-8a0d-fa65c6a5aeef&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

