### PR TITLE
Restrict ingest and classify to Brazil via pipeline_active_countries (#217)

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -54,6 +54,12 @@ class Settings(BaseSettings):
     # Pipeline settings
     pipeline_max_workers: int = 10
     pipeline_batch_size: int = 50
+    # ISO 3166-1 alpha-2 codes ingest + headline classification should process.
+    # Empty list (default / unset) = all countries in ALL_COUNTRIES (current behavior).
+    # Prod and staging machines: PIPELINE_ACTIVE_COUNTRIES=["BR"] so OpenRouter
+    # credit is not spent on the other 11 South American countries.
+    # Loaded from env as JSON, same as cors_origins (pydantic-settings).
+    pipeline_active_countries: list[str] = []
 
     # Download settings
     download_timeout_seconds: float = 20.0
@@ -124,3 +130,22 @@ class Settings(BaseSettings):
 def get_settings() -> Settings:
     """Get cached settings instance."""
     return Settings()
+
+
+def get_pipeline_active_countries() -> list[str]:
+    """Return ISO 3166-1 alpha-2 codes ingest and classify should process.
+
+    Empty or absent ``pipeline_active_countries`` returns every code in
+    ``ALL_COUNTRIES`` so existing tests and unrestricted deploys keep the
+    12-country behavior. Configured values are stripped and uppercased.
+    """
+    from app.country_registry import ALL_COUNTRIES
+
+    configured = [
+        code.strip().upper()
+        for code in get_settings().pipeline_active_countries
+        if code and str(code).strip()
+    ]
+    if not configured:
+        return list(ALL_COUNTRIES)
+    return configured

--- a/backend/app/services/classification.py
+++ b/backend/app/services/classification.py
@@ -10,7 +10,7 @@ from sqlmodel import select
 from tenacity import retry, stop_after_attempt, wait_exponential, retry_if_exception_type
 
 from app.services.classification_heuristics import apply_classification_heuristics
-from app.config import get_settings
+from app.config import get_pipeline_active_countries, get_settings
 from app.database import async_session_maker
 from app.models import SourceGoogleNews, SourceStatus
 
@@ -459,33 +459,57 @@ async def _reset_unfinished_classifying(source_ids: list[int]) -> int:
         return result.rowcount or 0
 
 
+def _sql_country_in_list(countries: list[str]) -> str:
+    """Quote ISO codes for a SQL IN clause; reject anything that is not AA."""
+    safe = []
+    for code in countries:
+        normalized = str(code).strip().upper()
+        if len(normalized) == 2 and normalized.isalpha():
+            safe.append(f"'{normalized}'")
+    if not safe:
+        return "'__none__'"
+    return ", ".join(safe)
+
+
 async def classify_pending_sources(limit: int = 50, concurrency: int = 10) -> dict:
     """
-    Batch classify all sources that are ready for classification (in parallel).
-    
+    Batch classify sources that are ready for classification (in parallel).
+
+    Only rows whose ``country`` is in ``pipeline_active_countries`` are
+    claimed. ``country IS NULL`` is treated as ``BR`` (legacy Brazil rows).
+    Inactive-country rows stay ``ready_for_classification`` — no discard,
+    no model call.
+
     Args:
         limit: Maximum number of sources to process
         concurrency: Maximum number of parallel classifications
-    
+
     Returns:
         Dict with classification statistics
     """
     import asyncio
-    
+    from sqlalchemy import text
+
+    active_countries = get_pipeline_active_countries()
+    country_in = _sql_country_in_list(active_countries)
+    logger.info(
+        f"Starting classification; active countries={active_countries}"
+    )
+
     # Use raw SQL to avoid SQLAlchemy enum caching issues
     async with async_session_maker() as session:
-        from sqlalchemy import text
         result = await session.execute(
-            text("""
-                SELECT id FROM source_google_news 
-                WHERE status = 'ready_for_classification' 
-                AND headline IS NOT NULL 
+            text(f"""
+                SELECT id FROM source_google_news
+                WHERE status = 'ready_for_classification'
+                AND headline IS NOT NULL
+                AND COALESCE(country, 'BR') IN ({country_in})
                 LIMIT :limit
             """),
             {"limit": limit}
         )
         candidate_ids = [row[0] for row in result.fetchall()]
-        
+
         if not candidate_ids:
             logger.info(f"Found 0 sources to classify")
             return {
@@ -496,14 +520,18 @@ async def classify_pending_sources(limit: int = 50, concurrency: int = 10) -> di
                 "model_call_errors": 0,
                 "other_errors": 0,
             }
-        
-        # Atomically claim these sources by updating status to prevent race conditions
+
+        # Atomically claim these sources by updating status to prevent race conditions.
+        # Country filter is repeated so a row from an inactive country cannot be
+        # claimed even if it slipped into candidate_ids.
         await session.execute(
-            text("""
-                UPDATE source_google_news 
+            text(f"""
+                UPDATE source_google_news
                 SET status = 'classifying', updated_at = CURRENT_TIMESTAMP
-                WHERE id IN ({}) AND status = 'ready_for_classification'
-            """.format(",".join(str(id) for id in candidate_ids)))
+                WHERE id IN ({",".join(str(id) for id in candidate_ids)})
+                AND status = 'ready_for_classification'
+                AND COALESCE(country, 'BR') IN ({country_in})
+            """)
         )
         await session.commit()
         

--- a/backend/app/services/ingestion.py
+++ b/backend/app/services/ingestion.py
@@ -19,6 +19,7 @@ from app.services.cities import (
     REQUESTS_PER_MINUTE,
     SHARDING_THRESHOLD,
 )
+from app.config import get_pipeline_active_countries
 from app.geography import Country
 from app.country_registry import ALL_COUNTRIES, get_country_config
 
@@ -575,26 +576,32 @@ async def ingest_all_countries(
     max_concurrent: int = 10,
 ) -> dict:
     """
-    Ingest news for all configured cities across all countries in the registry.
-    
-    Iterates the country registry and runs ingestion for all supported countries.
-    
+    Ingest news for configured cities across active countries.
+
+    Iterates ``get_pipeline_active_countries()`` (ALL_COUNTRIES when the
+    setting is empty). Country registry entries are not removed — inactive
+    codes are simply skipped.
+
     Args:
         when: Time filter (default "1h" for hourly ingestion)
         resolve_urls: Whether to resolve obfuscated URLs
         max_concurrent: Maximum concurrent city ingestions per country
-    
+
     Returns:
         Summary dict with statistics per country
     """
-    logger.info(f"Starting multi-country ingestion ({len(ALL_COUNTRIES)} countries)")
-    
+    active_countries = get_pipeline_active_countries()
+    logger.info(
+        f"Starting multi-country ingestion "
+        f"({len(active_countries)} of {len(ALL_COUNTRIES)} countries): {active_countries}"
+    )
+
     import time
     start_time = time.time()
-    
-    # Create ingestion tasks for all countries
+
+    # Create ingestion tasks for active countries only
     tasks = []
-    for country_code in ALL_COUNTRIES:
+    for country_code in active_countries:
         task = ingest_all_cities(
             cities=None,  # Use config cities
             when=when,
@@ -603,29 +610,32 @@ async def ingest_all_countries(
             country=country_code,
         )
         tasks.append(task)
-    
+
     # Run all countries in parallel
     results = await asyncio.gather(*tasks)
-    
+
     elapsed = time.time() - start_time
-    
+
     # Aggregate results
     country_results = {}
     total_entries = 0
     total_sources = 0
-    
-    for country_code, result in zip(ALL_COUNTRIES, results):
+
+    for country_code, result in zip(active_countries, results):
         country_results[country_code] = result
         total_entries += result["total_entries"]
         total_sources += result["total_sources_created"]
-    
+
     logger.info(f"\n{'='*60}")
-    logger.info(f"MULTI-COUNTRY INGESTION COMPLETE ({len(ALL_COUNTRIES)} countries)")
+    logger.info(
+        f"MULTI-COUNTRY INGESTION COMPLETE "
+        f"({len(active_countries)} countries): {active_countries}"
+    )
     logger.info(f"Total entries: {total_entries}")
     logger.info(f"Total sources: {total_sources}")
     logger.info(f"Time: {elapsed:.1f}s")
     logger.info(f"{'='*60}")
-    
+
     return {
         "total_entries": total_entries,
         "total_sources_created": total_sources,

--- a/backend/tests/test_active_countries.py
+++ b/backend/tests/test_active_countries.py
@@ -1,0 +1,264 @@
+"""Tests for pipeline_active_countries ingest/classify restriction (issue #217)."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.country_registry import ALL_COUNTRIES
+from app.services.classification import ViolentDeathClassification, classify_pending_sources
+
+
+EXPECTED_ALL = {"AR", "BO", "BR", "CL", "CO", "EC", "GY", "PY", "PE", "SR", "UY", "VE"}
+
+_INGEST_DUMMY = {
+    "country": "XX",
+    "cities_processed": 0,
+    "total_entries": 0,
+    "total_sources_created": 0,
+    "errors": 0,
+    "elapsed_seconds": 0,
+    "city_results": {},
+}
+
+
+class _EngineSessionMaker:
+    """Create a fresh AsyncSession per async-with block (supports parallel calls)."""
+
+    def __init__(self, engine):
+        self._engine = engine
+
+    def __call__(self):
+        return _EngineSessionContext(self._engine)
+
+
+class _EngineSessionContext:
+    def __init__(self, engine):
+        self._engine = engine
+        self._session = None
+
+    async def __aenter__(self):
+        self._session = AsyncSession(self._engine)
+        return self._session
+
+    async def __aexit__(self, exc_type, exc, tb):
+        await self._session.close()
+        return False
+
+
+@pytest.fixture
+def classification_batch_db(async_engine):
+    maker = _EngineSessionMaker(async_engine)
+    with patch("app.services.classification.async_session_maker", maker):
+        yield async_engine
+
+
+def _source(**kwargs):
+    from app.models.source_google_news import SourceGoogleNews, SourceStatus
+
+    defaults = {
+        "google_news_id": "test-id",
+        "google_news_url": "https://news.example/article",
+        "headline": "Test headline",
+        "status": SourceStatus.classifying,
+    }
+    defaults.update(kwargs)
+    return SourceGoogleNews(**defaults)
+
+
+def _classification(**kwargs) -> ViolentDeathClassification:
+    defaults = {
+        "is_violent_death": True,
+        "is_single_incident": True,
+        "confidence": "alta",
+        "reasoning": "Incident headline",
+    }
+    defaults.update(kwargs)
+    return ViolentDeathClassification(**defaults)
+
+
+def _called_countries(mock_ingest) -> list[str]:
+    return [call.kwargs["country"] for call in mock_ingest.await_args_list]
+
+
+class TestPipelineActiveCountriesSetting:
+    def test_defaults_to_empty_list(self, monkeypatch):
+        monkeypatch.delenv("PIPELINE_ACTIVE_COUNTRIES", raising=False)
+        from app.config import Settings
+
+        settings = Settings(_env_file=None)
+        assert settings.pipeline_active_countries == []
+
+    def test_loads_json_list_from_env(self, monkeypatch):
+        monkeypatch.setenv("PIPELINE_ACTIVE_COUNTRIES", '["BR"]')
+        from app.config import Settings
+
+        settings = Settings(_env_file=None)
+        assert settings.pipeline_active_countries == ["BR"]
+
+    def test_empty_list_means_all_registry_countries(self):
+        from app.config import get_pipeline_active_countries
+
+        with patch("app.config.get_settings") as mock_settings:
+            mock_settings.return_value.pipeline_active_countries = []
+            assert set(get_pipeline_active_countries()) == EXPECTED_ALL
+            assert len(get_pipeline_active_countries()) == 12
+
+    def test_br_only_returns_just_br(self):
+        from app.config import get_pipeline_active_countries
+
+        with patch("app.config.get_settings") as mock_settings:
+            mock_settings.return_value.pipeline_active_countries = ["BR"]
+            assert get_pipeline_active_countries() == ["BR"]
+
+
+class TestIngestActiveCountries:
+    @pytest.mark.asyncio
+    async def test_restricted_to_br_does_not_iterate_other_countries(self):
+        from app.services.ingestion import ingest_all_countries
+
+        with (
+            patch(
+                "app.services.ingestion.ingest_all_cities",
+                new_callable=AsyncMock,
+                return_value=_INGEST_DUMMY,
+            ) as mock_ingest,
+            patch(
+                "app.services.ingestion.get_pipeline_active_countries",
+                return_value=["BR"],
+            ),
+        ):
+            result = await ingest_all_countries(when="1h", resolve_urls=False)
+
+        countries = _called_countries(mock_ingest)
+        assert countries == ["BR"]
+        assert "AR" not in countries
+        assert "CL" not in countries
+        assert set(result["countries"].keys()) == {"BR"}
+
+    @pytest.mark.asyncio
+    async def test_empty_list_still_iterates_all_12(self):
+        from app.services.ingestion import ingest_all_countries
+
+        with (
+            patch(
+                "app.services.ingestion.ingest_all_cities",
+                new_callable=AsyncMock,
+                return_value=_INGEST_DUMMY,
+            ) as mock_ingest,
+            patch(
+                "app.services.ingestion.get_pipeline_active_countries",
+                return_value=list(ALL_COUNTRIES),
+            ),
+        ):
+            result = await ingest_all_countries(when="1h", resolve_urls=False)
+
+        countries = _called_countries(mock_ingest)
+        assert set(countries) == EXPECTED_ALL
+        assert len(countries) == 12
+        assert set(result["countries"].keys()) == EXPECTED_ALL
+
+
+class TestClassifyActiveCountries:
+    @pytest.mark.asyncio
+    async def test_restricted_to_br_skips_ar_and_claims_null_as_br(
+        self, classification_batch_db
+    ):
+        from app.models.source_google_news import SourceGoogleNews, SourceStatus
+
+        br_source = _source(
+            google_news_id="br-1",
+            headline="Homem é morto a tiros no Rio",
+            country="BR",
+            status=SourceStatus.ready_for_classification,
+        )
+        ar_source = _source(
+            google_news_id="ar-1",
+            headline="Homicidio en Buenos Aires deja un muerto",
+            country="AR",
+            status=SourceStatus.ready_for_classification,
+        )
+        null_source = _source(
+            google_news_id="legacy-br",
+            headline="Corpo é encontrado com marcas de violência",
+            country=None,
+            status=SourceStatus.ready_for_classification,
+        )
+
+        async with AsyncSession(classification_batch_db) as session:
+            session.add(br_source)
+            session.add(ar_source)
+            session.add(null_source)
+            await session.commit()
+            await session.refresh(br_source)
+            await session.refresh(ar_source)
+            await session.refresh(null_source)
+            br_id, ar_id, null_id = br_source.id, ar_source.id, null_source.id
+
+        with (
+            patch(
+                "app.services.classification.get_pipeline_active_countries",
+                return_value=["BR"],
+            ),
+            patch(
+                "app.services.classification.classify_headline",
+                return_value=_classification(),
+            ) as mock_classify,
+        ):
+            result = await classify_pending_sources(limit=10, concurrency=3)
+
+        assert result["processed"] == 2
+        assert result["violent_death"] == 2
+        assert result["discarded"] == 0
+        assert mock_classify.call_count == 2
+
+        async with AsyncSession(classification_batch_db) as session:
+            br_row = await session.get(SourceGoogleNews, br_id)
+            ar_row = await session.get(SourceGoogleNews, ar_id)
+            null_row = await session.get(SourceGoogleNews, null_id)
+
+        assert br_row.status == SourceStatus.ready_for_download
+        assert null_row.status == SourceStatus.ready_for_download
+        assert ar_row.status == SourceStatus.ready_for_classification
+        assert ar_row.status != SourceStatus.discarded
+        assert ar_row.status != SourceStatus.classifying
+
+    @pytest.mark.asyncio
+    async def test_unrestricted_still_claims_all_countries(self, classification_batch_db):
+        from app.models.source_google_news import SourceGoogleNews, SourceStatus
+
+        br_source = _source(
+            google_news_id="all-br",
+            headline="Homem é morto a tiros no Rio",
+            country="BR",
+            status=SourceStatus.ready_for_classification,
+        )
+        ar_source = _source(
+            google_news_id="all-ar",
+            headline="Homicidio en Buenos Aires deja un muerto",
+            country="AR",
+            status=SourceStatus.ready_for_classification,
+        )
+
+        async with AsyncSession(classification_batch_db) as session:
+            session.add(br_source)
+            session.add(ar_source)
+            await session.commit()
+            await session.refresh(br_source)
+            await session.refresh(ar_source)
+            br_id, ar_id = br_source.id, ar_source.id
+
+        with patch(
+            "app.services.classification.classify_headline",
+            return_value=_classification(),
+        ):
+            result = await classify_pending_sources(limit=10, concurrency=2)
+
+        assert result["processed"] == 2
+
+        async with AsyncSession(classification_batch_db) as session:
+            br_row = await session.get(SourceGoogleNews, br_id)
+            ar_row = await session.get(SourceGoogleNews, ar_id)
+
+        assert br_row.status == SourceStatus.ready_for_download
+        assert ar_row.status == SourceStatus.ready_for_download

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -64,6 +64,7 @@ services:
       - ENVIRONMENT=staging
       - ENABLE_AUTH=true
       - CORS_ORIGINS=["http://localhost:5173","http://localhost:8080","https://staging.arquivodaviolencia.com.br"]
+      - PIPELINE_ACTIVE_COUNTRIES=${PIPELINE_ACTIVE_COUNTRIES:-["BR"]}
       - JWT_SECRET_KEY=${STAGING_JWT_SECRET_KEY}
       - ADMIN_USERNAME=${STAGING_ADMIN_USERNAME:-admin}
       - TELEGRAM_BOT_TOKEN=${STAGING_TELEGRAM_BOT_TOKEN:-}
@@ -105,6 +106,7 @@ services:
       - DEDUP_MODEL=${STAGING_DEDUP_MODEL:-${DEDUP_MODEL:-google/gemini-3.1-flash-lite}}
       - ENRICHMENT_MODEL=${STAGING_ENRICHMENT_MODEL:-${ENRICHMENT_MODEL:-deepseek/deepseek-v4-flash}}
       - ENABLE_CRON=${STAGING_ENABLE_CRON:-false}
+      - PIPELINE_ACTIVE_COUNTRIES=${PIPELINE_ACTIVE_COUNTRIES:-["BR"]}
       - ENVIRONMENT=staging
       - ENABLE_AUTH=true
       - JWT_SECRET_KEY=${STAGING_JWT_SECRET_KEY}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@
 #   GITHUB_TOKEN=your-github-token  # For creating issues on failures
 #   GITHUB_REPO=owner/repo  # Repository for issues
 #   POSTGRES_PASSWORD=strong-password  # PostgreSQL password
+#   PIPELINE_ACTIVE_COUNTRIES=["BR"]   # ingest/classify Brazil only (issue #217)
 #
 # =============================================================================
 
@@ -91,6 +92,7 @@ services:
       - ENVIRONMENT=production
       - ENABLE_AUTH=true
       - CORS_ORIGINS=["http://localhost:5173","http://localhost:3000","http://localhost:80","https://arquivodaviolencia.com.br","https://www.arquivodaviolencia.com.br"]
+      - PIPELINE_ACTIVE_COUNTRIES=${PIPELINE_ACTIVE_COUNTRIES:-["BR"]}
       - TELEGRAM_BOT_TOKEN=${TELEGRAM_BOT_TOKEN:-}
       - TELEGRAM_CHAT_ID=${TELEGRAM_CHAT_ID:-}
       - HETZNER_API_TOKEN=${HETZNER_API_TOKEN:-}
@@ -140,6 +142,7 @@ services:
       - ENRICHMENT_MODEL=${ENRICHMENT_MODEL:-deepseek/deepseek-v4-flash}
       - GOOGLE_MAPS_API_KEY=${GOOGLE_MAPS_API_KEY:-}
       - ENABLE_CRON=${ENABLE_CRON:-false}
+      - PIPELINE_ACTIVE_COUNTRIES=${PIPELINE_ACTIVE_COUNTRIES:-["BR"]}
       - ENVIRONMENT=production
       - ENABLE_AUTH=true
       - TELEGRAM_BOT_TOKEN=${TELEGRAM_BOT_TOKEN:-}

--- a/env.example
+++ b/env.example
@@ -22,6 +22,12 @@ ENRICHMENT_MODEL=deepseek/deepseek-v4-flash
 # Get a key at https://console.cloud.google.com (enable the Geocoding API)
 GOOGLE_MAPS_API_KEY=
 
+# Restrict ingest + headline classification to these ISO 3166-1 alpha-2 codes
+# (JSON list, same format as CORS_ORIGINS). Empty / unset = all 12 SA countries.
+# Prod and staging: Brazil only so OpenRouter credit is not spent on AR/CL/etc.
+# Existing UniqueEvents on the map are not deleted.
+PIPELINE_ACTIVE_COUNTRIES=["BR"]
+
 # Enable hourly cron job for city ingestion
 ENABLE_CRON=false
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 📝 Descrição

João (2026-09-03) / #217: Arquivo da Violência must run **Brazil only** on prod and staging so OpenRouter credit is not spent ingesting/classifying the other 11 South American countries.

This PR adds `pipeline_active_countries` (`PIPELINE_ACTIVE_COUNTRIES`) and applies it on the hourly ingest path and on `classify_pending_sources` claim SELECT + UPDATE.

- Empty list / unset = current behavior (all 12 / `ALL_COUNTRIES`).
- Machines: `PIPELINE_ACTIVE_COUNTRIES=["BR"]` (wired as the default on prod + staging compose).
- `country IS NULL` is treated as `BR` (legacy Brazil rows).
- Other-country `ready_for_classification` rows stay in that status — no discard, no model call, no claim.
- Country registry entries (`AR`, `CL`, …) are **not** removed. UniqueEvent / SourceGoogleNews rows are **not** deleted.

Out of scope (intentionally not in this PR): #214 OpenRouter credit, #215/#216 error-counting (already on `develop`), any cherry-pick to `master`.

## 🔗 Issue Relacionada

Fixes #217

## 🏷️ Tipo de Mudança

- [x] 🐛 Bug fix (mudança que corrige um problema)
- [x] ✅ Testes (adição ou correção de testes)

## 🧪 Como Foi Testado?

TDD: failing tests first (7 red / 1 already-green unrestricted classify), then implementation, then green.

**Red → green** in `backend/tests/test_active_countries.py`:

- `TestPipelineActiveCountriesSetting::test_defaults_to_empty_list`
- `TestPipelineActiveCountriesSetting::test_loads_json_list_from_env`
- `TestPipelineActiveCountriesSetting::test_empty_list_means_all_registry_countries`
- `TestPipelineActiveCountriesSetting::test_br_only_returns_just_br`
- `TestIngestActiveCountries::test_restricted_to_br_does_not_iterate_other_countries`
- `TestIngestActiveCountries::test_empty_list_still_iterates_all_12`
- `TestClassifyActiveCountries::test_restricted_to_br_skips_ar_and_claims_null_as_br`
- `TestClassifyActiveCountries::test_unrestricted_still_claims_all_countries` (already passed on red run; empty setting still claims all)

Related suites still pass (44 tests): `test_country_registry`, `test_classification_error_handling` (#215/#216 untouched), `test_classification_filters`, `test_country_classification`.

- [x] Testes unitários
- [ ] Testes manuais
- [ ] Testado com Docker

**Setting:** `pipeline_active_countries` / env `PIPELINE_ACTIVE_COUNTRIES=["BR"]`

HEAD: `872444c0a69736432cdfc4cc4c9a39cb7b7228fa` on `cursor/pipeline-active-countries-27b1`  
Base: `develop` @ `7427a4b` (not `master`).

## ✅ Checklist

- [x] Base branch is `develop` (not `master`)
- [x] No UniqueEvent / SA rows deleted
- [x] No mix-in from #214 / #215 / #216
- [x] Draft PR — do not merge, do not mark ready

## 📚 Documentação

- [x] Docstrings/comentários no código
- [x] Outro: `env.example`, prod/staging compose default `["BR"]`

## 💬 Notas Adicionais

Ops: after this lands on `develop`, staging compose defaults to `["BR"]`. Prod compose does the same when this is later promoted. Local/dev compose is unchanged (empty = all 12). Existing map events stay.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-14aafb44-9e75-4040-9f7a-0e7ef9b327b1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-14aafb44-9e75-4040-9f7a-0e7ef9b327b1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

