### PR TITLE
fix(pipeline-health): cherry-pick remediator NameError fix onto master (#224)

### DIFF
--- a/backend/app/services/pipeline_health.py
+++ b/backend/app/services/pipeline_health.py
@@ -189,3 +189,38 @@ def should_enqueue_classify_during_remediation(
         return True, "no_pipeline_with_recent_ingest"
     
     return False, "no_condition_met"
+
+
+def bash_bool_to_python_literal(value: str) -> str:
+    """Convert a bash true/false string to a Python True/False literal.
+
+    ``scripts/check-pipeline-health.sh`` interpolates these into an unquoted
+    ``<<PY`` heredoc. Interpolating lowercase ``true``/``false`` is a
+    ``NameError`` (issue #224).
+    """
+    if value == "true":
+        return "True"
+    if value == "false":
+        return "False"
+    raise ValueError(f"expected bash true/false, got {value!r}")
+
+
+def remediator_enqueue_followup(
+    classify_decision_output: str,
+    had_no_pipeline: bool,
+    had_stale_ingest: bool,
+) -> str:
+    """Choose remediator follow-up from the classify-enqueue snippet output.
+
+    A failed or unparseable decision must not enqueue the pipeline (issue #224).
+    The pipeline branch runs only after a clean ``enqueue=False``.
+
+    Returns one of: ``classify``, ``pipeline``, ``skip``, ``error``.
+    """
+    if "enqueue=True" in classify_decision_output:
+        return "classify"
+    if "enqueue=False" in classify_decision_output:
+        if had_no_pipeline or had_stale_ingest:
+            return "pipeline"
+        return "skip"
+    return "error"

--- a/backend/tests/test_pipeline_health.py
+++ b/backend/tests/test_pipeline_health.py
@@ -1,14 +1,22 @@
 """Tests for pipeline health check and remediation logic."""
 
-import pytest
+import subprocess
 from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
 
 from app.services.pipeline_health import (
     InProgressJob,
     WorkerLogs,
-    should_treat_lock_as_stale,
+    bash_bool_to_python_literal,
+    remediator_enqueue_followup,
     should_enqueue_classify_during_remediation,
+    should_treat_lock_as_stale,
 )
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HEALTH_SCRIPT = REPO_ROOT / "scripts" / "check-pipeline-health.sh"
 
 
 class TestInProgressJob:
@@ -316,3 +324,151 @@ class TestShouldEnqueueClassifyDuringRemediation:
         
         assert not should_enqueue
         assert reason == "active_ingest_with_progress"
+
+
+class TestBashBoolToPythonLiteral:
+    """Convert bash true/false so unquoted heredoc interpolation is valid Python (issue #224)."""
+
+    def test_false_becomes_python_false(self):
+        assert bash_bool_to_python_literal("false") == "False"
+
+    def test_true_becomes_python_true(self):
+        assert bash_bool_to_python_literal("true") == "True"
+
+    def test_rejects_other_values(self):
+        with pytest.raises(ValueError):
+            bash_bool_to_python_literal("False")
+
+
+class TestRemediatorEnqueueFollowup:
+    """
+    Issue #224: a failed classify-enqueue decide must not silently enqueue pipeline.
+
+    The elif had_no_pipeline || had_stale_ingest branch may run only after a clean
+    enqueue=False decision.
+    """
+
+    def test_error_decision_does_not_enqueue_pipeline_when_no_pipeline(self):
+        action = remediator_enqueue_followup(
+            "enqueue=error;reason=check_failed",
+            had_no_pipeline=True,
+            had_stale_ingest=False,
+        )
+        assert action == "error"
+
+    def test_error_decision_does_not_enqueue_pipeline_when_stale_ingest(self):
+        action = remediator_enqueue_followup(
+            "enqueue=error;reason=check_failed",
+            had_no_pipeline=False,
+            had_stale_ingest=True,
+        )
+        assert action == "error"
+
+    def test_empty_or_traceback_decision_is_error_not_pipeline(self):
+        traceback = "NameError: name 'false' is not defined\nenqueue=error;reason=check_failed"
+        assert (
+            remediator_enqueue_followup(
+                traceback, had_no_pipeline=True, had_stale_ingest=True
+            )
+            == "error"
+        )
+        assert remediator_enqueue_followup("", had_no_pipeline=True, had_stale_ingest=True) == "error"
+
+    def test_clean_false_with_no_pipeline_enqueues_pipeline(self):
+        action = remediator_enqueue_followup(
+            "enqueue=False;reason=no_condition_met",
+            had_no_pipeline=True,
+            had_stale_ingest=False,
+        )
+        assert action == "pipeline"
+
+    def test_clean_false_with_stale_ingest_enqueues_pipeline(self):
+        action = remediator_enqueue_followup(
+            "enqueue=False;reason=no_condition_met",
+            had_no_pipeline=False,
+            had_stale_ingest=True,
+        )
+        assert action == "pipeline"
+
+    def test_clean_false_without_pipeline_flags_skips(self):
+        action = remediator_enqueue_followup(
+            "enqueue=False;reason=no_condition_met",
+            had_no_pipeline=False,
+            had_stale_ingest=False,
+        )
+        assert action == "skip"
+
+    def test_clean_true_enqueues_classify(self):
+        action = remediator_enqueue_followup(
+            "enqueue=True;reason=queue_jammed",
+            had_no_pipeline=True,
+            had_stale_ingest=True,
+        )
+        assert action == "classify"
+
+
+class TestRemediatorBoolInterpolation:
+    """The unquoted <<PY heredoc must not see bash lowercase true/false (issue #224)."""
+
+    def test_py_bool_false_flags_do_not_nameerror(self):
+        """All three remediator flags as bash false interpolate as Python False."""
+        script = r"""
+        py_bool() { [ "$1" = true ] && echo True || echo False; }
+        had_queue_jam_py=$(py_bool false)
+        had_no_pipeline_py=$(py_bool false)
+        had_recent_ingest_py=$(py_bool false)
+        python3 - <<PY
+had_queue_jam = ${had_queue_jam_py}
+had_no_pipeline = ${had_no_pipeline_py}
+had_recent_ingest = ${had_recent_ingest_py}
+assert had_queue_jam is False
+assert had_no_pipeline is False
+assert had_recent_ingest is False
+print("ok")
+PY
+        """
+        result = subprocess.run(
+            ["bash", "-c", script],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.strip() == "ok"
+        assert "NameError" not in result.stderr
+
+    def test_raw_bash_false_in_heredoc_nameerrors(self):
+        """Document the original bug: interpolating bash false is a Python NameError."""
+        script = r"""
+        had_queue_jam=false
+        python3 - <<PY
+had_queue_jam = ${had_queue_jam}
+print(had_queue_jam)
+PY
+        """
+        result = subprocess.run(
+            ["bash", "-c", script],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode != 0
+        assert "NameError" in result.stderr
+        assert "false" in result.stderr
+
+    def test_health_script_interpolates_python_bool_literals(self):
+        text = HEALTH_SCRIPT.read_text()
+        assert 'py_bool() { [ "$1" = true ] && echo True || echo False; }' in text
+        assert "had_queue_jam=${had_queue_jam_py}" in text
+        assert "had_no_pipeline=${had_no_pipeline_py}" in text
+        assert "had_recent_ingest=${had_recent_ingest_py}" in text
+        assert "had_stale_ingest=${had_stale_ingest_py}" in text
+        assert "had_queue_jam=${had_queue_jam}," not in text
+        assert "remediator_enqueue_followup" in text
+        assert "enqueue_classify_decision_failed" in text
+        assert 'should_enqueue_classify="enqueue=error;reason=check_failed;action=error"' in text
+        # Old bug: elif ran on bash flags even when Python decide failed (issue #224).
+        assert (
+            'elif [ "$had_no_pipeline" = true ] || [ "$had_stale_ingest" = true ]; then'
+            not in text
+        )

--- a/backend/tests/test_pipeline_health.py
+++ b/backend/tests/test_pipeline_health.py
@@ -465,6 +465,7 @@ PY
         assert "had_stale_ingest=${had_stale_ingest_py}" in text
         assert "had_queue_jam=${had_queue_jam}," not in text
         assert "remediator_enqueue_followup" in text
+        assert "except ImportError:" in text
         assert "enqueue_classify_decision_failed" in text
         assert 'should_enqueue_classify="enqueue=error;reason=check_failed;action=error"' in text
         # Old bug: elif ran on bash flags even when Python decide failed (issue #224).

--- a/scripts/check-pipeline-health.sh
+++ b/scripts/check-pipeline-health.sh
@@ -435,9 +435,21 @@ sys.path.insert(0, "/app")
 from app.services.pipeline_health import (
     InProgressJob,
     WorkerLogs,
-    remediator_enqueue_followup,
     should_enqueue_classify_during_remediation,
 )
+# Prod API may not have this helper until a backend deploy. Inline fallback so
+# the synced health script still works against the running image (issue #224).
+try:
+    from app.services.pipeline_health import remediator_enqueue_followup
+except ImportError:
+    def remediator_enqueue_followup(classify_decision_output, had_no_pipeline, had_stale_ingest):
+        if "enqueue=True" in classify_decision_output:
+            return "classify"
+        if "enqueue=False" in classify_decision_output:
+            if had_no_pipeline or had_stale_ingest:
+                return "pipeline"
+            return "skip"
+        return "error"
 
 # Parse in-progress keys
 in_progress_raw = """$arq_in_progress_raw"""

--- a/scripts/check-pipeline-health.sh
+++ b/scripts/check-pipeline-health.sh
@@ -102,6 +102,10 @@ echo_step() {
     fi
 }
 
+# Convert bash true/false to a Python True/False literal for unquoted <<PY
+# heredocs. Interpolating lowercase true/false is a NameError (issue #224).
+py_bool() { [ "$1" = true ] && echo True || echo False; }
+
 # --- Checks -------------------------------------------------------------------
 
 echo_step "🏥 Pipeline health check ($(date -u +%Y-%m-%dT%H:%M:%SZ))"
@@ -421,10 +425,19 @@ if [ "$REMEDIATE" = true ]; then
     fi
     # Use Python logic to decide whether to enqueue classify (considers active ingest)
     worker_logs_for_classify_check="$(docker logs "$WORKER_CONTAINER" --since "${PIPELINE_ACTIVITY_MINUTES}m" 2>&1 || true)"
-    should_enqueue_classify="$(docker compose $COMPOSE_PROD exec -T api python - <<PY
+    had_queue_jam_py="$(py_bool "$had_queue_jam")"
+    had_no_pipeline_py="$(py_bool "$had_no_pipeline")"
+    had_recent_ingest_py="$(py_bool "$had_recent_ingest")"
+    had_stale_ingest_py="$(py_bool "$had_stale_ingest")"
+    if ! should_enqueue_classify="$(docker compose $COMPOSE_PROD exec -T api python - <<PY
 import sys
 sys.path.insert(0, "/app")
-from app.services.pipeline_health import InProgressJob, WorkerLogs, should_enqueue_classify_during_remediation
+from app.services.pipeline_health import (
+    InProgressJob,
+    WorkerLogs,
+    remediator_enqueue_followup,
+    should_enqueue_classify_during_remediation,
+)
 
 # Parse in-progress keys
 in_progress_raw = """$arq_in_progress_raw"""
@@ -438,27 +451,41 @@ for line in in_progress_raw.strip().split('\n'):
 logs = WorkerLogs("""$worker_logs_for_classify_check""")
 
 # Check if we should enqueue classify
-should_enqueue, reason = should_enqueue_classify_during_remediation(
-    had_queue_jam=${had_queue_jam},
-    had_no_pipeline=${had_no_pipeline},
-    had_recent_ingest=${had_recent_ingest},
-    in_progress_jobs=jobs,
-    worker_logs=logs,
+try:
+    should_enqueue, reason = should_enqueue_classify_during_remediation(
+        had_queue_jam=${had_queue_jam_py},
+        had_no_pipeline=${had_no_pipeline_py},
+        had_recent_ingest=${had_recent_ingest_py},
+        in_progress_jobs=jobs,
+        worker_logs=logs,
+    )
+    decision = f"enqueue={should_enqueue};reason={reason}"
+except Exception:
+    decision = "enqueue=error;reason=check_failed"
+action = remediator_enqueue_followup(
+    decision,
+    had_no_pipeline=${had_no_pipeline_py},
+    had_stale_ingest=${had_stale_ingest_py},
 )
-print(f"enqueue={should_enqueue};reason={reason}")
+print(f"{decision};action={action}")
 PY
-)" || echo "enqueue=error;reason=check_failed"
-    
-    # Prefer classify when appropriate, but NOT when ingest is active
-    if echo "$should_enqueue_classify" | grep -q 'enqueue=True'; then
-        enqueue_reason="$(echo "$should_enqueue_classify" | sed -n 's/.*reason=\([^;]*\).*/\1/p')"
+)"; then
+        should_enqueue_classify="enqueue=error;reason=check_failed;action=error"
+    fi
+
+    # Prefer classify when appropriate, but NOT when ingest is active.
+    # Failed decide (action=error / missing) must not enqueue pipeline (issue #224).
+    classify_action="$(echo "$should_enqueue_classify" | sed -n 's/.*action=\([^;]*\).*/\1/p')"
+    enqueue_reason="$(echo "$should_enqueue_classify" | sed -n 's/.*reason=\([^;]*\).*/\1/p')"
+    if [ "$classify_action" = classify ]; then
         DETAILS+=("INFO: enqueue_classify_decision(reason=${enqueue_reason})")
         tier_a_enqueue_classify || true
-    elif [ "$had_no_pipeline" = true ] || [ "$had_stale_ingest" = true ]; then
-        # Only enqueue pipeline if classify was not appropriate
+    elif [ "$classify_action" = pipeline ]; then
+        # Only when Python decide succeeded and returned enqueue=False
         tier_a_enqueue_pipeline || true
+    elif [ "$classify_action" = error ] || [ -z "$classify_action" ]; then
+        DETAILS+=("WARN: enqueue_classify_decision_failed(reason=${enqueue_reason:-check_failed})")
     else
-        enqueue_reason="$(echo "$should_enqueue_classify" | sed -n 's/.*reason=\([^;]*\).*/\1/p')"
         DETAILS+=("INFO: skip_classify_enqueue(reason=${enqueue_reason})")
     fi
     if [ "$had_stuck" = true ]; then


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 📝 Descrição

Cherry-pick of PR #225 (`ec21056`) onto `master` so the scheduled Pipeline Health workflow stops:

1. `NameError: name 'false' is not defined` from interpolating bash `true`/`false` into an unquoted `<<PY` heredoc
2. Silently enqueueing `ingest_cities_full_pipeline` when the classify-enqueue decide fails (`enqueue=error;reason=check_failed`)

Latest master health run 33908170666 still shows both symptoms. The workflow checks out `master` and syncs `scripts/check-pipeline-health.sh` to the VPS; merging this PR is enough for the next scheduled run **if Deploy Backend is not allowed to run** (see notes).

**What changed (same as #225):**
- `py_bool` converts bash `true`/`false` to Python `True`/`False` before heredoc interpolation
- `remediator_enqueue_followup` only returns `pipeline` after a clean `enqueue=False`
- Failed decide (`enqueue=error` / `action=error`) logs `WARN: enqueue_classify_decision_failed` and does **not** call classify or pipeline

**Master-only follow-up:** the health workflow does **not** deploy the API image. Production currently lacks `remediator_enqueue_followup`. The script falls back to an in-heredoc copy on `ImportError` so the next scheduled run can still decide classify/pipeline/skip without a backend deploy.

**Not in this PR** (left on `develop`): Telegram isolation (#216/#220/#223), Redis health parse (#221/#222), date-extraction #204, `/estatisticas`, or any other develop-only work.

Diff vs `master` is three files only:
- `scripts/check-pipeline-health.sh`
- `backend/app/services/pipeline_health.py` (helpers only; no Redis timestamp #221/#222)
- `backend/tests/test_pipeline_health.py` (issue #224 tests)

## 🔗 Issue Relacionada

Cherry-pick of #225 for production. Relates to #224.

## 🏷️ Tipo de Mudança

- [x] 🐛 Bug fix (mudança que corrige um problema)
- [x] ✅ Testes (adição ou correção de testes)

## 🧪 Como Foi Testado?

- [x] Testes unitários — `pytest --noconftest tests/test_pipeline_health.py` **33 passed**
- [ ] Testes de integração (não aplicável — sem restart de worker / sem staging)
- [x] Testes manuais — bash simulation of NameError vs py_bool + `enqueue=error` does not enqueue pipeline
- [x] Testado em desenvolvimento local (`pytest --noconftest` + `bash -n`)
- [ ] Testado com Docker (Docker unavailable in this Cloud Agent environment)

**Ambiente de teste:**
- OS: Linux (Cloud Agent)
- Sem deploy de backend / sem GitHub Actions Deploy Backend para master

**Results:**
- `bash -n scripts/check-pipeline-health.sh` OK
- Raw bash `false` in `<<PY` still NameErrors (bug repro)
- `py_bool false` interpolates as Python `False` (no NameError)
- `enqueue=error` + `had_no_pipeline=true` → `WARN: enqueue_classify_decision_failed`, **not** `enqueued_ingest_cities_full_pipeline`
- ImportError fallback still returns classify/pipeline/skip on a clean decide

This repo has no PR unit-test workflow (only deploy workflows on **push** to `master`/`develop`). Local pytest is the verification.

## ✅ Checklist

- [x] Meu código segue o guia de estilo do projeto
- [x] Realizei uma auto-revisão do meu código
- [x] Adicionei testes que provam que meu fix/feature funciona
- [x] Testes unitários novos e existentes passam localmente (33 passed)
- [x] Diff vs master limitado ao remediator/`py_bool` fix (+ ImportError fallback)
- [x] Sem misturar #204, #216/#220/#223, #221/#222
- [x] Sem deploy de backend neste recorte
- [x] Base = `master`

## 💬 Notas Adicionais

- Do **not** merge from the agent. Human review first.
- **Merging this PR to `master` will trigger Deploy Backend.** `.github/workflows/deploy-backend.yml` runs on push to `master` when `backend/**` or `scripts/check-pipeline-health.sh` change, and that job copies the production database onto staging. To apply the health-script fix without that deploy, merge with `[skip ci]` (or cancel Deploy Backend immediately if it starts).
- After the script is on `master`, the next scheduled Pipeline Health run syncs it to the VPS automatically. No production backend image deploy is required thanks to the ImportError fallback.

Cherry-picked commit: `ec21056` (`fix(pipeline-health): convert bash bools before remediator Python (#224)`).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-55256121-de96-4d8a-8a47-458c7ed08725?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-55256121-de96-4d8a-8a47-458c7ed08725&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

