### PR TITLE
fix(public): keep unfiltered city ranking Brazil-only

### DIFF
--- a/backend/app/routers/public.py
+++ b/backend/app/routers/public.py
@@ -27,9 +27,23 @@ from app.geography import COUNTRY_NAMES, BRAZILIAN_STATES, BRAZILIAN_CAPITALS
 router = APIRouter(prefix="/public", tags=["public"])
 
 # Simple cache for rankings endpoint (default 365d payload)
-# Invalidate on ingest or every 1 hour
+# Invalidate on ingest or every 1 hour.
+# Version bump: unfiltered city ranking is Brazil-only (issue #231).
 _rankings_cache: dict[str, tuple[dict, float]] = {}
 RANKINGS_CACHE_TTL = 3600  # 1 hour in seconds
+RANKINGS_CACHE_VERSION = "br_cities"
+
+# UniqueEvent.country values treated as Brazil — same BR|Brasil pattern as
+# get_rankings build_query when country=BR. NULL/empty is excluded:
+# UniqueEvent.country defaults to "BR" on insert, so remaining NULLs are
+# unknown/foreign pollution rather than Brazil (issue #231).
+_BRAZIL_COUNTRY_VALUES = frozenset({"BR", "Brasil"})
+
+
+def _event_country_is_brazil(country: str | None) -> bool:
+    """True when UniqueEvent.country is canonical BR or legacy Brasil."""
+    return country in _BRAZIL_COUNTRY_VALUES
+
 
 # Rolling window shared by the map, export, and temporal-scope note.
 PUBLIC_MAP_DAYS = 365
