### PR TITLE
fix(pipeline_health): ignore invalid Redis timestamps in from_redis_key (#221)

### DIFF
--- a/backend/app/services/pipeline_health.py
+++ b/backend/app/services/pipeline_health.py
@@ -29,11 +29,14 @@ class InProgressJob:
         # For cron jobs: arq:in-progress:cron:JOB_NAME:TIMESTAMP
         if len(parts) >= 4 and parts[2] == "cron":
             job_name = parts[3]
-            # Try to parse timestamp if present
+            # .isdigit() is not a valid Unix-seconds check; catch fromtimestamp
+            # failures so malformed Redis keys cannot crash the health check.
+            enqueued_at = None
             if len(parts) >= 5 and parts[4].isdigit():
-                enqueued_at = datetime.fromtimestamp(int(parts[4]), tz=timezone.utc)
-            else:
-                enqueued_at = None
+                try:
+                    enqueued_at = datetime.fromtimestamp(int(parts[4]), tz=timezone.utc)
+                except (ValueError, OverflowError, OSError):
+                    enqueued_at = None
         else:
             # Non-cron job: arq:in-progress:JOB_ID
             job_name = "unknown"

--- a/backend/tests/test_pipeline_health.py
+++ b/backend/tests/test_pipeline_health.py
@@ -49,6 +49,26 @@ class TestInProgressJob:
         assert job.job_name == "unknown"
         assert job.enqueued_at is None
 
+    def test_parse_cron_job_key_with_out_of_range_timestamp(self):
+        """Malformed numeric junk in parts[4] must not crash the health check.
+
+        .isdigit() accepts huge digit strings that are not valid Unix-seconds
+        timestamps. datetime.fromtimestamp then raises ValueError (year out of
+        range) — production: year 58644 from Pipeline Health run 33817606339.
+        """
+        # Huge digit string: fromtimestamp raises ValueError (year out of range).
+        # Production (run 33817606339) failed with year 58644.
+        junk_ts = "1850000000000"
+        with pytest.raises((ValueError, OverflowError, OSError)):
+            datetime.fromtimestamp(int(junk_ts), tz=timezone.utc)
+
+        key = f"arq:in-progress:cron:ingest_cities_hourly:{junk_ts}"
+        job = InProgressJob.from_redis_key(key)
+
+        assert job.key == key
+        assert job.job_name == "ingest_cities_hourly"
+        assert job.enqueued_at is None
+
 
 class TestWorkerLogs:
     """Tests for WorkerLogs progress detection using ACTUAL log patterns."""


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 📝 Descrição

Cherry-pick of the Redis `from_redis_key` harden onto **master only**.

Malformed ARQ in-progress keys can put numeric junk in `parts[4]`. `.isdigit()` accepts that junk, then `datetime.fromtimestamp` raises `ValueError: year … is out of range` and the Pipeline Health check crashes (false positive during live BR ingest).

This wraps `fromtimestamp` in `try/except (ValueError, OverflowError, OSError)`, sets `enqueued_at=None`, and keeps `job_name`.

Source on develop: `fb4927e3c6673a06829c9a251829c1ad817faa54` (PR #222 / issue #221). Applied with `git cherry-pick fb4927e3` onto current `origin/master` (`1257e13aa7a5` — remediator #224/#226 already on master). Auto-merged cleanly; remediator helpers on master are unchanged.

Prod failure this ports: https://github.com/JoaoCarabetta/arquivo-da-violencia/actions/runs/34249494548

## 🔗 Issue Relacionada

Fixes #221 (prod master still unguarded; develop already has this from PR #222)

## 🏷️ Tipo de Mudança

- [x] 🐛 Bug fix (mudança que corrige um problema)

## 🧪 Como Foi Testado?

- [x] Testes unitários
- [ ] Testes de integração
- [ ] Testes manuais
- [ ] Testado em desenvolvimento local
- [ ] Testado com Docker

**Ambiente de teste:**
- OS: Cloud agent Linux
- Command: `pytest backend/tests/test_pipeline_health.py -v`

## ✅ Checklist

- [x] Meu código segue o guia de estilo do projeto
- [x] Realizei uma auto-revisão do meu código
- [x] Comentei meu código em áreas complexas
- [ ] Atualizei a documentação correspondente
- [x] Minhas mudanças não geram novos warnings
- [x] Adicionei testes que provam que meu fix/feature funciona
- [x] Testes unitários novos e existentes passam localmente
- [x] Quaisquer mudanças dependentes foram mergeadas
- [ ] Atualizei o CHANGELOG (se aplicável)

## 💬 Notas Adicionais

**Scope locks (do not merge extra work):**
- Base: `origin/master` only. One draft PR against `master`. Do not merge. Do not mark ready.
- **Only** the #221/#222 `from_redis_key` try/except + `test_parse_cron_job_key_with_out_of_range_timestamp`.
- **Not included:** #216 (classification counter), #220/#223 (batch_dedup Telegram), estatisticas, #204.
- **Not** a merge of develop.

Cherry-pick vs manual port: **cherry-pick** of `fb4927e3` (no conflicts).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0f499053-4e21-43ee-b9c2-fec1f2a1f1cb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0f499053-4e21-43ee-b9c2-fec1f2a1f1cb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

