### PR TITLE
fix(extract): clamp Brazil event dates after publication (#228)

### DIFF
--- a/backend/app/services/extraction_heuristics.py
+++ b/backend/app/services/extraction_heuristics.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import re
-from datetime import datetime
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta
+
 from unidecode import unidecode
 
 from app.services.extraction_schemas import ViolentDeathEvent
@@ -273,20 +275,122 @@ def should_be_qualificado(text: str) -> bool:
     return False
 
 
+DEFAULT_FUTURE_DATE_SKEW_DAYS = 1
+NULL_DATE_PRECISION = "não informada"
+
+_REFERENCE_DATETIME_FORMATS = (
+    "%d/%m/%Y as %H:%M",
+    "%d/%m/%Y",
+    "%Y-%m-%d %H:%M:%S.%f",
+    "%Y-%m-%d %H:%M:%S",
+    "%Y-%m-%d",
+)
+
+
+@dataclass(frozen=True)
+class EventDateClampResult:
+    """Outcome of the future-vs-publish date clamp (issue #228)."""
+
+    date: str | None
+    date_precision: str | None
+    action: str  # keep | previous_year | null
+
+    @property
+    def changed(self) -> bool:
+        return self.action != "keep"
+
+
+def parse_reference_datetime(value: object) -> datetime | None:
+    """Parse published_at / created_at from datetime, ISO, or BR extract metadata."""
+    if value is None or value == "":
+        return None
+    if isinstance(value, datetime):
+        return value.replace(tzinfo=None) if value.tzinfo else value
+    if isinstance(value, date):
+        return datetime.combine(value, datetime.min.time())
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    if not text:
+        return None
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+        return parsed.replace(tzinfo=None) if parsed.tzinfo else parsed
+    except ValueError:
+        pass
+    ascii_text = unidecode(text)
+    for fmt in _REFERENCE_DATETIME_FORMATS:
+        try:
+            return datetime.strptime(ascii_text, fmt)
+        except ValueError:
+            continue
+    return None
+
+
+def _as_date(value: object) -> date | None:
+    if value is None or value == "":
+        return None
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, date):
+        return value
+    parsed = parse_reference_datetime(value)
+    return parsed.date() if parsed else None
+
+
+def resolve_publish_reference(metadata: dict | None) -> datetime | None:
+    """published_at, else created_at / fetched_at when publish is missing."""
+    if not metadata:
+        return None
+    for key in ("published_at", "created_at", "fetched_at"):
+        parsed = parse_reference_datetime(metadata.get(key))
+        if parsed:
+            return parsed
+    return None
+
+
 def _parse_published_at(metadata: dict | None) -> datetime | None:
     if not metadata:
         return None
