### PR TITLE
fix(pipeline_health): ignore invalid Redis timestamps (#221)

### DIFF
--- a/backend/app/services/pipeline_health.py
+++ b/backend/app/services/pipeline_health.py
@@ -29,11 +29,14 @@ class InProgressJob:
         # For cron jobs: arq:in-progress:cron:JOB_NAME:TIMESTAMP
         if len(parts) >= 4 and parts[2] == "cron":
             job_name = parts[3]
-            # Try to parse timestamp if present
+            # .isdigit() is not a valid Unix-seconds check; catch fromtimestamp
+            # failures so malformed Redis keys cannot crash the health check.
+            enqueued_at = None
             if len(parts) >= 5 and parts[4].isdigit():
-                enqueued_at = datetime.fromtimestamp(int(parts[4]), tz=timezone.utc)
-            else:
-                enqueued_at = None
+                try:
+                    enqueued_at = datetime.fromtimestamp(int(parts[4]), tz=timezone.utc)
+                except (ValueError, OverflowError, OSError):
+                    enqueued_at = None
         else:
             # Non-cron job: arq:in-progress:JOB_ID
             job_name = "unknown"

--- a/backend/tests/test_pipeline_health.py
+++ b/backend/tests/test_pipeline_health.py
@@ -41,6 +41,26 @@ class TestInProgressJob:
         assert job.job_name == "unknown"
         assert job.enqueued_at is None
 
+    def test_parse_cron_job_key_with_out_of_range_timestamp(self):
+        """Malformed numeric junk in parts[4] must not crash the health check.
+
+        .isdigit() accepts huge digit strings that are not valid Unix-seconds
+        timestamps. datetime.fromtimestamp then raises ValueError (year out of
+        range) — production: year 58644 from Pipeline Health run 33817606339.
+        """
+        # Huge digit string: fromtimestamp raises ValueError (year out of range).
+        # Production (run 33817606339) failed with year 58644.
+        junk_ts = "1850000000000"
+        with pytest.raises((ValueError, OverflowError, OSError)):
+            datetime.fromtimestamp(int(junk_ts), tz=timezone.utc)
+
+        key = f"arq:in-progress:cron:ingest_cities_hourly:{junk_ts}"
+        job = InProgressJob.from_redis_key(key)
+
+        assert job.key == key
+        assert job.job_name == "ingest_cities_hourly"
+        assert job.enqueued_at is None
+
 
 class TestWorkerLogs:
     """Tests for WorkerLogs progress detection using ACTUAL log patterns."""


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 📝 Descrição

`InProgressJob.from_redis_key` crashed the Pipeline Health check when an ARQ Redis key had a numeric `parts[4]` that was not a valid Unix-seconds timestamp (`.isdigit()` is not enough). `datetime.fromtimestamp` then raised `ValueError: year 58644 is out of range`, which the vigia reported as `stale=error;reason=check_failed` / `WARN: lock_stale_check_failed`.

This change catches `ValueError` / `OverflowError` / `OSError` around `fromtimestamp`, sets `enqueued_at = None`, and still returns the cron `job_name`. Valid timestamps (e.g. `1724594700`) are unchanged.

## 🔗 Issue Relacionada

Fixes #221

## 🏷️ Tipo de Mudança

- [x] 🐛 Bug fix (mudança que corrige um problema)
- [x] ✅ Testes (adição ou correção de testes)

## 🧪 Como Foi Testado?

- [x] Testes unitários
- [ ] Testes de integração (módulo `test_pipeline_health_integration.py` também passou)
- [ ] Testes manuais
- [ ] Testado em desenvolvimento local
- [ ] Testado com Docker (Docker não está disponível neste ambiente)

TDD: teste vermelho (`ValueError: year 60594 is out of range` em `from_redis_key`) → verde após o `try/except`.

```
tests/test_pipeline_health.py::TestInProgressJob::test_parse_cron_job_key_with_out_of_range_timestamp PASSED
tests/test_pipeline_health.py::TestInProgressJob::test_parse_cron_job_key_with_timestamp PASSED
tests/test_pipeline_health.py::TestInProgressJob::test_parse_cron_job_key_without_timestamp PASSED
tests/test_pipeline_health.py::TestInProgressJob::test_parse_non_cron_job_key PASSED
```

29 testes em `test_pipeline_health.py` + `test_pipeline_health_integration.py`.

**Ambiente de teste:**
- OS: Linux (Cloud Agent)
- Python 3.12.3 + pytest 9.1.1 (`PYTHONPATH=. pytest --noconftest`; Docker Compose não disponível)

## ✅ Checklist

- [x] Meu código segue o guia de estilo do projeto
- [x] Realizei uma auto-revisão do meu código
- [x] Adicionei testes que provam que meu fix/feature funciona
- [x] Testes unitários novos e existentes passam localmente
- [x] Minhas mudanças não geram novos warnings

## 💬 Notas Adicionais

- Base: **`develop`** (`eb08d65`), not `master`.
- Does not mix #204.
- Does not touch #220 / `batch_dedup` / Telegram.
- Parked 111 / 112 / 145 / #1 / #126 untouched.
- Draft PR only; do not merge / do not mark ready.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-52703b32-d8cd-4797-abfc-848eaadd5f9c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-52703b32-d8cd-4797-abfc-848eaadd5f9c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

