### PR TITLE
fix(classification): count model-call failures as errors, not discards (#215)

### DIFF
--- a/backend/app/services/classification.py
+++ b/backend/app/services/classification.py
@@ -15,6 +15,10 @@ from app.database import async_session_maker
 from app.models import SourceGoogleNews, SourceStatus
 
 
+class ClassificationModelCallError(Exception):
+    """Raised when the upstream LLM/model call fails (HTTP 402, 401, timeout, etc.)."""
+
+
 class ViolentDeathClassification(BaseModel):
     """Classification result for whether news is about a violent death."""
     
@@ -394,7 +398,9 @@ async def classify_source(source_id: int) -> bool:
                 {"id": source_id},
             )
             await session.commit()
-        return False
+        raise ClassificationModelCallError(
+            f"Model call failed for source {source_id}: {e}"
+        ) from e
 
     # Step 3: persist the result in a fresh short-lived session.
     passes_gate = classification.is_violent_death and classification.is_single_incident
@@ -487,6 +493,8 @@ async def classify_pending_sources(limit: int = 50, concurrency: int = 10) -> di
                 "violent_death": 0,
                 "discarded": 0,
                 "errors": 0,
+                "model_call_errors": 0,
+                "other_errors": 0,
             }
         
         # Atomically claim these sources by updating status to prevent race conditions
@@ -516,6 +524,8 @@ async def classify_pending_sources(limit: int = 50, concurrency: int = 10) -> di
             "violent_death": 0,
             "discarded": 0,
             "errors": 0,
+            "model_call_errors": 0,
+            "other_errors": 0,
         }
     
     # Semaphore to limit concurrency
@@ -541,26 +551,35 @@ async def classify_pending_sources(limit: int = 50, concurrency: int = 10) -> di
     
     violent_death_count = 0
     discarded_count = 0
-    error_count = 0
-    
+    model_call_error_count = 0
+    other_error_count = 0
+
     for result in results:
-        if isinstance(result, Exception):
+        if isinstance(result, ClassificationModelCallError):
+            logger.error(f"Classification model call failed: {result}")
+            model_call_error_count += 1
+        elif isinstance(result, Exception):
             logger.error(f"Classification failed with exception: {result}")
-            error_count += 1
+            other_error_count += 1
         elif result is True:
             violent_death_count += 1
         else:
             discarded_count += 1
-    
+
+    error_count = model_call_error_count + other_error_count
+
     logger.info(
         f"Classification complete: {violent_death_count} violent death, "
-        f"{discarded_count} discarded, {error_count} errors"
+        f"{discarded_count} discarded, {error_count} errors "
+        f"(model_call={model_call_error_count}, other={other_error_count})"
     )
-    
+
     return {
         "processed": len(source_ids),
         "violent_death": violent_death_count,
         "discarded": discarded_count,
         "errors": error_count,
+        "model_call_errors": model_call_error_count,
+        "other_errors": other_error_count,
     }
 

--- a/backend/app/tasks/pipeline.py
+++ b/backend/app/tasks/pipeline.py
@@ -140,10 +140,10 @@ async def classify_task(ctx: dict, source_id: int) -> dict:
             f"[CLASSIFY] source_id {source_id}: model call failed (row reset to queue): {e}"
         )
         return {
-            "status": "completed",
+            "status": "requeued",
             "task": "classify",
             "source_id": source_id,
-            "is_violent_death": False,
+            "reason": "model_call_error",
         }
     
     if is_violent_death:

