### PR TITLE
fix(public): require Brazilian UF in unfiltered city rankings (master)

### DIFF
--- a/backend/app/routers/public.py
+++ b/backend/app/routers/public.py
@@ -19,6 +19,7 @@ from app.services.public_filters import (
     apply_public_incident_filter,
     homicide_type_filter,
     homicide_types_filter,
+    is_brazilian_uf,
 )
 from app.geography import COUNTRY_NAMES
 
@@ -26,10 +27,12 @@ router = APIRouter(prefix="/public", tags=["public"])
 
 # Simple cache for rankings endpoint (default 365d payload)
 # Invalidate on ingest or every 1 hour.
-# Version bump: unfiltered city ranking is Brazil-only (issue #231).
+# Version bump: unfiltered city ranking requires BR/Brasil + Brazilian UF
+# (issue #234). Previous key ``br_cities`` (issue #231) still served
+# mislabeled country=Brasil rows with foreign states.
 _rankings_cache: dict[str, tuple[dict, float]] = {}
 RANKINGS_CACHE_TTL = 3600  # 1 hour in seconds
-RANKINGS_CACHE_VERSION = "br_cities"
+RANKINGS_CACHE_VERSION = "br_cities_uf"
 
 # UniqueEvent.country values treated as Brazil — same BR|Brasil pattern as
 # get_rankings build_query when country=BR. NULL/empty is excluded:
@@ -41,6 +44,18 @@ _BRAZIL_COUNTRY_VALUES = frozenset({"BR", "Brasil"})
 def _event_country_is_brazil(country: str | None) -> bool:
     """True when UniqueEvent.country is canonical BR or legacy Brasil."""
     return country in _BRAZIL_COUNTRY_VALUES
+
+
+def include_in_unfiltered_brazil_city_ranking(
+    country: str | None, state: str | None
+) -> bool:
+    """Keep a city in the homepage ranking only with BR geography (issue #234).
+
+    Requires country in {BR, Brasil} **and** a Brazilian UF. NULL/empty/non-UF
+    states are excluded so mislabeled ``country=Brasil`` rows (Tumbler Ridge,
+    Joanesburgo, Paramaribo, Homs) cannot enter the unfiltered city list.
+    """
+    return _event_country_is_brazil(country) and is_brazilian_uf(state)
 
 
 # Rolling window shared by the map, export, and temporal-scope note.
@@ -496,7 +511,7 @@ async def get_security_force_stats(session: AsyncSession = Depends(get_session))
 async def get_rankings(
     session: AsyncSession = Depends(get_session),
     days: int = Query(365, ge=1, le=3650, description="Only events in the last N days"),
-    country: str | None = Query(None, description="Filter by country ISO (AR, BO, BR, CL, CO, EC, GY, PY, PE, SR, UY, VE) or omit for all SA. Unfiltered city ranking is Brazil-only (BR/Brasil)."),
+    country: str | None = Query(None, description="Filter by country ISO (AR, BO, BR, CL, CO, EC, GY, PY, PE, SR, UY, VE) or omit for all SA. Unfiltered city ranking is Brazil-only (BR/Brasil + UF)."),
     city_limit: int | None = Query(50, ge=1, le=10000, description="Limit number of cities returned (default 50 for fast load)"),
 ):
     """
@@ -505,11 +520,13 @@ async def get_rankings(
     
     Includes delta vs previous equal period.
 
-    When ``country`` is omitted, the city list is Brazil-only (UniqueEvent.country
-    BR or legacy Brasil). Country rollup stays multi-country historical.
+    When ``country`` is omitted, the city list is Brazil-only: UniqueEvent.country
+    BR or legacy Brasil **and** state in the Brazilian UF set. Country rollup
+    stays multi-country historical. Explicit ``?country=`` does not apply the
+    BR UF gate.
     """
     # Check cache (before expensive aggregation). Versioned so the in-process
-    # TTL cache cannot serve the old unfiltered city payload (issue #231).
+    # TTL cache cannot serve the old unfiltered city payload (issue #234).
     cache_key = f"rankings_{RANKINGS_CACHE_VERSION}_{days}_{country}_{city_limit}"
     if cache_key in _rankings_cache:
         cached_result, cached_time = _rankings_cache[cache_key]