@@ -484,7 +498,7 @@ async def get_security_force_stats(session: AsyncSession = Depends(get_session))
 async def get_rankings(
     session: AsyncSession = Depends(get_session),
     days: int = Query(365, ge=1, le=3650, description="Only events in the last N days"),
-    country: str | None = Query(None, description="Filter by country ISO (AR, BO, BR, CL, CO, EC, GY, PY, PE, SR, UY, VE) or omit for all SA"),
+    country: str | None = Query(None, description="Filter by country ISO (AR, BO, BR, CL, CO, EC, GY, PY, PE, SR, UY, VE) or omit for all SA. Unfiltered city ranking is Brazil-only (BR/Brasil)."),
     city_limit: int | None = Query(50, ge=1, le=10000, description="Limit number of cities returned (default 50 for fast load)"),
 ):
     """
@@ -492,6 +506,9 @@ async def get_rankings(
     by victim count and event count for a given time period.
     
     Includes delta vs previous equal period, and rate per 100k for matched BR locations (cities and states).
+
+    When ``country`` is omitted, the city list is Brazil-only (UniqueEvent.country
+    BR or legacy Brasil). Country rollup stays multi-country historical.
     """
     from app.services.ibge_population import (
         lookup_city_codes,
@@ -502,7 +519,7 @@ async def get_rankings(
     )
     
     # Check cache for default 365d unfiltered request (before expensive aggregation)
-    cache_key = f"rankings_{days}_{country}_{city_limit}"
+    cache_key = f"rankings_{RANKINGS_CACHE_VERSION}_{days}_{country}_{city_limit}"
     if cache_key in _rankings_cache:
         cached_result, cached_time = _rankings_cache[cache_key]
         # Check if cache is still valid (TTL)
@@ -597,15 +614,26 @@ async def get_rankings(
         
         return aggregated
     
+    def brazil_city_events(events):
+        """Homepage/unfiltered city ranking is Brazil-only (issue #231).
+
+        When ``country`` is omitted, only aggregate cities from UniqueEvents
+        whose country is BR or legacy Brasil. Explicit ``?country=`` keeps the
+        already-filtered event set (CL/AR/etc. city lists still work).
+        """
+        if country is not None:
+            return events
+        return [event for event in events if _event_country_is_brazil(event.country)]
+
     # Aggregate current period
-    cities_current = aggregate_by_field(current_events, "city")
+    cities_current = aggregate_by_field(brazil_city_events(current_events), "city")
     states_current = aggregate_by_field(current_events, "state")
     countries_current = aggregate_by_field(current_events, "country")
     types_current = aggregate_by_field(current_events, "homicide_type")
     methods_current = aggregate_by_field(current_events, "method_of_death")
     
     # Aggregate previous period
-    cities_prev = aggregate_by_field(prev_events, "city")
+    cities_prev = aggregate_by_field(brazil_city_events(prev_events), "city")
     states_prev = aggregate_by_field(prev_events, "state")
     countries_prev = aggregate_by_field(prev_events, "country")
     types_prev = aggregate_by_field(prev_events, "homicide_type")

--- a/backend/tests/test_rankings.py
+++ b/backend/tests/test_rankings.py
@@ -9,6 +9,16 @@ from app.models.unique_event import UniqueEvent
 from app.geography import BRAZILIAN_STATES
 
 
+@pytest.fixture(autouse=True)
+def clear_rankings_cache():
+    """Rankings responses live in a process-global TTL cache; isolate tests."""
+    from app.routers.public import _rankings_cache
+
+    _rankings_cache.clear()
+    yield
+    _rankings_cache.clear()
+
+
 def create_ranking_event(
     event_date: datetime,
     country: str = "Brasil",
@@ -173,6 +183,151 @@ async def test_rankings_country_filter_brazil(app, async_session):
         assert data["cities"][0]["city"] == "Rio de Janeiro"
         assert len(data["countries"]) == 1
         assert data["countries"][0]["country"] == "Brasil"
+
+
+@pytest.mark.asyncio
+async def test_unfiltered_city_ranking_excludes_foreign_cities_issue_231(
+    app, async_session
+):
+    """Unfiltered city ranking is Brazil-only even when country= is omitted (issue #231).
+
+    Tumbler Ridge / Joanesburgo / Paramaribo / Homs with non-BR country must not
+    appear. Real BR cities (Rio, SP) still appear. Country rollup stays multi-country.
+    """
+    from app.models.ibge_population import IBGEPopulation
+
+    now = datetime.utcnow()
+    current_start = now - timedelta(days=30)
+
+    events = [
+        create_ranking_event(
+            event_date=current_start + timedelta(days=1),
+            country="BR",
+            city="Rio de Janeiro",
+            state="RJ",
+            victim_count=4,
+        ),
+        create_ranking_event(
+            event_date=current_start + timedelta(days=2),
+            country="Brasil",
+            city="São Paulo",
+            state="SP",
+            victim_count=3,
+        ),
+        # Foreign / wrong-country pollution. IBGE pop > 100k + a BR UF so they
+        # would pass the city size floor without the Brazil country filter.
+        create_ranking_event(
+            event_date=current_start + timedelta(days=3),
+            country="CA",
+            city="Tumbler Ridge",
+            state="SP",
+            victim_count=20,
+        ),
+        create_ranking_event(
+            event_date=current_start + timedelta(days=4),
+            country="ZA",
+            city="Joanesburgo",
+            state="SP",
+            victim_count=9,
+        ),
+        create_ranking_event(
+            event_date=current_start + timedelta(days=5),
+            country="SR",
+            city="Paramaribo",
+            state="SP",
+            victim_count=9,
+        ),
+        create_ranking_event(
+            event_date=current_start + timedelta(days=6),
+            country="SY",
+            city="Homs",
+            state="SP",
+            victim_count=8,
+        ),
+        create_ranking_event(
+            event_date=current_start + timedelta(days=8),
+            country="CL",
+            city="Santiago",
+            state="SP",
+            victim_count=2,
+        ),
+    ]
+
+    populations = [
+        IBGEPopulation(
+            code_muni=9900001,
+            name_muni="Tumbler Ridge",
+            abbrev_state="SP",
+            population=200_000,
+            year=2022,
+        ),
+        IBGEPopulation(
+            code_muni=9900002,
+            name_muni="Joanesburgo",
+            abbrev_state="SP",
+            population=5_000_000,
+            year=2022,
+        ),
+        IBGEPopulation(
+            code_muni=9900003,
+            name_muni="Paramaribo",
+            abbrev_state="SP",
+            population=250_000,
+            year=2022,
+        ),
+        IBGEPopulation(
+            code_muni=9900004,
+            name_muni="Homs",
+            abbrev_state="SP",
+            population=800_000,
+            year=2022,
+        ),
+        IBGEPopulation(
+            code_muni=9900006,
+            name_muni="Santiago",
+            abbrev_state="SP",
+            population=6_000_000,
+            year=2022,
+        ),
+    ]
+
+    for event in events:
+        async_session.add(event)
+    for pop in populations:
+        async_session.add(pop)
+    await async_session.commit()
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        response = await client.get("/api/public/stats/rankings?days=30")
+        assert response.status_code == 200
+        data = response.json()
+
+        city_names = {c["city"] for c in data["cities"]}
+        forbidden = {"Tumbler Ridge", "Joanesburgo", "Paramaribo", "Homs", "Santiago"}
+        assert city_names.isdisjoint(forbidden), (
+            f"Unfiltered city ranking leaked non-BR cities: {city_names & forbidden}"
+        )
+        assert "Rio de Janeiro" in city_names
+        assert "São Paulo" in city_names
+
+        # Country rollup stays historical / multi-country (out of scope for #231).
+        country_names = {c["country"] for c in data["countries"]}
+        assert "Brasil" in country_names
+        assert "Chile" in country_names
+        assert "Suriname" in country_names
+        assert data["country_filter"] is None
+
+        # Explicit country=BR still returns BR cities and not the foreign set.
+        response_br = await client.get("/api/public/stats/rankings?days=30&country=BR")
+        assert response_br.status_code == 200
+        data_br = response_br.json()
+        br_cities = {c["city"] for c in data_br["cities"]}
+        assert br_cities.isdisjoint(forbidden)
+        assert "Rio de Janeiro" in br_cities
+        assert "São Paulo" in br_cities
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 📝 Descrição

Unfiltered `GET /api/public/stats/rankings` (homepage / no `country=` query) was aggregating **every** UniqueEvent into the city list. Leftover foreign rows therefore showed up on production as:

- Tumbler Ridge (20 victims / 2 events)
- Joanesburgo (9 / 1)
- Paramaribo (9 / 1)
- Homs (8 / 1)

Brazil-only ingest (`PIPELINE_ACTIVE_COUNTRIES=["BR"]`) does not hide those older rows. This PR filters **city aggregation only** when `country` is omitted.

### How the city filter works

In `get_rankings`, events are filtered **before** `aggregate_by_field(..., "city")`:

- When `country` is omitted: keep UniqueEvents whose `country` is `BR` or legacy `Brasil` — the same pattern as `build_query` when `country=BR`.
- When `country` is set (`BR`, `CL`, …): city aggregation still uses the already-filtered event set (Chile/AR city lists unchanged).
- **SQL NULL / empty country is excluded** from the unfiltered city list. `UniqueEvent.country` defaults to `BR` on insert, and `country=BR` rankings already require an exact `BR|Brasil` match (they do not `COALESCE` NULL to Brazil). Remaining NULLs are treated as unknown/foreign pollution, not Brazil.
- Country rollup table is **unchanged** (historical AR/PE/CO/etc. still appear). No UniqueEvent deletes.
- States: already restricted to BR UFs on develop (issue 186). Not expanded here.

Rankings cache key bumped to `rankings_br_cities_{days}_{country}_{city_limit}` so in-process TTL cache cannot serve the old unfiltered city payload.

## 🔗 Issue Relacionada

Fixes #231

## 🏷️ Tipo de Mudança

- [x] 🐛 Bug fix (mudança que corrige um problema)
- [x] ✅ Testes (adição ou correção de testes)

## 🧪 Como Foi Testado?

- [x] Testes unitários
- [ ] Testes de integração
- [ ] Testes manuais
- [x] Testado em desenvolvimento local
- [ ] Testado com Docker

**Ambiente de teste:**
- OS: Linux (Cloud Agent)
- Docker version: not available in this environment; `uv run pytest` in `backend/`
- Browser: n/a (API-only)

Ran:

```
uv run pytest tests/test_rankings.py::test_unfiltered_city_ranking_excludes_foreign_cities_issue_231 \
  tests/test_rankings.py::test_rankings_country_filter_brazil \
  tests/test_rankings.py::test_rankings_basic_aggregation \
  tests/test_rankings.py::test_rankings_empty_chile_data \
  tests/test_rankings.py::test_rankings_delta_calculation \
  tests/test_rankings.py::test_rankings_victim_vs_event_counts \
  tests/test_rankings.py::test_city_size_floor_excludes_small_towns \
  tests/test_rankings.py::test_rankings_default_sort_by_victims \
  tests/test_rankings.py::test_rankings_brazil_excludes_non_uf_states \
  tests/test_rankings.py::test_rankings_empty_database \
  tests/test_rankings.py::test_rankings_different_periods -q
```

**11 passed.** New test: `test_unfiltered_city_ranking_excludes_foreign_cities_issue_231`. Existing `test_rankings_country_filter_brazil` stays green.

`test_rankings_country_filter_chile` still fails on `develop` itself (fixture stores `country="Chile"` while `?country=CL` matches ISO `CL` only). That path is unchanged here; confirmed the same failure on unmodified `develop`.

## ✅ Checklist

- [x] Meu código segue o guia de estilo do projeto
- [x] Realizei uma auto-revisão do meu código
- [x] Comentei meu código em áreas complexas
- [x] Minhas mudanças não geram novos warnings
- [x] Adicionei testes que provam que meu fix/feature funciona
- [x] Testes unitários novos e existentes passam localmente

## 💬 Notas Adicionais

### Locks held (do not ship from this PR)

- **No PR #204** deploy / cherry-pick to master.
- **No staging worker start.**
- **No `/estatisticas` promote** (issue 124 hold).
- **No** re-opening South America ingest.
- **No** mass delete of foreign UniqueEvents (filter-only).
- Draft PR against **`develop` only**. Do not merge. Do not mark ready.

### Out of scope (issue 231)

Leftover country rollup rows (Argentina, Perú, Colombia, etc.) stay visible. UniqueEvent cleanup is a later remediator, not this tracer.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0f73b76e-b464-4993-9d5d-f6187c4b7afb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0f73b76e-b464-4993-9d5d-f6187c4b7afb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