--- a/backend/app/tasks/pipeline.py
+++ b/backend/app/tasks/pipeline.py
@@ -131,9 +131,20 @@ async def classify_task(ctx: dict, source_id: int) -> dict:
     """
     logger.info(f"[CLASSIFY] Starting for source_id: {source_id}")
     
-    from app.services.classification import classify_source
-    
-    is_violent_death = await classify_source(source_id)
+    from app.services.classification import ClassificationModelCallError, classify_source
+
+    try:
+        is_violent_death = await classify_source(source_id)
+    except ClassificationModelCallError as e:
+        logger.warning(
+            f"[CLASSIFY] source_id {source_id}: model call failed (row reset to queue): {e}"
+        )
+        return {
+            "status": "completed",
+            "task": "classify",
+            "source_id": source_id,
+            "is_violent_death": False,
+        }
     
     if is_violent_death:
         logger.info(f"[CLASSIFY] source_id {source_id}: VIOLENT DEATH - enqueueing download")
@@ -585,6 +596,8 @@ async def _run_classify_until_drained(
         "violent_death": 0,
         "discarded": 0,
         "errors": 0,
+        "model_call_errors": 0,
+        "other_errors": 0,
     }
     for batch in range(1, max_batches + 1):
         result = await classify_pending_sources(

--- a/backend/tests/test_classification_error_handling.py
+++ b/backend/tests/test_classification_error_handling.py
@@ -1,0 +1,227 @@
+"""Tests for classification error handling vs content-gate discards (issue #215)."""
+
+from unittest.mock import patch
+
+import pytest
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.services.classification import (
+    ClassificationModelCallError,
+    ViolentDeathClassification,
+    classify_pending_sources,
+    classify_source,
+)
+
+
+class _TestSessionMaker:
+    """Route classification DB calls through the pytest async_session."""
+
+    def __init__(self, session):
+        self._session = session
+
+    def __call__(self):
+        return self
+
+    async def __aenter__(self):
+        return self._session
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+@pytest.fixture
+def classification_db(async_session):
+    maker = _TestSessionMaker(async_session)
+    with patch("app.services.classification.async_session_maker", maker):
+        yield async_session
+
+
+class _EngineSessionMaker:
+    """Create a fresh AsyncSession per async-with block (supports parallel calls)."""
+
+    def __init__(self, engine):
+        self._engine = engine
+
+    def __call__(self):
+        return _EngineSessionContext(self._engine)
+
+
+class _EngineSessionContext:
+    def __init__(self, engine):
+        self._engine = engine
+        self._session = None
+
+    async def __aenter__(self):
+        self._session = AsyncSession(self._engine)
+        return self._session
+
+    async def __aexit__(self, exc_type, exc, tb):
+        await self._session.close()
+        return False
+
+
+@pytest.fixture
+def classification_batch_db(async_engine):
+    maker = _EngineSessionMaker(async_engine)
+    with patch("app.services.classification.async_session_maker", maker):
+        yield async_engine
+
+
+def _source(**kwargs):
+    from app.models.source_google_news import SourceGoogleNews, SourceStatus
+
+    defaults = {
+        "google_news_id": "test-id",
+        "google_news_url": "https://news.example/article",
+        "headline": "Test headline",
+        "status": SourceStatus.classifying,
+    }
+    defaults.update(kwargs)
+    return SourceGoogleNews(**defaults)
+
+
+def _classification(**kwargs) -> ViolentDeathClassification:
+    defaults = {
+        "is_violent_death": True,
+        "is_single_incident": True,
+        "confidence": "alta",
+        "reasoning": "Incident headline",
+    }
+    defaults.update(kwargs)
+    return ViolentDeathClassification(**defaults)
+
+
+class InsufficientCreditsError(Exception):
+    """Simulates OpenRouter HTTP 402 insufficient credits."""
+
+    def __init__(self):
+        super().__init__("402 Insufficient credits")
+
+
+@pytest.mark.asyncio
+async def test_classify_source_raises_on_model_call_failure(classification_db):
+    from app.models.source_google_news import SourceStatus
+
+    source = _source(
+        google_news_id="model-fail-1",
+        headline="Homem é morto a tiros em operação policial",
+    )
+    classification_db.add(source)
+    await classification_db.commit()
+    await classification_db.refresh(source)
+
+    with patch(
+        "app.services.classification.classify_headline",
+        side_effect=InsufficientCreditsError(),
+    ):
+        with pytest.raises(ClassificationModelCallError) as exc_info:
+            await classify_source(source.id)
+
+    assert "402" in str(exc_info.value) or "Insufficient credits" in str(
+        exc_info.value
+    )
+    await classification_db.refresh(source)
+    assert source.status == SourceStatus.ready_for_classification
+
+
+@pytest.mark.asyncio
+async def test_classify_pending_sources_counts_model_errors_not_discards(
+    classification_batch_db,
+):
+    from app.models.source_google_news import SourceStatus
+
+    batch_size = 4
+    sources = []
+    async with AsyncSession(classification_batch_db) as session:
+        for i in range(batch_size):
+            source = _source(
+                google_news_id=f"batch-fail-{i}",
+                headline=f"Headline {i} about violent death",
+                status=SourceStatus.ready_for_classification,
+            )
+            session.add(source)
+            sources.append(source)
+        await session.commit()
+        for source in sources:
+            await session.refresh(source)
+
+    with patch(
+        "app.services.classification.classify_headline",
+        side_effect=InsufficientCreditsError(),
+    ):
+        result = await classify_pending_sources(limit=batch_size, concurrency=2)
+
+    assert result["processed"] == batch_size
+    assert result["violent_death"] == 0
+    assert result["discarded"] == 0
+    assert result["errors"] == batch_size
+    assert result["model_call_errors"] == batch_size
+    assert result["other_errors"] == 0
+
+    for source in sources:
+        async with AsyncSession(classification_batch_db) as session:
+            row = await session.get(type(source), source.id)
+        assert row.status == SourceStatus.ready_for_classification
+
+
+@pytest.mark.asyncio
+async def test_classify_pending_sources_mixed_discard_and_model_errors(
+    classification_batch_db,
+):
+    from app.models.source_google_news import SourceStatus
+
+    discard_source = _source(
+        google_news_id="discard-1",
+        headline="Polícia prende suspeito de roubo",
+        status=SourceStatus.ready_for_classification,
+    )
+    fail_sources = [
+        _source(
+            google_news_id=f"fail-{i}",
+            headline=f"Fail headline {i}",
+            status=SourceStatus.ready_for_classification,
+        )
+        for i in range(3)
+    ]
+    async with AsyncSession(classification_batch_db) as session:
+        session.add(discard_source)
+        for source in fail_sources:
+            session.add(source)
+        await session.commit()
+        await session.refresh(discard_source)
+        for source in fail_sources:
+            await session.refresh(source)
+
+    discard_headline = discard_source.headline
+
+    def classify_side_effect(headline: str, **_kwargs):
+        if headline == discard_headline:
+            return _classification(
+                is_violent_death=False,
+                is_single_incident=False,
+                reasoning="No death mentioned",
+            )
+        raise InsufficientCreditsError()
+
+    with patch(
+        "app.services.classification.classify_headline",
+        side_effect=classify_side_effect,
+    ):
+        result = await classify_pending_sources(limit=10, concurrency=3)
+
+    assert result["processed"] == 4
+    assert result["violent_death"] == 0
+    assert result["discarded"] == 1
+    assert result["errors"] == 3
+    assert result["model_call_errors"] == 3
+    assert result["other_errors"] == 0
+
+    from app.models.source_google_news import SourceGoogleNews
+
+    async with AsyncSession(classification_batch_db) as session:
+        row = await session.get(SourceGoogleNews, discard_source.id)
+    assert row.status == SourceStatus.discarded
+    for source in fail_sources:
+        async with AsyncSession(classification_batch_db) as session:
+            row = await session.get(SourceGoogleNews, source.id)
+        assert row.status == SourceStatus.ready_for_classification

--- a/backend/tests/test_classification_error_handling.py
+++ b/backend/tests/test_classification_error_handling.py
@@ -1,6 +1,6 @@
 """Tests for classification error handling vs content-gate discards (issue #215)."""
 
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from sqlmodel.ext.asyncio.session import AsyncSession
@@ -225,3 +225,36 @@ async def test_classify_pending_sources_mixed_discard_and_model_errors(
         async with AsyncSession(classification_batch_db) as session:
             row = await session.get(SourceGoogleNews, source.id)
         assert row.status == SourceStatus.ready_for_classification
+
+
+@pytest.mark.asyncio
+async def test_classify_task_requeues_on_model_call_error(classification_db):
+    from app.models.source_google_news import SourceStatus
+    from app.tasks.pipeline import classify_task
+
+    source = _source(
+        google_news_id="task-fail-1",
+        headline="Homem é morto a tiros em operação policial",
+    )
+    classification_db.add(source)
+    await classification_db.commit()
+    await classification_db.refresh(source)
+    source_id = source.id
+
+    ctx = {"redis": AsyncMock()}
+
+    with patch(
+        "app.services.classification.classify_headline",
+        side_effect=InsufficientCreditsError(),
+    ):
+        result = await classify_task(ctx, source_id)
+
+    assert result["status"] != "completed"
+    assert result["status"] == "requeued"
+    assert "is_violent_death" not in result
+    assert result["reason"] == "model_call_error"
+    assert result["task"] == "classify"
+    assert result["source_id"] == source_id
+
+    await classification_db.refresh(source)
+    assert source.status == SourceStatus.ready_for_classification


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 📝 Descrição

Fixes #215 — classification batch summaries no longer report upstream model-call failures (HTTP 402/401, timeouts, etc.) as content-gate **discards**.

Related incident: #214 (OpenRouter 402 *Insufficient credits* left ~150 sources spinning in `Batch N/12` while logs showed `0 violent death, 150 discarded, 0 errors`).

### Root cause (confirmed in code)

In `backend/app/services/classification.py`, `classify_source` caught **any** exception from `classify_headline`, reset the row to `ready_for_classification` (correct), but **`return False`** instead of re-raising. `classify_pending_sources` already used `asyncio.gather(..., return_exceptions=True)` with correct bucketing for real exceptions — but never received them because failures were converted to plain `False`, landing in `discarded_count`.

### Fix (error-handling / counting only — content gate untouched)

1. Added `ClassificationModelCallError` for upstream LLM/model failures.
2. `classify_source`: on model-call failure, still resets status to `ready_for_classification`, then **raises** `ClassificationModelCallError` (chained). Gate-decision paths still return plain `True`/`False` unchanged.
3. `classify_pending_sources`: buckets `ClassificationModelCallError` → `model_call_errors`, other exceptions → `other_errors`; `errors = model_call_errors + other_errors`. Backward-compatible keys kept; adds `model_call_errors` / `other_errors`.
4. `_run_classify_until_drained`: sums the new breakdown keys across batches.
5. **`classify_task` design choice:** catches `ClassificationModelCallError` without triggering `@notify_on_failure("classify")` per-item alerts. **Follow-up (PM review):** the except branch now returns `status: "requeued"` with `reason: "model_call_error"` — no `is_violent_death` key — so a failed model call is not indistinguishable from a real negative classification outcome.

## 🔗 Issue Relacionada

Fixes #215

Refs #214 (402 insufficient credits incident)

## 🏷️ Tipo de Mudança

- [x] 🐛 Bug fix (mudança que corrige um problema)
- [x] ✅ Testes (adição ou correção de testes)

## 🧪 Como Foi Testado?

TDD red → green:

| Test | Purpose |
|------|---------|
| `test_classify_source_raises_on_model_call_failure` | Unit: model failure raises, row reset |
| `test_classify_pending_sources_counts_model_errors_not_discards` | Batch: 402 × N → errors=N, discarded=0 |
| `test_classify_pending_sources_mixed_discard_and_model_errors` | Mixed discard + errors not conflated |
| `test_classify_task_requeues_on_model_call_error` | Single-item path: returns `requeued`, no `is_violent_death` |

**Existing suite:** `backend/tests/test_classification_filters.py` — **unmodified**, 9/9 green.

```
python3 -m pytest backend/tests/test_classification_error_handling.py backend/tests/test_classification_filters.py -v
# 13 passed
```

- [x] Testes unitários

## ✅ Checklist

- [x] Adicionei testes que provam que meu fix/feature funciona
- [x] Testes unitários novos e existentes passam localmente

## 💬 Notas Adicionais

### Optional stretch (skipped)

Did **not** add a health route / alert for growing `ready_for_classification` backlog — out of scope per PM.

### HEAD

`b17d5b1a774637c90e33cd8d1e936bd822fd412d`

**Base branch:** `develop` (not `master`).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-26fdf03b-6641-4f2c-85ae-2134fd8f1ed3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-26fdf03b-6641-4f2c-85ae-2134fd8f1ed3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

