### PR TITLE
fix(dedup): isolate batch_dedup from Telegram notify hangs (#220)

### DIFF
--- a/backend/app/services/enrichment.py
+++ b/backend/app/services/enrichment.py
@@ -11,6 +11,7 @@ Deduplication Strategy:
 4. Enrich UniqueEvents using all related sources via LLM
 """
 
+import asyncio
 import json
 import re
 from collections import Counter, defaultdict
@@ -29,6 +30,25 @@ from app.models import RawEvent, UniqueEvent
 from app.services.extraction_derived import derive_public_fields_from_data
 from app.services.telegram import notify_new_death
 from app.taxonomy import format_legacy_homicide_type, parse_legacy_homicide_type
+
+# Cap Telegram round-trips so a hung notify cannot burn the ARQ job budget (#220).
+NOTIFY_NEW_DEATH_TIMEOUT_SECONDS = 2.0
+
+
+async def _notify_new_death_best_effort(**kwargs) -> None:
+    """Best-effort Telegram notify; never raise into UniqueEvent create/batch."""
+    unique_event_id = kwargs.get("unique_event_id")
+    try:
+        await asyncio.wait_for(
+            notify_new_death(**kwargs),
+            timeout=NOTIFY_NEW_DEATH_TIMEOUT_SECONDS,
+        )
+    except Exception as exc:
+        logger.warning(
+            "[Create] Telegram notify failed for UniqueEvent {}: {}",
+            unique_event_id,
+            exc,
+        )
 
 
 def parse_datetime(value) -> datetime | None:
@@ -1189,6 +1209,20 @@ async def create_unique_event_from_cluster(cluster: list[RawEvent]) -> UniqueEve
                 {"raw_event_id": raw_event_id, "unique_event_id": unique_event_id}
             )
         
+        # Snapshot notify fields before commit so expired ORM attributes cannot
+        # block or fail the post-commit Telegram path (#220).
+        notify_kwargs = {
+            "unique_event_id": unique_event_id,
+            "title": best.title,
+            "city": best.city,
+            "state": best.state,
+            "event_date": best.event_date,
+            "victim_count": best.victim_count,
+            "victims_summary": victims_summary,
+            "homicide_type": best.homicide_type,
+            "source_count": len(cluster),
+        }
+
         await session.commit()
         
         logger.info(f"[Create] Created UniqueEvent {unique_event_id} from {len(cluster)} RawEvent(s): {raw_event_ids}")
@@ -1211,18 +1245,8 @@ async def create_unique_event_from_cluster(cluster: list[RawEvent]) -> UniqueEve
             needs_enrichment=row.needs_enrichment,
         )
         
-        # Send Telegram notification for new death
-        await notify_new_death(
-            unique_event_id=unique_event_id,
-            title=best.title,
-            city=best.city,
-            state=best.state,
-            event_date=best.event_date,
-            victim_count=best.victim_count,
-            victims_summary=victims_summary,
-            homicide_type=best.homicide_type,
-            source_count=len(cluster),
-        )
+        # Best-effort: Telegram must not abort or freeze UniqueEvent create.
+        await _notify_new_death_best_effort(**notify_kwargs)
         
         return unique_event
 
@@ -1752,7 +1776,6 @@ async def enrich_unique_event(unique_event_id: int) -> bool:
                 winning_payload = payload
         
         # Update UniqueEvent with enriched data (retry transient SQLite locks).
-        import asyncio
         from sqlalchemy.exc import OperationalError
 
         update_params = {

--- a/backend/app/services/telegram.py
+++ b/backend/app/services/telegram.py
@@ -70,7 +70,11 @@ class TelegramNotifier:
                 else:
                     logger.error(f"[Telegram] ❌ Failed: {response.status_code} - {response.text}")
                     return False
-                    
+
+        except TimeoutError as e:
+            # asyncio/httpx timeout — never raise to callers (#220).
+            logger.error(f"[Telegram] ❌ Timeout sending message: {e}")
+            return False
         except Exception as e:
             logger.error(f"[Telegram] ❌ Error sending message: {e}")
             return False

--- a/backend/tests/test_batch_dedup_telegram_isolation.py
+++ b/backend/tests/test_batch_dedup_telegram_isolation.py
@@ -1,0 +1,196 @@
+"""Telegram/notify failure must not freeze or abort batch_dedup (#220)."""
+
+from datetime import datetime
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlalchemy import text
+
+from app.models.raw_event import RawEvent
+from app.services.enrichment import (
+    create_unique_event_from_cluster,
+    process_pending_deduplication,
+)
+from app.services.telegram import TelegramNotifier
+
+
+PENDING_COUNT = 10
+CITIES = [
+    "Recife",
+    "Várzea Grande",
+    "Zumbi dos Palmares",
+    "Manaus",
+    "Belém",
+    "Fortaleza",
+    "Salvador",
+    "Natal",
+    "Maceió",
+    "João Pessoa",
+]
+
+
+class _TestSessionMaker:
+    def __init__(self, session):
+        self._session = session
+
+    def __call__(self):
+        return self
+
+    async def __aenter__(self):
+        return self._session
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+def _pending_raw_events() -> list[RawEvent]:
+    return [
+        RawEvent(
+            title=f"HOMICÍDIO - {city.upper()} - 03/09/2026",
+            event_date=datetime(2026, 9, 3),
+            city=city,
+            state="BR",
+            country="BR",
+            victim_count=1,
+            source_google_news_id=2000 + idx,
+            deduplication_status="pending",
+            chronological_description=f"Uma pessoa morreu em {city}.",
+        )
+        for idx, city in enumerate(CITIES)
+    ]
+
+
+async def _count_unique_events(session) -> int:
+    result = await session.execute(text("SELECT COUNT(*) FROM unique_event"))
+    return int(result.scalar_one())
+
+
+async def _count_pending_raw_events(session) -> int:
+    result = await session.execute(
+        text("SELECT COUNT(*) FROM raw_event WHERE deduplication_status = 'pending'")
+    )
+    return int(result.scalar_one())
+
+
+@pytest.mark.asyncio
+async def test_batch_dedup_creates_all_unique_events_when_notify_raises(async_session):
+    """A lot of ≥10 pending clusters must finish even if notify_new_death raises every time."""
+    events = _pending_raw_events()
+    async_session.add_all(events)
+    await async_session.commit()
+    for event in events:
+        await async_session.refresh(event)
+
+    notify_mock = AsyncMock(side_effect=TimeoutError())
+
+    with (
+        patch(
+            "app.services.enrichment.async_session_maker",
+            _TestSessionMaker(async_session),
+        ),
+        patch(
+            "app.services.enrichment.notify_new_death",
+            notify_mock,
+        ),
+        patch(
+            "app.services.enrichment._merge_near_duplicates_in_buckets",
+            AsyncMock(return_value=0),
+        ),
+    ):
+        result = await process_pending_deduplication(limit=20)
+
+    assert result["status"] == "completed"
+    assert result["unique_events_created"] == PENDING_COUNT
+    assert result["processed"] == PENDING_COUNT
+    assert await _count_unique_events(async_session) == PENDING_COUNT
+    assert await _count_pending_raw_events(async_session) == 0
+    assert notify_mock.await_count == PENDING_COUNT
+
+
+@pytest.mark.asyncio
+async def test_create_unique_event_from_cluster_survives_notify_raise(async_session):
+    """UniqueEvent commit must succeed when notify_new_death raises TimeoutError."""
+    raw_event = _pending_raw_events()[0]
+    async_session.add(raw_event)
+    await async_session.commit()
+    await async_session.refresh(raw_event)
+
+    with (
+        patch(
+            "app.services.enrichment.async_session_maker",
+            _TestSessionMaker(async_session),
+        ),
+        patch(
+            "app.services.enrichment.notify_new_death",
+            AsyncMock(side_effect=TimeoutError("telegram hung")),
+        ),
+    ):
+        unique_event = await create_unique_event_from_cluster([raw_event])
+
+    assert unique_event.id is not None
+    assert await _count_unique_events(async_session) == 1
+    clustered = await async_session.execute(
+        text("SELECT deduplication_status FROM raw_event WHERE id = :id"),
+        {"id": raw_event.id},
+    )
+    assert clustered.scalar_one() == "clustered"
+
+
+@pytest.mark.asyncio
+async def test_create_unique_event_from_cluster_does_not_wait_on_slow_notify(
+    async_session,
+):
+    """Slow Telegram must not serialize into UniqueEvent create for more than a short cap."""
+    import asyncio
+    import time
+
+    raw_event = _pending_raw_events()[1]
+    async_session.add(raw_event)
+    await async_session.commit()
+    await async_session.refresh(raw_event)
+
+    async def slow_notify(**kwargs):
+        await asyncio.sleep(10)
+        raise TimeoutError("still hanging")
+
+    started = time.perf_counter()
+    with (
+        patch(
+            "app.services.enrichment.async_session_maker",
+            _TestSessionMaker(async_session),
+        ),
+        patch(
+            "app.services.enrichment.notify_new_death",
+            slow_notify,
+        ),
+    ):
+        unique_event = await create_unique_event_from_cluster([raw_event])
+    elapsed = time.perf_counter() - started
+
+    assert unique_event.id is not None
+    assert elapsed < 3.0, f"create blocked on Telegram for {elapsed:.2f}s"
+    assert await _count_unique_events(async_session) == 1
+
+
+@pytest.mark.asyncio
+async def test_send_message_returns_false_on_timeout_error():
+    """httpx/asyncio TimeoutError must not escape send_message."""
+    notifier = TelegramNotifier.__new__(TelegramNotifier)
+    notifier.bot_token = "token"
+    notifier.chat_id = "123"
+    notifier.enabled = True
+
+    class _BoomClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return False
+
+        async def post(self, *args, **kwargs):
+            raise TimeoutError()
+
+    with patch("app.services.telegram.httpx.AsyncClient", return_value=_BoomClient()):
+        result = await notifier.send_message("hello")
+
+    assert result is False

--- a/backend/tests/test_batch_dedup_telegram_isolation.py
+++ b/backend/tests/test_batch_dedup_telegram_isolation.py
@@ -1,5 +1,7 @@
 """Telegram/notify failure must not freeze or abort batch_dedup (#220)."""
 
+import asyncio
+import time
 from datetime import datetime
 from unittest.mock import AsyncMock, patch
 
@@ -12,7 +14,6 @@ from app.services.enrichment import (
     process_pending_deduplication,
 )
 from app.services.telegram import TelegramNotifier
-
 
 PENDING_COUNT = 10
 CITIES = [
@@ -115,6 +116,7 @@ async def test_create_unique_event_from_cluster_survives_notify_raise(async_sess
     await async_session.commit()
     await async_session.refresh(raw_event)
 
+    raw_event_id = raw_event.id
     with (
         patch(
             "app.services.enrichment.async_session_maker",
@@ -131,7 +133,7 @@ async def test_create_unique_event_from_cluster_survives_notify_raise(async_sess
     assert await _count_unique_events(async_session) == 1
     clustered = await async_session.execute(
         text("SELECT deduplication_status FROM raw_event WHERE id = :id"),
-        {"id": raw_event.id},
+        {"id": raw_event_id},
     )
     assert clustered.scalar_one() == "clustered"
 
@@ -141,9 +143,6 @@ async def test_create_unique_event_from_cluster_does_not_wait_on_slow_notify(
     async_session,
 ):
     """Slow Telegram must not serialize into UniqueEvent create for more than a short cap."""
-    import asyncio
-    import time
-
     raw_event = _pending_raw_events()[1]
     async_session.add(raw_event)
     await async_session.commit()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 📝 Descrição

`batch_dedup_task` awaited `notify_new_death` **inline after each UniqueEvent commit**. A slow or failing Telegram path (httpx timeout up to 10s per create, or an uncaught `TimeoutError`) serialized into the batch and could burn the ARQ job budget after only 1–2 creates, leaving remaining pending RawEvents undrained.

This matches the prod hang on 2026-09-04 (~00:42–00:45 UTC): UniqueEvent 12634–12636 then `TimeoutError` with an empty message, with Telegram `send_message` failing at the same moment.

**Fix (minimal, Telegram kept):** after UniqueEvent commit, notification is best-effort:
- Snapshot notify fields before commit (avoids expired-ORM access on the Telegram path)
- `asyncio.wait_for(notify_new_death(...), timeout=2)` inside try/except
- Failure is logged as a warning; `create_unique_event_from_cluster` still returns
- `TelegramNotifier.send_message` still never raises (`TimeoutError` → `False`)

Clustering/LLM matching is unchanged. Workers are not restarted. Does not mix #204 or #216.

## 🔗 Issue Relacionada

Fixes #220

## 🏷️ Tipo de Mudança

- [x] 🐛 Bug fix (mudança que corrige um problema)
- [x] ✅ Testes (adição ou correção de testes)

## 🧪 Como Foi Testado?

TDD red → green:

**Red** (notify awaited inline): `TimeoutError` from `notify_new_death` aborted the batch after UniqueEvent 1.

**Green:**
- `test_batch_dedup_creates_all_unique_events_when_notify_raises` — 10 pending clusters all create UniqueEvents; notify raises every call; batch does not raise
- `test_create_unique_event_from_cluster_survives_notify_raise`
- `test_create_unique_event_from_cluster_does_not_wait_on_slow_notify` — 10s hang capped at 2s
- `test_send_message_returns_false_on_timeout_error`

Also green: `test_batch_dedup_still_clusters_when_no_existing_match`, title-blocking / victim-extraction / pair-signal dedup tests (21 passed).

- [x] Testes unitários
- [x] Testado em desenvolvimento local

**Ambiente de teste:** Linux Cloud Agent, `uv run pytest` in `backend/`

## ✅ Checklist

- [x] Meu código segue o guia de estilo do projeto
- [x] Realizei uma auto-revisão do meu código
- [x] Adicionei testes que provam que meu fix/feature funciona
- [x] Testes unitários novos e existentes passam localmente

## 💬 Notas Adicionais

- Draft against `develop` only. Do not merge. Do not mark ready.
- Does **not** mix #204 (naive dates) or #216 counter work.
- Does **not** restart workers or delete SA leftover rows.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-45f3dedc-8860-4a49-93c2-97f1c930f5c7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-45f3dedc-8860-4a49-93c2-97f1c930f5c7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