-    published_at = metadata.get("published_at")
-    if not published_at:
-        return None
-    if isinstance(published_at, datetime):
-        return published_at
-    if isinstance(published_at, str):
-        try:
-            return datetime.fromisoformat(published_at.replace("Z", "+00:00"))
-        except ValueError:
-            return None
-    return None
+    return parse_reference_datetime(metadata.get("published_at"))
+
+
+def clamp_event_date_against_publish(
+    event_date: date | datetime | str | None,
+    reference: date | datetime | str | None,
+    *,
+    skew_days: int = DEFAULT_FUTURE_DATE_SKEW_DAYS,
+) -> EventDateClampResult:
+    """Reject event dates strictly after publish/created_at + skew.
+
+    Prefer the same month/day in the previous year when that date is still
+    plausible (≤ reference + skew); otherwise null the date.
+    """
+    event_d = _as_date(event_date)
+    if event_d is None:
+        return EventDateClampResult(date=None, date_precision=None, action="keep")
+    iso = event_d.isoformat()
+    ref_d = _as_date(reference)
+    if ref_d is None:
+        return EventDateClampResult(date=iso, date_precision=None, action="keep")
+    limit = ref_d + timedelta(days=skew_days)
+    if event_d <= limit:
+        return EventDateClampResult(date=iso, date_precision=None, action="keep")
+    try:
+        previous = event_d.replace(year=event_d.year - 1)
+    except ValueError:
+        previous = None
+    if previous is not None and previous <= limit:
+        return EventDateClampResult(
+            date=previous.isoformat(),
+            date_precision=None,
+            action="previous_year",
+        )
+    return EventDateClampResult(
+        date=None,
+        date_precision=NULL_DATE_PRECISION,
+        action="null",
+    )
 
 
 def fix_weekday_paren_day(
@@ -525,9 +629,28 @@ def apply_extraction_heuristics(
 
     fixed_date = infer_date_from_source(content, metadata, event.date_time.date)
     normalized_date = normalize_date_string(fixed_date or event.date_time.date)
-    if normalized_date != event.date_time.date:
-        dt = event.date_time.model_copy(update={"date": normalized_date})
-        updates["date_time"] = dt
+    clamped = clamp_event_date_against_publish(
+        normalized_date,
+        resolve_publish_reference(metadata),
+    )
+    dt_update: dict = {}
+    if clamped.action == "null":
+        dt_update["date"] = None
+        dt_update["date_precision"] = clamped.date_precision
+        dt_update["date_verification"] = event.date_time.date_verification.model_copy(
+            update={
+                "has_explicit_date": False,
+                "date_source": "none",
+                "verification_reasoning": (
+                    "event_date after publication; year rejected "
+                    "(issue #228 future-vs-publish clamp)"
+                ),
+            }
+        )
+    elif clamped.date != event.date_time.date:
+        dt_update["date"] = clamped.date
+    if dt_update:
+        updates["date_time"] = event.date_time.model_copy(update=dt_update)
 
     fatal_count = infer_fatal_victim_count(source)
     if fatal_count and event.victims.number_of_victims != fatal_count:

--- a/backend/app/services/maintenance.py
+++ b/backend/app/services/maintenance.py
@@ -1,6 +1,7 @@
 """Maintenance helpers for recovering the pipeline from stuck states."""
 
 import asyncio
+import json
 from datetime import date, datetime, timedelta
 from typing import Any
 
@@ -11,7 +12,6 @@ from app.config import get_settings
 from app.database import async_session_maker
 from app.services import diagnostics
 from app.services.enrichment import normalize_title
-
 
 # Map of transient "claimed" statuses back to the queue status they should
 # return to if a worker crashed / errored out mid-processing and left the row
@@ -723,3 +723,228 @@ async def backfill_null_resolved_urls(
         "failed": failed,
         "skipped": 0,
     }
+
+
+def _patch_extraction_date_payload(
+    payload: Any,
+    date_iso: str | None,
+    precision: str | None,
+) -> Any:
+    """Keep UniqueEvent.merged_data / RawEvent.extraction_data date fields in sync."""
+    if payload is None:
+        return None
+    if isinstance(payload, str):
+        try:
+            payload = json.loads(payload)
+        except json.JSONDecodeError:
+            return payload
+    if not isinstance(payload, dict):
+        return payload
+    date_time = payload.get("date_time")
+    if not isinstance(date_time, dict):
+        date_time = {}
+    new_dt = dict(date_time)
+    new_dt["date"] = date_iso
+    if precision is not None:
+        new_dt["date_precision"] = precision
+    if date_iso is None:
+        verification = dict(date_time.get("date_verification") or {})
+        verification["has_explicit_date"] = False
+        verification["date_source"] = "none"
+        new_dt["date_verification"] = verification
+    return {**payload, "date_time": new_dt}
+
+
+def _earliest_datetime(values: list[Any]) -> datetime | None:
+    from app.services.extraction_heuristics import parse_reference_datetime
+
+    parsed = [item for item in (parse_reference_datetime(value) for value in values) if item]
+    return min(parsed) if parsed else None
+
+
+async def remediate_future_event_dates(
+    *,
+    dry_run: bool = False,
+    country: str = "BR",
+) -> dict[str, Any]:
+    """Clamp Brazil UniqueEvent dates that sit after linked source publication.
+
+    Default writes the fix. Pass dry_run=True to report only.
+    """
+    from app.services.extraction_heuristics import (
+        clamp_event_date_against_publish,
+        parse_reference_datetime,
+    )
+
+    country_upper = (country or "BR").upper()
+    aliases = ("BR", "BRASIL") if country_upper in {"BR", "BRASIL"} else (country_upper,)
+
+    audit: dict[str, Any] = {
+        "dry_run": dry_run,
+        "country": country_upper,
+        "scanned": 0,
+        "updated": 0,
+        "would_update": 0,
+        "previous_year": 0,
+        "nulled": 0,
+        "skipped": 0,
+        "ids": [],
+    }
+
+    async with async_session_maker() as session:
+        placeholders = ", ".join(f":c{i}" for i in range(len(aliases)))
+        params = {f"c{i}": alias for i, alias in enumerate(aliases)}
+        result = await session.execute(
+            text(
+                f"""
+                SELECT
+                    ue.id AS unique_id,
+                    ue.event_date,
+                    ue.date_precision,
+                    ue.created_at,
+                    ue.merged_data,
+                    re.id AS raw_id,
+                    re.extraction_data,
+                    s.published_at,
+                    s.fetched_at
+                FROM unique_event ue
+                LEFT JOIN raw_event re ON re.unique_event_id = ue.id
+                LEFT JOIN source_google_news s ON s.id = re.source_google_news_id
+                WHERE ue.event_date IS NOT NULL
+                  AND (
+                    ue.country IS NULL
+                    OR ue.country = ''
+                    OR UPPER(ue.country) IN ({placeholders})
+                  )
+                """
+            ),
+            params,
+        )
+        grouped: dict[int, dict[str, Any]] = {}
+        for row in result.mappings().all():
+            uid = row["unique_id"]
+            bucket = grouped.setdefault(
+                uid,
+                {
+                    "event_date": row["event_date"],
+                    "date_precision": row["date_precision"],
+                    "created_at": row["created_at"],
+                    "merged_data": row["merged_data"],
+                    "raws": [],
+                    "published_at": [],
+                    "fetched_at": [],
+                },
+            )
+            if row["raw_id"] is not None:
+                bucket["raws"].append(
+                    {"id": row["raw_id"], "extraction_data": row["extraction_data"]}
+                )
+            if row["published_at"] is not None:
+                bucket["published_at"].append(row["published_at"])
+            if row["fetched_at"] is not None:
+                bucket["fetched_at"].append(row["fetched_at"])
+
+        audit["scanned"] = len(grouped)
+        pending: list[dict[str, Any]] = []
+        for uid, bucket in grouped.items():
+            reference = (
+                _earliest_datetime(bucket["published_at"])
+                or _earliest_datetime(bucket["fetched_at"])
+                or parse_reference_datetime(bucket["created_at"])
+            )
+            clamped = clamp_event_date_against_publish(bucket["event_date"], reference)
+            if not clamped.changed:
+                audit["skipped"] += 1
+                continue
+            new_precision = (
+                clamped.date_precision
+                if clamped.date_precision is not None
+                else bucket["date_precision"]
+            )
+            pending.append(
+                {
+                    "id": uid,
+                    "action": clamped.action,
+                    "event_date": (
+                        datetime.strptime(clamped.date, "%Y-%m-%d") if clamped.date else None
+                    ),
+                    "date_precision": new_precision,
+                    "merged_data": _patch_extraction_date_payload(
+                        bucket["merged_data"], clamped.date, new_precision
+                    ),
+                    "raws": [
+                        {
+                            "id": raw["id"],
+                            "extraction_data": _patch_extraction_date_payload(
+                                raw["extraction_data"], clamped.date, new_precision
+                            ),
+                        }
+                        for raw in bucket["raws"]
+                    ],
+                }
+            )
+            if clamped.action == "previous_year":
+                audit["previous_year"] += 1
+            elif clamped.action == "null":
+                audit["nulled"] += 1
+
+        audit["would_update"] = len(pending)
+        audit["ids"] = [item["id"] for item in pending[:50]]
+        if dry_run or not pending:
+            return audit
+
+        for item in pending:
+            merged = item["merged_data"]
+            if isinstance(merged, dict):
+                merged = json.dumps(merged)
+            await session.execute(
+                text(
+                    """
+                    UPDATE unique_event
+                    SET event_date = :event_date,
+                        date_precision = :date_precision,
+                        merged_data = :merged_data,
+                        updated_at = CURRENT_TIMESTAMP
+                    WHERE id = :id
+                    """
+                ),
+                {
+                    "id": item["id"],
+                    "event_date": item["event_date"],
+                    "date_precision": item["date_precision"],
+                    "merged_data": merged,
+                },
+            )
+            for raw in item["raws"]:
+                extraction = raw["extraction_data"]
+                if isinstance(extraction, dict):
+                    extraction = json.dumps(extraction)
+                await session.execute(
+                    text(
+                        """
+                        UPDATE raw_event
+                        SET event_date = :event_date,
+                            date_precision = :date_precision,
+                            extraction_data = :extraction_data,
+                            updated_at = CURRENT_TIMESTAMP
+                        WHERE id = :id
+                        """
+                    ),
+                    {
+                        "id": raw["id"],
+                        "event_date": item["event_date"],
+                        "date_precision": item["date_precision"],
+                        "extraction_data": extraction,
+                    },
+                )
+        await session.commit()
+        audit["updated"] = len(pending)
+        logger.info(
+            "[FUTURE-DATE] Updated {n} UniqueEvent(s) country={country} "
+            "(previous_year={py}, nulled={nu})",
+            n=audit["updated"],
+            country=country_upper,
+            py=audit["previous_year"],
+            nu=audit["nulled"],
+        )
+    return audit

--- a/backend/scripts/remediate_future_event_dates.py
+++ b/backend/scripts/remediate_future_event_dates.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Clamp Brazil UniqueEvent dates that sit after source publication (issue #228).
+
+Re-checks UniqueEvents whose event_date is after the linked article's
+published_at (or created_at / fetched_at when publish is missing). Applies the
+same previous-year-or-null rule used at extract time.
+
+Brazil-only by default (prod PIPELINE_ACTIVE_COUNTRIES=["BR"]).
+
+Usage (from backend/ or via docker compose exec api):
+
+    # Apply the fix (default):
+    python scripts/remediate_future_event_dates.py
+
+    # Report planned writes without committing:
+    python scripts/remediate_future_event_dates.py --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from app.services.maintenance import remediate_future_event_dates
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Clamp UniqueEvent dates that are after source publication."
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report rows that would change without writing.",
+    )
+    parser.add_argument(
+        "--country",
+        default="BR",
+        help="ISO country to remediate (default: BR).",
+    )
+    args = parser.parse_args()
+    audit = await remediate_future_event_dates(
+        dry_run=args.dry_run,
+        country=args.country,
+    )
+    print(json.dumps(audit, default=str, indent=2))
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/backend/tests/test_extraction_heuristics.py
+++ b/backend/tests/test_extraction_heuristics.py
@@ -1,8 +1,11 @@
 """Unit tests for extraction post-LLM heuristics."""
 
+from datetime import date, datetime
+
 from app.services.extraction_heuristics import (
     _norm,
     apply_extraction_heuristics,
+    clamp_event_date_against_publish,
     fix_same_day_relative_weekday,
     fix_weekday_paren_day,
     infer_fatal_victim_count,
@@ -236,3 +239,147 @@ def _source_norm(content: str, metadata: dict) -> str:
     from app.services.extraction_heuristics import _source_text
 
     return _source_text(content, metadata)
+
+
+def _october_event(*, city: str, state: str, event_date: str, year_explicit: bool) -> ViolentDeathEvent:
+    return _event(
+        location_info=Location(city=city, state=state),
+        date_time=DateTime(
+            date=event_date,
+            date_precision="exata",
+            date_verification=_date_verification(
+                has_explicit_date=True,
+                date_source="inferred_from_publication",
+                year_explicitly_mentioned=year_explicit,
+                date_text_quote="16 de outubro" if "16" in event_date else "12 de outubro",
+                verification_reasoning="LLM inferred calendar year from publication",
+            ),
+        ),
+    )
+
+
+def test_clamp_lins_october_after_august_publish_uses_previous_year():
+    result = clamp_event_date_against_publish("2026-10-16", "2026-08-20T12:00:00Z")
+    assert result.date == "2025-10-16"
+    assert result.action == "previous_year"
+
+
+def test_clamp_bh_october_after_august_publish_uses_previous_year():
+    result = clamp_event_date_against_publish("2026-10-12", datetime(2026, 8, 20, 12, 0, 0))
+    assert result.date == "2025-10-12"
+    assert result.action == "previous_year"
+
+
+def test_clamp_keeps_date_within_one_day_skew():
+    result = clamp_event_date_against_publish("2026-08-21", date(2026, 8, 20))
+    assert result.date == "2026-08-21"
+    assert result.action == "keep"
+
+
+def test_clamp_nulls_when_previous_year_still_after_publish():
+    result = clamp_event_date_against_publish("2027-01-20", "2026-01-05")
+    assert result.date is None
+    assert result.date_precision == "não informada"
+    assert result.action == "null"
+
+
+def test_apply_lins_16_de_outubro_not_future_of_august_publish():
+    """Issue #228: Lins UniqueEvent 11701 — '16 de outubro' + Aug 2026 publish."""
+    event = _october_event(
+        city="Lins",
+        state="SP",
+        event_date="2026-10-16",
+        year_explicit=False,
+    )
+    content = (
+        "Homem é morto a tiros em Lins. O crime aconteceu no dia 16 de outubro "
+        "no bairro Centro."
+    )
+    result = apply_extraction_heuristics(
+        event,
+        content,
+        {
+            "headline": "Homem é morto a tiros em Lins",
+            "published_at": "20/08/2026 às 12:00",
+        },
+    )
+    assert result.date_time.date != "2026-10-16"
+    assert result.date_time.date == "2025-10-16"
+
+
+def test_apply_bh_12_de_outubro_not_future_of_august_publish():
+    """Issue #228: Belo Horizonte UniqueEvent 11816 — '12 de outubro' + Aug 2026 publish."""
+    event = _october_event(
+        city="Belo Horizonte",
+        state="MG",
+        event_date="2026-10-12",
+        year_explicit=False,
+    )
+    content = (
+        "Vítima foi assassinada em Belo Horizonte no dia 12 de outubro, "
+        "segundo a Polícia Militar."
+    )
+    result = apply_extraction_heuristics(
+        event,
+        content,
+        {
+            "headline": "Homem é morto em Belo Horizonte",
+            "published_at": "2026-08-20T15:30:00Z",
+        },
+    )
+    assert result.date_time.date != "2026-10-12"
+    assert result.date_time.date == "2025-10-12"
+
+
+def test_apply_keeps_explicit_year_within_skew_of_publish():
+    event = _event(
+        date_time=DateTime(
+            date="2026-08-21",
+            date_precision="exata",
+            date_verification=_date_verification(
+                year_explicitly_mentioned=True,
+                date_text_quote="21 de agosto de 2026",
+            ),
+        ),
+    )
+    result = apply_extraction_heuristics(
+        event,
+        "Crime ocorreu em 21 de agosto de 2026.",
+        {"published_at": "2026-08-20T12:00:00Z"},
+    )
+    assert result.date_time.date == "2026-08-21"
+    assert result.date_time.date_precision == "exata"
+
+
+def test_apply_clamps_explicit_future_year_beyond_skew():
+    event = _october_event(
+        city="Lins",
+        state="SP",
+        event_date="2026-10-16",
+        year_explicit=True,
+    )
+    result = apply_extraction_heuristics(
+        event,
+        "O crime ocorreu em 16 de outubro de 2026 em Lins.",
+        {"published_at": "2026-08-20T12:00:00Z"},
+    )
+    assert result.date_time.date == "2025-10-16"
+
+
+def test_apply_nulls_when_previous_year_still_after_publish():
+    event = _event(
+        date_time=DateTime(
+            date="2027-01-20",
+            date_precision="exata",
+            date_verification=_date_verification(year_explicitly_mentioned=True),
+        ),
+    )
+    result = apply_extraction_heuristics(
+        event,
+        "O crime ocorreu em 20 de janeiro de 2027.",
+        {"created_at": "2026-01-05T08:00:00Z"},
+    )
+    assert result.date_time.date is None
+    assert result.date_time.date_precision == "não informada"
+    assert result.date_time.date_verification.has_explicit_date is False
+    assert result.date_time.date_verification.date_source == "none"

--- a/backend/tests/test_remediate_future_event_dates.py
+++ b/backend/tests/test_remediate_future_event_dates.py
@@ -1,0 +1,292 @@
+"""Tests for Brazil future-vs-publish event_date remediator (issue #228)."""
+
+from datetime import datetime
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import text
+
+from app.models.raw_event import RawEvent
+from app.models.source_google_news import SourceGoogleNews, SourceStatus
+from app.models.unique_event import UniqueEvent
+from app.services.extraction_heuristics import clamp_event_date_against_publish
+from app.services.maintenance import remediate_future_event_dates
+
+
+class _TestSessionMaker:
+    def __init__(self, session):
+        self._session = session
+
+    def __call__(self):
+        return self
+
+    async def __aenter__(self):
+        return self._session
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+async def _seed_event(
+    session,
+    *,
+    title: str,
+    city: str,
+    state: str,
+    country: str,
+    event_date: datetime,
+    published_at: datetime | None,
+    google_news_id: str,
+    merged_date: str | None = None,
+):
+    unique = UniqueEvent(
+        title=title,
+        event_date=event_date,
+        date_precision="exata",
+        city=city,
+        state=state,
+        country=country,
+        event_family="homicidio",
+        event_subtype="simples",
+        content_class="incident",
+        source_count=1,
+        merged_data={
+            "date_time": {
+                "date": merged_date or event_date.strftime("%Y-%m-%d"),
+                "date_precision": "exata",
+            }
+        },
+        created_at=datetime(2026, 8, 20, 18, 0, 0),
+    )
+    session.add(unique)
+    await session.commit()
+    await session.refresh(unique)
+    unique_id = unique.id
+
+    source = SourceGoogleNews(
+        google_news_id=google_news_id,
+        google_news_url=f"https://news.google.com/rss/articles/{google_news_id}",
+        headline=title,
+        content=f"Crime em {city}.",
+        published_at=published_at,
+        status=SourceStatus.extracted,
+        country=country,
+    )
+    session.add(source)
+    await session.commit()
+    await session.refresh(source)
+    source_id = source.id
+
+    raw = RawEvent(
+        title=title,
+        event_date=event_date,
+        date_precision="exata",
+        city=city,
+        state=state,
+        country=country,
+        source_google_news_id=source_id,
+        unique_event_id=unique_id,
+        deduplication_status="matched",
+        extraction_data={
+            "date_time": {
+                "date": merged_date or event_date.strftime("%Y-%m-%d"),
+                "date_precision": "exata",
+            }
+        },
+    )
+    session.add(raw)
+    await session.commit()
+    await session.refresh(raw)
+    return unique, raw, source
+
+
+@pytest.mark.asyncio
+async def test_remediator_lins_shifts_to_previous_year(async_session):
+    unique, raw, _source = await _seed_event(
+        async_session,
+        title="Homicídio em Lins",
+        city="Lins",
+        state="SP",
+        country="BR",
+        event_date=datetime(2026, 10, 16),
+        published_at=datetime(2026, 8, 20, 12, 0, 0),
+        google_news_id="lins-228",
+    )
+
+    with patch(
+        "app.services.maintenance.async_session_maker",
+        _TestSessionMaker(async_session),
+    ):
+        audit = await remediate_future_event_dates(dry_run=False)
+
+    await async_session.refresh(unique)
+    await async_session.refresh(raw)
+
+    assert unique.event_date.date().isoformat() == "2025-10-16"
+    assert unique.date_precision == "exata"
+    assert unique.merged_data["date_time"]["date"] == "2025-10-16"
+    assert raw.event_date.date().isoformat() == "2025-10-16"
+    assert audit["updated"] == 1
+    assert audit["dry_run"] is False
+
+
+@pytest.mark.asyncio
+async def test_remediator_bh_shifts_to_previous_year(async_session):
+    unique, raw, _source = await _seed_event(
+        async_session,
+        title="Homicídio em Belo Horizonte",
+        city="Belo Horizonte",
+        state="MG",
+        country="BR",
+        event_date=datetime(2026, 10, 12),
+        published_at=datetime(2026, 8, 20, 15, 0, 0),
+        google_news_id="bh-228",
+    )
+
+    with patch(
+        "app.services.maintenance.async_session_maker",
+        _TestSessionMaker(async_session),
+    ):
+        audit = await remediate_future_event_dates()
+
+    await async_session.refresh(unique)
+    await async_session.refresh(raw)
+    assert unique.event_date.date().isoformat() == "2025-10-12"
+    assert raw.event_date.date().isoformat() == "2025-10-12"
+    assert audit["updated"] == 1
+
+
+@pytest.mark.asyncio
+async def test_remediator_dry_run_does_not_write(async_session):
+    unique, _raw, _source = await _seed_event(
+        async_session,
+        title="Homicídio em Lins",
+        city="Lins",
+        state="SP",
+        country="BR",
+        event_date=datetime(2026, 10, 16),
+        published_at=datetime(2026, 8, 20, 12, 0, 0),
+        google_news_id="lins-dry-228",
+    )
+
+    with patch(
+        "app.services.maintenance.async_session_maker",
+        _TestSessionMaker(async_session),
+    ):
+        audit = await remediate_future_event_dates(dry_run=True)
+
+    await async_session.refresh(unique)
+    assert unique.event_date.date().isoformat() == "2026-10-16"
+    assert audit["dry_run"] is True
+    assert audit["would_update"] == 1
+    assert audit["updated"] == 0
+
+
+@pytest.mark.asyncio
+async def test_remediator_skips_non_brazil(async_session):
+    unique, _raw, _source = await _seed_event(
+        async_session,
+        title="Homicidio en Santiago",
+        city="Santiago",
+        state="RM",
+        country="CL",
+        event_date=datetime(2026, 10, 16),
+        published_at=datetime(2026, 8, 20, 12, 0, 0),
+        google_news_id="cl-228",
+    )
+
+    with patch(
+        "app.services.maintenance.async_session_maker",
+        _TestSessionMaker(async_session),
+    ):
+        audit = await remediate_future_event_dates(dry_run=False)
+
+    await async_session.refresh(unique)
+    assert unique.event_date.date().isoformat() == "2026-10-16"
+    assert audit["updated"] == 0
+
+
+@pytest.mark.asyncio
+async def test_remediator_falls_back_to_created_at_when_publish_missing(async_session):
+    unique, raw, _source = await _seed_event(
+        async_session,
+        title="Homicídio em Lins",
+        city="Lins",
+        state="SP",
+        country="BR",
+        event_date=datetime(2026, 10, 16),
+        published_at=None,
+        google_news_id="lins-nopub-228",
+    )
+
+    with patch(
+        "app.services.maintenance.async_session_maker",
+        _TestSessionMaker(async_session),
+    ):
+        await remediate_future_event_dates(dry_run=False)
+
+    await async_session.refresh(unique)
+    await async_session.refresh(raw)
+    assert unique.event_date.date().isoformat() == "2025-10-16"
+    assert raw.event_date.date().isoformat() == "2025-10-16"
+
+
+@pytest.mark.asyncio
+async def test_remediator_nulls_when_previous_year_still_after_publish(async_session):
+    unique, raw, _source = await _seed_event(
+        async_session,
+        title="Homicídio futuro",
+        city="Recife",
+        state="PE",
+        country="BR",
+        event_date=datetime(2027, 1, 20),
+        published_at=datetime(2026, 1, 5, 8, 0, 0),
+        google_news_id="recife-228",
+    )
+
+    with patch(
+        "app.services.maintenance.async_session_maker",
+        _TestSessionMaker(async_session),
+    ):
+        await remediate_future_event_dates(dry_run=False)
+
+    await async_session.refresh(unique)
+    await async_session.refresh(raw)
+    assert unique.event_date is None
+    assert unique.date_precision == "não informada"
+    assert unique.merged_data["date_time"]["date"] is None
+    assert raw.event_date is None
+    assert raw.date_precision == "não informada"
+
+
+def test_shared_clamp_helper_is_used_by_remediator_contract():
+    """Remediator and extract heuristics share one pure clamp."""
+    result = clamp_event_date_against_publish("2026-10-16", datetime(2026, 8, 20))
+    assert result.action == "previous_year"
+    assert result.date == "2025-10-16"
+
+
+@pytest.mark.asyncio
+async def test_remediator_skips_date_within_skew(async_session):
+    unique, _raw, _source = await _seed_event(
+        async_session,
+        title="Homicídio recente",
+        city="Salvador",
+        state="BA",
+        country="BR",
+        event_date=datetime(2026, 8, 21),
+        published_at=datetime(2026, 8, 20, 12, 0, 0),
+        google_news_id="ssa-skew-228",
+    )
+
+    with patch(
+        "app.services.maintenance.async_session_maker",
+        _TestSessionMaker(async_session),
+    ):
+        audit = await remediate_future_event_dates(dry_run=False)
+
+    await async_session.refresh(unique)
+    assert unique.event_date.date().isoformat() == "2026-08-21"
+    count = await async_session.execute(text("SELECT COUNT(*) FROM unique_event"))
+    assert count.scalar_one() == 1
+    assert audit["updated"] == 0


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 📝 Descrição

Hard clamp so inferred `event_date` cannot sit after the article’s `published_at` (or `created_at` / `fetched_at` when publish is missing) by more than one day.

This is the Brazil map pollution from year inference: stories that said “16 de outubro” / “12 de outubro” (no year) with mid-August 2026 publication were stored as `2026-10-16` / `2026-10-12` and floated to the top of `/api/public/events`.

Rule (shared pure helper `clamp_event_date_against_publish`):
- If `event_date` is strictly after `publish + 1 day`, reject that year.
- Prefer the same month/day in the previous year when that date is still ≤ publish+skew.
- Otherwise set `event_date=NULL` and `date_precision='não informada'`.

Wired into `apply_extraction_heuristics` (the extract seam). One-shot remediator for existing Brazil UniqueEvents.

## 🔗 Issue Relacionada

Fixes #228

## 🏷️ Tipo de Mudança

- [x] 🐛 Bug fix (mudança que corrige um problema)
- [x] ✅ Testes (adição ou correção de testes)

## 🧪 Como Foi Testado?

- [x] Testes unitários
- [ ] Testes de integração
- [ ] Testes manuais
- [x] Testado em desenvolvimento local
- [ ] Testado com Docker

TDD: red tests first against current code (allowed `2026-10-16`), then clamp + remediator, then green.

**Red → green test names**
- `test_clamp_lins_october_after_august_publish_uses_previous_year`
- `test_clamp_bh_october_after_august_publish_uses_previous_year`
- `test_apply_lins_16_de_outubro_not_future_of_august_publish`
- `test_apply_bh_12_de_outubro_not_future_of_august_publish`
- `test_apply_keeps_explicit_year_within_skew_of_publish`
- `test_apply_clamps_explicit_future_year_beyond_skew`
- `test_remediator_lins_shifts_to_previous_year`
- `test_remediator_bh_shifts_to_previous_year`

**Ambiente de teste:**
- OS: Linux (cloud agent)
- Tests via `uv run pytest` in `backend/`
- Docker not used (no Docker daemon in this environment)

## ✅ Checklist

- [x] Meu código segue o guia de estilo do projeto
- [x] Realizei uma auto-revisão do meu código
- [x] Comentei meu código em áreas complexas
- [x] Minhas mudanças não geram novos warnings
- [x] Adicionei testes que provam que meu fix/feature funciona
- [x] Testes unitários novos e existentes passam localmente

## 💬 Notas Adicionais

**Clamp lives in:** `backend/app/services/extraction_heuristics.py` (`clamp_event_date_against_publish`, called from `apply_extraction_heuristics`). Remediator: `backend/app/services/maintenance.py` (`remediate_future_event_dates`).

**Remediator entrypoint:**
```
python scripts/remediate_future_event_dates.py
python scripts/remediate_future_event_dates.py --dry-run
```
(from `backend/` or `docker compose exec api`)

**Locks respected (do not do these in this PR):**
- Base is `develop`, not `master`.
- Does **not** ship/cherry-pick/promote PR #204 (SA null-date fallback) to master.
- Does **not** merge develop→master.
- Does **not** start the staging worker.
- Does not expand the existing #203 date-fallback on develop; this ticket is only the future-vs-publish clamp.

Draft PR — leave as draft; do not merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d443900a-52b4-42c0-aa3f-9b56d6d67350?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d443900a-52b4-42c0-aa3f-9b56d6d67350&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