@@ -589,16 +606,21 @@ async def get_rankings(
         return aggregated
 
     def brazil_city_events(events):
-        """Homepage/unfiltered city ranking is Brazil-only (issue #231).
+        """Homepage/unfiltered city ranking is Brazil-only (issues #231/#234).
 
-        When ``country`` is omitted, only aggregate cities from UniqueEvents
-        whose country is BR or legacy Brasil. Explicit ``?country=`` keeps the
-        already-filtered event set (CL/AR/etc. city lists still work).
+        When ``country`` is omitted, keep a city only when country is BR/Brasil
+        **and** state is a Brazilian UF. NULL/empty/non-UF states are excluded.
+        Explicit ``?country=`` keeps the already-filtered event set (CL/AR/etc.
+        city lists still work; do not force the BR UF gate).
         """
         if country is not None:
             return events
-        return [event for event in events if _event_country_is_brazil(event.country)]
-    
+        return [
+            event
+            for event in events
+            if include_in_unfiltered_brazil_city_ranking(event.country, event.state)
+        ]
+
     # Aggregate current period
     cities_current = aggregate_by_field(brazil_city_events(current_events), "city")
     states_current = aggregate_by_field(current_events, "state")

--- a/backend/app/services/maintenance.py
+++ b/backend/app/services/maintenance.py
@@ -948,3 +948,179 @@ async def remediate_future_event_dates(
             nu=audit["nulled"],
         )
     return audit
+
+
+# Production UniqueEvent ids confirmed as foreign geography labeled Brasil
+# (issue #234). Combined with the city denylist so a re-ingest with a new
+# id still matches.
+MISLABELED_BRAZIL_EVENT_IDS = frozenset({17, 837, 1061, 8240, 8258})
+
+_BRAZIL_COUNTRY_LABELS = frozenset({"BR", "Brasil"})
+
+# City → ISO country. Keys are lowercase, accent-stripped.
+MISLABELED_CITY_TO_COUNTRY = {
+    "tumbler ridge": "CA",
+    "joanesburgo": "ZA",
+    "johannesburg": "ZA",
+    "paramaribo": "SR",
+    "homs": "SY",
+}
+
+# State / region hints used when the city is unknown but the id is known.
+MISLABELED_STATE_TO_COUNTRY = {
+    "columbia britanica": "CA",
+    "british columbia": "CA",
+    "bc": "CA",
+    "siria": "SY",
+    "syria": "SY",
+    "gauteng": "ZA",
+    "suriname": "SR",
+}
+
+
+def _normalize_geo_token(value: str | None) -> str:
+    """Lowercase, strip, drop accents for city/state matching."""
+    import unicodedata
+
+    if not value:
+        return ""
+    text = unicodedata.normalize("NFD", value.strip().lower())
+    return "".join(ch for ch in text if unicodedata.category(ch) != "Mn")
+
+
+def infer_country_from_mislabeled_geography(
+    city: str | None, state: str | None
+) -> str | None:
+    """Return ISO country from known-bad city/state evidence, else None.
+
+    None means "clear country off Brasil" rather than guess.
+    """
+    city_key = _normalize_geo_token(city)
+    if city_key in MISLABELED_CITY_TO_COUNTRY:
+        return MISLABELED_CITY_TO_COUNTRY[city_key]
+    state_key = _normalize_geo_token(state)
+    if state_key in MISLABELED_STATE_TO_COUNTRY:
+        return MISLABELED_STATE_TO_COUNTRY[state_key]
+    return None
+
+
+def _is_brazil_country_label(country: str | None) -> bool:
+    return country in _BRAZIL_COUNTRY_LABELS
+
+
+async def remediate_mislabeled_brazil_cities(*, dry_run: bool = False) -> dict[str, Any]:
+    """Relabel UniqueEvents that are Brasil but have non-BR geography (issue #234).
+
+    Targets known ids (17, 837, 1061, 8240, 8258) and the city denylist
+    (Tumbler Ridge, Joanesburgo, Paramaribo, Homs). Sets the correct ISO
+    country from city/state evidence, or nulls country so the row leaves
+    BR rankings. Does not delete UniqueEvents.
+
+    Default writes the fix. Pass dry_run=True to report only.
+    """
+    from app.services.public_filters import is_brazilian_uf
+
+    audit: dict[str, Any] = {
+        "dry_run": dry_run,
+        "scanned": 0,
+        "updated": 0,
+        "would_update": 0,
+        "skipped": 0,
+        "nulled": 0,
+        "relabeled": 0,
+        "ids": [],
+        "changes": [],
+    }
+
+    id_placeholders = ", ".join(f":id{i}" for i, _ in enumerate(sorted(MISLABELED_BRAZIL_EVENT_IDS)))
+    city_placeholders = ", ".join(
+        f":city{i}" for i, _ in enumerate(sorted(MISLABELED_CITY_TO_COUNTRY))
+    )
+    params: dict[str, Any] = {
+        **{f"id{i}": event_id for i, event_id in enumerate(sorted(MISLABELED_BRAZIL_EVENT_IDS))},
+        **{f"city{i}": city for i, city in enumerate(sorted(MISLABELED_CITY_TO_COUNTRY))},
+    }
+
+    async with async_session_maker() as session:
+        result = await session.execute(
+            text(
+                f"""
+                SELECT id, city, state, country
+                FROM unique_event
+                WHERE (country = 'BR' OR country = 'Brasil')
+                  AND (
+                    id IN ({id_placeholders})
+                    OR lower(city) IN ({city_placeholders})
+                  )
+                """
+            ),
+            params,
+        )
+        rows = result.mappings().all()
+        audit["scanned"] = len(rows)
+
+        pending: list[dict[str, Any]] = []
+        for row in rows:
+            event_id = row["id"]
+            city = row["city"]
+            state = row["state"]
+            country = row["country"]
+            city_key = _normalize_geo_token(city)
+            on_denylist = city_key in MISLABELED_CITY_TO_COUNTRY
+            known_id = event_id in MISLABELED_BRAZIL_EVENT_IDS
+
+            if not _is_brazil_country_label(country):
+                audit["skipped"] += 1
+                continue
+
+            # Known id with real BR UF and not a denylist city: leave it.
+            if known_id and not on_denylist and is_brazilian_uf(state):
+                audit["skipped"] += 1
+                continue
+
+            if not on_denylist and not known_id:
+                audit["skipped"] += 1
+                continue
+
+            new_country = infer_country_from_mislabeled_geography(city, state)
+            pending.append(
+                {
+                    "id": event_id,
+                    "city": city,
+                    "state": state,
+                    "old_country": country,
+                    "new_country": new_country,
+                }
+            )
+
+        audit["would_update"] = len(pending)
+        audit["ids"] = [item["id"] for item in pending]
+        audit["changes"] = pending
+        audit["nulled"] = sum(1 for item in pending if item["new_country"] is None)
+        audit["relabeled"] = sum(1 for item in pending if item["new_country"] is not None)
+
+        if dry_run or not pending:
+            return audit
+
+        for item in pending:
+            await session.execute(
+                text(
+                    """
+                    UPDATE unique_event
+                    SET country = :country,
+                        updated_at = CURRENT_TIMESTAMP
+                    WHERE id = :id
+                    """
+                ),
+                {"id": item["id"], "country": item["new_country"]},
+            )
+        await session.commit()
+        audit["updated"] = len(pending)
+        logger.info(
+            "[MISLABELED-BR] Updated {n} UniqueEvent(s) "
+            "(relabeled={relabeled}, nulled={nulled})",
+            n=audit["updated"],
+            relabeled=audit["relabeled"],
+            nulled=audit["nulled"],
+        )
+    return audit

--- a/backend/app/services/public_filters.py
+++ b/backend/app/services/public_filters.py
@@ -11,6 +11,21 @@ _HOMICIDIO_SUBTYPES = SUBTYPES_BY_FAMILY["homicidio"]
 # Brazilian federative units (27 states + DF).
 BR_UFS = frozenset(BRAZILIAN_STATES)
 
+
+def is_brazilian_uf(state: str | None) -> bool:
+    """True when ``state`` is a Brazilian UF code (SP, RJ, …).
+
+    NULL, empty, full names, and foreign regions (Colúmbia Britânica, Síria)
+    do not pass. Matching is case-insensitive against ``BR_UFS``.
+    """
+    if state is None:
+        return False
+    normalized = state.strip().upper()
+    if not normalized:
+        return False
+    return normalized in BR_UFS
+
+
 # Chilean regions (regiones)
 CL_REGIONS = frozenset(CHILEAN_REGIONS)
 

--- a/backend/scripts/remediate_mislabeled_brazil_cities.py
+++ b/backend/scripts/remediate_mislabeled_brazil_cities.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Relabel UniqueEvents that are Brasil but have non-BR geography (issue #234).
+
+Targets known ids (17, 837, 1061, 8240, 8258) and the city denylist
+(Tumbler Ridge, Joanesburgo, Paramaribo, Homs). Sets the correct ISO
+country from city/state evidence, or nulls country so the row leaves
+BR rankings. Does not delete UniqueEvents.
+
+Usage (from backend/ or via docker compose exec api):
+
+    # Report planned writes without committing:
+    python scripts/remediate_mislabeled_brazil_cities.py --dry-run
+
+    # Apply the fix:
+    python scripts/remediate_mislabeled_brazil_cities.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from app.services.maintenance import remediate_mislabeled_brazil_cities
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Relabel UniqueEvents labeled Brasil that have non-BR geography "
+            "(Tumbler Ridge, Joanesburgo, Paramaribo, Homs / known ids)."
+        )
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report rows that would change without writing.",
+    )
+    args = parser.parse_args()
+    audit = await remediate_mislabeled_brazil_cities(dry_run=args.dry_run)
+    print(json.dumps(audit, default=str, indent=2))
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/backend/tests/test_public_filters.py
+++ b/backend/tests/test_public_filters.py
@@ -1,6 +1,6 @@
 """Tests for public incident filters (homicide archive)."""
 
-from app.services.public_filters import public_incident_criteria
+from app.services.public_filters import is_brazilian_uf, public_incident_criteria
 from app.taxonomy import is_public_incident
 
 
@@ -13,3 +13,16 @@ def test_is_public_incident_homicide_only():
 def test_public_incident_criteria_includes_family_and_content_class():
     criteria = public_incident_criteria()
     assert len(criteria) == 4
+
+
+def test_is_brazilian_uf_accepts_codes_rejects_foreign_and_empty():
+    assert is_brazilian_uf("SP")
+    assert is_brazilian_uf("rj")
+    assert is_brazilian_uf("BA")
+    assert not is_brazilian_uf(None)
+    assert not is_brazilian_uf("")
+    assert not is_brazilian_uf("  ")
+    assert not is_brazilian_uf("Colúmbia Britânica")
+    assert not is_brazilian_uf("BC")
+    assert not is_brazilian_uf("Síria")
+    assert not is_brazilian_uf("São Paulo")

--- a/backend/tests/test_rankings.py
+++ b/backend/tests/test_rankings.py
@@ -289,6 +289,134 @@ async def test_unfiltered_city_ranking_excludes_foreign_cities_issue_231(
         assert "São Paulo" in br_cities
 
 
+def test_include_in_unfiltered_brazil_city_ranking_requires_uf():
+    """UF gate: country=Brasil is not enough without a Brazilian UF (issue #234)."""
+    from app.routers.public import include_in_unfiltered_brazil_city_ranking
+
+    assert include_in_unfiltered_brazil_city_ranking("BR", "SP")
+    assert include_in_unfiltered_brazil_city_ranking("Brasil", "RJ")
+    assert include_in_unfiltered_brazil_city_ranking("Brasil", "BA")
+    assert not include_in_unfiltered_brazil_city_ranking("Brasil", "Colúmbia Britânica")
+    assert not include_in_unfiltered_brazil_city_ranking("Brasil", "BC")
+    assert not include_in_unfiltered_brazil_city_ranking("Brasil", "Síria")
+    assert not include_in_unfiltered_brazil_city_ranking("Brasil", None)
+    assert not include_in_unfiltered_brazil_city_ranking("Brasil", "")
+    assert not include_in_unfiltered_brazil_city_ranking("CA", "SP")
+    assert not include_in_unfiltered_brazil_city_ranking(None, "SP")
+
+
+@pytest.mark.asyncio
+async def test_unfiltered_city_ranking_excludes_mislabeled_brasil_issue_234(
+    app, async_session
+):
+    """Mislabeled country=Brasil + foreign city/state must not appear (issue #234).
+
+    Production rows after #231/#233 still leaked because country was Brasil.
+    Real BR cities with a UF (São Paulo/SP, Salvador/BA, Rio/RJ) remain.
+    Explicit ?country=CL does not apply the BR UF gate.
+
+    Master has no city-size floor / IBGEPopulation table (those live on develop).
+    """
+    now = datetime.utcnow()
+    current_start = now - timedelta(days=30)
+
+    events = [
+        create_ranking_event(
+            event_date=current_start + timedelta(days=1),
+            country="BR",
+            city="Rio de Janeiro",
+            state="RJ",
+            victim_count=4,
+        ),
+        create_ranking_event(
+            event_date=current_start + timedelta(days=2),
+            country="Brasil",
+            city="São Paulo",
+            state="SP",
+            victim_count=3,
+        ),
+        create_ranking_event(
+            event_date=current_start + timedelta(days=3),
+            country="Brasil",
+            city="Salvador",
+            state="BA",
+            victim_count=2,
+        ),
+        # Production pollution: labeled Brasil, foreign geography.
+        create_ranking_event(
+            event_date=current_start + timedelta(days=4),
+            country="Brasil",
+            city="Tumbler Ridge",
+            state="Colúmbia Britânica",
+            victim_count=9,
+        ),
+        create_ranking_event(
+            event_date=current_start + timedelta(days=5),
+            country="Brasil",
+            city="Joanesburgo",
+            state="Gauteng",
+            victim_count=9,
+        ),
+        create_ranking_event(
+            event_date=current_start + timedelta(days=6),
+            country="Brasil",
+            city="Paramaribo",
+            state="Suriname",
+            victim_count=8,
+        ),
+        create_ranking_event(
+            event_date=current_start + timedelta(days=7),
+            country="Brasil",
+            city="Homs",
+            state="Síria",
+            victim_count=8,
+        ),
+        create_ranking_event(
+            event_date=current_start + timedelta(days=8),
+            country="CL",
+            city="Santiago",
+            state="Metropolitana",
+            victim_count=2,
+        ),
+    ]
+
+    for event in events:
+        async_session.add(event)
+    await async_session.commit()
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        response = await client.get("/api/public/stats/rankings?days=30")
+        assert response.status_code == 200
+        data = response.json()
+
+        city_names = {c["city"] for c in data["cities"]}
+        forbidden = {"Tumbler Ridge", "Joanesburgo", "Paramaribo", "Homs", "Santiago"}
+        assert city_names.isdisjoint(forbidden), (
+            f"Unfiltered city ranking leaked mislabeled cities: {city_names & forbidden}"
+        )
+        assert "Rio de Janeiro" in city_names
+        assert "São Paulo" in city_names
+        assert "Salvador" in city_names
+
+        country_names = {c["country"] for c in data["countries"]}
+        assert "Brasil" in country_names
+        assert "Chile" in country_names
+        assert data["country_filter"] is None
+
+        # Explicit country=CL must not force the BR UF gate.
+        response_cl = await client.get("/api/public/stats/rankings?days=30&country=CL")
+        assert response_cl.status_code == 200
+        data_cl = response_cl.json()
+        assert data_cl["total_events"] == 1
+        assert data_cl["total_victims"] == 2
+        cl_cities = {c["city"] for c in data_cl["cities"]}
+        assert "Santiago" in cl_cities
+        assert cl_cities.isdisjoint({"Tumbler Ridge", "Joanesburgo", "Paramaribo", "Homs"})
+
+
 @pytest.mark.asyncio
 async def test_rankings_country_filter_chile(app, async_session):
     """Test country filter for Chile only."""

--- a/backend/tests/test_rankings.py
+++ b/backend/tests/test_rankings.py
@@ -406,15 +406,15 @@ async def test_unfiltered_city_ranking_excludes_mislabeled_brasil_issue_234(
         assert "Chile" in country_names
         assert data["country_filter"] is None
 
-        # Explicit country=CL must not force the BR UF gate: the CL event is
-        # counted. (Develop city size floor may still hide Santiago from the
-        # city list when IBGE lookup is skipped for non-BR country=.)
+        # Explicit country=CL must not force the BR UF gate. Master has no
+        # city size floor, so Santiago stays in the city list.
         response_cl = await client.get("/api/public/stats/rankings?days=30&country=CL")
         assert response_cl.status_code == 200
         data_cl = response_cl.json()
         assert data_cl["total_events"] == 1
         assert data_cl["total_victims"] == 2
         cl_cities = {c["city"] for c in data_cl["cities"]}
+        assert "Santiago" in cl_cities
         assert cl_cities.isdisjoint({"Tumbler Ridge", "Joanesburgo", "Paramaribo", "Homs"})
 
 

--- a/backend/tests/test_rankings.py
+++ b/backend/tests/test_rankings.py
@@ -406,14 +406,15 @@ async def test_unfiltered_city_ranking_excludes_mislabeled_brasil_issue_234(
         assert "Chile" in country_names
         assert data["country_filter"] is None
 
-        # Explicit country=CL must not force the BR UF gate.
+        # Explicit country=CL must not force the BR UF gate: the CL event is
+        # counted. (Develop city size floor may still hide Santiago from the
+        # city list when IBGE lookup is skipped for non-BR country=.)
         response_cl = await client.get("/api/public/stats/rankings?days=30&country=CL")
         assert response_cl.status_code == 200
         data_cl = response_cl.json()
         assert data_cl["total_events"] == 1
         assert data_cl["total_victims"] == 2
         cl_cities = {c["city"] for c in data_cl["cities"]}
-        assert "Santiago" in cl_cities
         assert cl_cities.isdisjoint({"Tumbler Ridge", "Joanesburgo", "Paramaribo", "Homs"})
 
 

--- a/backend/tests/test_remediate_mislabeled_brazil_cities.py
+++ b/backend/tests/test_remediate_mislabeled_brazil_cities.py
@@ -1,0 +1,161 @@
+"""Tests for mislabeled Brasil UniqueEvent remediator (issue #234)."""
+
+from datetime import datetime
+from unittest.mock import patch
+
+import pytest
+
+from app.models.unique_event import UniqueEvent
+from app.routers.public import include_in_unfiltered_brazil_city_ranking
+from app.services.maintenance import (
+    infer_country_from_mislabeled_geography,
+    remediate_mislabeled_brazil_cities,
+)
+
+
+class _TestSessionMaker:
+    def __init__(self, session):
+        self._session = session
+
+    def __call__(self):
+        return self
+
+    async def __aenter__(self):
+        return self._session
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+def _make_event(
+    *,
+    event_id: int | None = None,
+    city: str,
+    state: str | None,
+    country: str = "Brasil",
+    title: str | None = None,
+) -> UniqueEvent:
+    kwargs = dict(
+        title=title or f"Event in {city}",
+        event_date=datetime(2026, 8, 1),
+        country=country,
+        state=state,
+        city=city,
+        event_family="homicidio",
+        event_subtype="simples",
+        content_class="incident",
+        homicide_type="Homicídio simples",
+        victim_count=1,
+        source_count=1,
+    )
+    if event_id is not None:
+        kwargs["id"] = event_id
+    return UniqueEvent(**kwargs)
+
+
+def test_infer_country_from_known_cities_and_states():
+    assert infer_country_from_mislabeled_geography("Tumbler Ridge", "Colúmbia Britânica") == "CA"
+    assert infer_country_from_mislabeled_geography("Joanesburgo", None) == "ZA"
+    assert infer_country_from_mislabeled_geography("Paramaribo", "") == "SR"
+    assert infer_country_from_mislabeled_geography("Homs", "Síria") == "SY"
+    assert infer_country_from_mislabeled_geography("São Paulo", "SP") is None
+
+
+@pytest.mark.asyncio
+async def test_remediator_relabels_known_pollution_and_skips_real_br(async_session):
+    tumbler = _make_event(
+        event_id=8240, city="Tumbler Ridge", state="Colúmbia Britânica"
+    )
+    tumbler_dup = _make_event(
+        event_id=8258, city="Tumbler Ridge", state="BC"
+    )
+    joanesburgo = _make_event(event_id=17, city="Joanesburgo", state=None)
+    paramaribo = _make_event(event_id=1061, city="Paramaribo", state="")
+    homs = _make_event(event_id=837, city="Homs", state="Síria")
+    salvador = _make_event(city="Salvador", state="BA", country="BR")
+    sao_paulo = _make_event(city="São Paulo", state="SP", country="Brasil")
+
+    async_session.add_all(
+        [tumbler, tumbler_dup, joanesburgo, paramaribo, homs, salvador, sao_paulo]
+    )
+    await async_session.commit()
+
+    with patch(
+        "app.services.maintenance.async_session_maker",
+        _TestSessionMaker(async_session),
+    ):
+        dry = await remediate_mislabeled_brazil_cities(dry_run=True)
+
+    await async_session.refresh(tumbler)
+    assert tumbler.country == "Brasil"
+    assert dry["dry_run"] is True
+    assert dry["would_update"] == 5
+    assert dry["updated"] == 0
+    assert set(dry["ids"]) == {17, 837, 1061, 8240, 8258}
+
+    with patch(
+        "app.services.maintenance.async_session_maker",
+        _TestSessionMaker(async_session),
+    ):
+        audit = await remediate_mislabeled_brazil_cities(dry_run=False)
+
+    for event in (tumbler, tumbler_dup, joanesburgo, paramaribo, homs, salvador, sao_paulo):
+        await async_session.refresh(event)
+
+    assert tumbler.country == "CA"
+    assert tumbler_dup.country == "CA"
+    assert joanesburgo.country == "ZA"
+    assert paramaribo.country == "SR"
+    assert homs.country == "SY"
+    assert salvador.country == "BR"
+    assert sao_paulo.country == "Brasil"
+    assert audit["updated"] == 5
+    assert audit["relabeled"] == 5
+
+    # Defense in depth: even the old Brasil+foreign-state combo would fail the UF gate.
+    assert not include_in_unfiltered_brazil_city_ranking("Brasil", "Colúmbia Britânica")
+    assert not include_in_unfiltered_brazil_city_ranking("Brasil", "Síria")
+    assert not include_in_unfiltered_brazil_city_ranking("Brasil", None)
+    assert not include_in_unfiltered_brazil_city_ranking(tumbler.country, tumbler.state)
+    assert include_in_unfiltered_brazil_city_ranking(salvador.country, salvador.state)
+    assert include_in_unfiltered_brazil_city_ranking(sao_paulo.country, sao_paulo.state)
+
+
+@pytest.mark.asyncio
+async def test_remediator_skips_already_correct_country(async_session):
+    already_ca = _make_event(
+        event_id=8240, city="Tumbler Ridge", state="Colúmbia Britânica", country="CA"
+    )
+    async_session.add(already_ca)
+    await async_session.commit()
+
+    with patch(
+        "app.services.maintenance.async_session_maker",
+        _TestSessionMaker(async_session),
+    ):
+        audit = await remediate_mislabeled_brazil_cities(dry_run=False)
+
+    await async_session.refresh(already_ca)
+    assert already_ca.country == "CA"
+    assert audit["updated"] == 0
+    assert audit["would_update"] == 0
+
+
+@pytest.mark.asyncio
+async def test_remediator_skips_known_id_with_real_br_uf_and_br_city(async_session):
+    """Do not relabel a known id that looks like a real Brazilian event."""
+    real_br = _make_event(
+        event_id=17, city="São Paulo", state="SP", country="Brasil"
+    )
+    async_session.add(real_br)
+    await async_session.commit()
+
+    with patch(
+        "app.services.maintenance.async_session_maker",
+        _TestSessionMaker(async_session),
+    ):
+        audit = await remediate_mislabeled_brazil_cities(dry_run=False)
+
+    await async_session.refresh(real_br)
+    assert real_br.country == "Brasil"
+    assert audit["updated"] == 0


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 📝 Descrição

Cherry-pick / port of issue #234 onto **master only** (companion of develop PR #235).

After #231/#233 (`8e1fbe1`), production unfiltered city rankings still showed:

- Tumbler Ridge — ids `8240`, `8258` (state Colúmbia Britânica / BC)
- Joanesburgo — id `17`
- Paramaribo — id `1061`
- Homs — id `837` (state Síria)

Those UniqueEvents have `country="Brasil"`. Country filter alone cannot remove them.

### How the UF gate works

In `get_rankings` / `brazil_city_events`:

- When `country` is **omitted**: keep a city only when `country` is BR/Brasil **and** `state` is a Brazilian UF (`is_brazilian_uf` / `BR_UFS`). NULL, empty, and non-UF states are excluded.
- When `?country=` is **set** (CL/AR/etc.): do not force the BR UF gate — existing country-param behavior is unchanged.
- Rankings cache key bumped from `br_cities` to `RANKINGS_CACHE_VERSION = "br_cities_uf"`.

Country rollup stays historical / multi-country. No UniqueEvent deletes.

### Remediator

```
python scripts/remediate_mislabeled_brazil_cities.py --dry-run
python scripts/remediate_mislabeled_brazil_cities.py
```

Calls `remediate_mislabeled_brazil_cities()` in `maintenance.py`. Relabels known ids (`17`, `837`, `1061`, `8240`, `8258`) and denylist cities (Tumbler Ridge → CA, Joanesburgo → ZA, Paramaribo → SR, Homs → SY). If geography cannot be inferred, country is nulled. Does not mass-delete. After remediator, those cities still fail the UF gate (defense in depth).

### Cherry-pick vs manual port

- Source commits on develop: `de85992`, `6e04e12` (PR #235)
- Base: current `origin/master` (`8e1fbe1`, after PR #233)
- `git cherry-pick` conflicted on `backend/app/routers/public.py` (master lags develop IBGE / city-size-floor).
- Resolution: kept master’s rankings handler and applied the UF-gate hunks + remediator. Dropped `IBGEPopulation` fixtures from the issue 234 HTTP test (that model does not exist on master). Kept `assert "Santiago" in cl_cities` because master has no size floor.

HEAD: `ca6a0628730a0b889c58d102829e6f301520f5d8`

## 🔗 Issue Relacionada

Fixes #234

Same fix on develop: PR #235. Do **not** merge full develop→master.

## 🏷️ Tipo de Mudança

- [x] 🐛 Bug fix (mudança que corrige um problema)
- [x] ✅ Testes (adição ou correção de testes)

## 🧪 Como Foi Testado?

- [x] Testes unitários
- [ ] Testes de integração
- [ ] Testes manuais
- [x] Testado em desenvolvimento local
- [ ] Testado com Docker

**Ambiente de teste:**
- OS: Linux (Cloud Agent)
- Docker version: not used (`uv run pytest` in `backend/`)
- Browser: n/a (API-only)

```
uv run pytest \
  tests/test_rankings.py::test_rankings_country_filter_brazil \
  tests/test_rankings.py::test_unfiltered_city_ranking_excludes_foreign_cities_issue_231 \
  tests/test_rankings.py::test_include_in_unfiltered_brazil_city_ranking_requires_uf \
  tests/test_rankings.py::test_unfiltered_city_ranking_excludes_mislabeled_brasil_issue_234 \
  tests/test_rankings.py::test_rankings_basic_aggregation \
  tests/test_rankings.py::test_rankings_empty_database \
  tests/test_rankings.py::test_rankings_brazil_excludes_non_uf_states \
  tests/test_remediate_mislabeled_brazil_cities.py \
  tests/test_public_filters.py::test_is_public_incident_homicide_only \
  tests/test_public_filters.py::test_is_brazilian_uf_accepts_codes_rejects_foreign_and_empty \
  -v
```

**13 passed.**

## ✅ Checklist

- [x] Meu código segue o guia de estilo do projeto
- [x] Realizei uma auto-revisão do meu código
- [x] Comentei meu código em áreas complexas
- [x] Adicionei testes que provam que meu fix/feature funciona
- [x] Testes unitários novos e existing #231 tests passam localmente

## 💬 Notas Adicionais

### Locks held (do not ship from this PR)

- Draft PR against **`master` only**. Do **not** merge. Do **not** mark ready.
- **No PR #204**.
- **No** staging worker start.
- **No** `/estatisticas` promote.
- **No** full develop→master merge.
- **No** mass UniqueEvent delete.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ff4dc589-78e9-47e8-a61e-24949f0ef211?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ff4dc589-78e9-47e8-a61e-24949f0ef211&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

